### PR TITLE
Remove governance in favor of project base repository

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,1 +1,0 @@
-This project follows https://github.com/grafana/grafana/blob/main/GOVERNANCE.md in spirit. See [MAINTAINERS.md](MAINTAINERS.md) for team members.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,13 @@
+# Licensing
+
+License names used in this document are as per [SPDX License List](https://spdx.org/licenses/).
+
+The default license for this project is [AGPL-3.0-only](LICENSE).
+
+## Vendored code
+
+The following directories and their subdirectories are under the original upstream licenses, all of them ship the entire license text they are under.
+
+```
+vendor/
+```


### PR DESCRIPTION
https://github.com/grafana/faro now exists and has the project base.
