### PR TITLE
Update Licensing.md to specify correct default license

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -2,12 +2,4 @@
 
 License names used in this document are as per [SPDX License List](https://spdx.org/licenses/).
 
-The default license for this project is [AGPL-3.0-only](LICENSE).
-
-## Vendored code
-
-The following directories and their subdirectories are under the original upstream licenses, all of them ship the entire license text they are under.
-
-```
-vendor/
-```
+The default license for this project is [Apache v2](LICENSE).


### PR DESCRIPTION
**What is this feature and why do we need it?**

Licensing.md was saying that default license is AGPL, but it's supposed to be Apache v2. Thanks @devnewton for spotting this

fixes #70 
