### PR TITLE
Fix broken link in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ for more information.
 
 ### React Support
 
-[@grafana/faro-react](https://github.com/grafana/faro-web-sdk/tree/main/packages/transport-fetch)
+[@grafana/faro-react](https://github.com/grafana/faro-web-sdk/tree/main/packages/react)
 is a package that enables easier integration in projects built with React.


### PR DESCRIPTION
**What is this feature and why do we need it?**

Seems like the link to @grafana/faro-react was broken. This PR should fix that. 
