### PR TITLE
Allow multiple instances of same transport type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Fix bug where if multiple instances of a transport class where configured, only one would be used
+
 ## 1.0.0.beta1, 1.0.0.beta2 (2022-10-31)
 
 - Rename to "Faro Web SDK"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 <p align="left"><img src="docs/faro_logo.png" alt="Grafana Faro logo" width="400"></p>
 
-The Grafana Faro Web SDK can instrument frontend JavaScript applications to collect 
-telemetry and forward it to the [Grafana Agent](https://grafana.com/docs/agent/latest/) 
+The Grafana Faro Web SDK can instrument frontend JavaScript applications to collect
+telemetry and forward it to the [Grafana Agent](https://grafana.com/docs/agent/latest/)
 (with app agent receiver integration enabled).
-Grafana Agent can then send this data to 
+Grafana Agent can then send this data to
 [Loki](https://grafana.com/logs/) or [Tempo](https://grafana.com/traces/).
 
 The repository consists of multiple packages that can be combined depending on your requirements,

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -41,7 +41,7 @@ export function initializeTransports(internalLogger: InternalLogger, config: Con
     newTransports.forEach((newTransport) => {
       internalLogger.debug(`Adding "${newTransport.name}" transport`);
 
-      const exists = transports.some((existingTransport) => existingTransport.name === newTransport.name);
+      const exists = transports.some((existingTransport) => existingTransport === newTransport);
 
       if (exists) {
         internalLogger.warn(`Transport ${newTransport.name} is already added`);
@@ -111,18 +111,9 @@ export function initializeTransports(internalLogger: InternalLogger, config: Con
     transportsToRemove.forEach((transportToRemove) => {
       internalLogger.debug(`Removing "${transportToRemove.name}" transport`);
 
-      const existingTransportIndex = transports.reduce<number | null>(
-        (acc, existingTransport, existingTransportIndex) => {
-          if (acc === null && existingTransport.name === transportToRemove.name) {
-            return existingTransportIndex;
-          }
+      const existingTransportIndex = transports.indexOf(transportToRemove);
 
-          return null;
-        },
-        null
-      );
-
-      if (!existingTransportIndex) {
+      if (existingTransportIndex === -1) {
         internalLogger.warn(`Transport "${transportToRemove.name}" is not added`);
 
         return;

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -93,6 +93,29 @@ describe('transports', () => {
       expect((transport.sentItems[0]?.payload as ErrorEvent).type).toEqual('NewType');
     });
   });
+
+  describe('multiple transports of the same type', () => {
+    const transport1 = new MockTransport();
+    const transport2 = new MockTransport();
+
+    const config = {
+      transports: [transport1, transport2],
+    } as any as Config;
+    const transports = initializeTransports(mockInternalLogger, config);
+
+    it('will all be added and receive events', () => {
+      transports.execute(makeExceptionTransportItem('Error', 'ResizeObserver loop limit exceeded'));
+      expect(transport1.sentItems).toHaveLength(1);
+      expect(transport2.sentItems).toHaveLength(1);
+    });
+
+    it('one of them can be removed by instance', () => {
+      transports.remove(transport1);
+      transports.execute(makeExceptionTransportItem('Error', 'Kaboom'));
+      expect(transport1.sentItems).toHaveLength(1);
+      expect(transport2.sentItems).toHaveLength(2);
+    });
+  });
 });
 
 function makeExceptionTransportItem(type: string, value: string): TransportItem<ExceptionEvent> {


### PR DESCRIPTION
I wanted to add two instances of `FetchTransport` to my side project, one to sent to cloud endpoint, one to an agent instance.
It didn't work, as `transports.add` deduplicates transports by name, which is the same for all instances of `FetchTransport`.

I'm certain that adding multiple instances of `FetchTransport` is a legit use case, updated to dedupe by reference only. 

Also updated `transports.remove`. Previously it would remove the last instance with the same name, and would not remove it if it was first in the transport list -  `0` is `false` :) 

