### PR TITLE
Add Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,36 +2,58 @@
 name: Bug report
 about: Report a bug
 title: ''
-labels: 'T: bug'
+labels: 'bug'
 assignees: ''
 ---
 
-**Description**
-Add a clear and concise description of what the bug is. Example: Capturing metrics manually does not work properly.
+## Description
 
-**Steps to reproduce**
+<!-- Add a clear and concise description of what the bug is. -->
+<!-- Example -->
+<!-- Capturing metrics manually does not work properly. -->
 
-1. Add Faro to the project
-2. Send a metric manually using the Faro API
-3. ...
+## Steps to reproduce
 
-**Expected behavior**
-Add a clear and concise description of what is expected to happen. Example: The following metric should be captured ...
+<!-- Example -->
+<!-- 1. Add Faro to the project -->
+<!-- 2. Send a metric manually using the Faro API -->
+<!-- 3. ... -->
 
-**Actual behavior**
-Add a clear and concise description of what is happening. Example: Metric ... does not get captured.
+## Expected behavior
 
-**Environment**
+<!-- Add a clear and concise description of what is expected to happen. -->
+<!-- Example -->
+<!-- The following metric should be captured ... -->
 
-- SDK version: 1.0.0
-- SDK instrumentations: Web SDK, Web Tracing, React
-- Device type: desktop, tablet, mobile
-- Device name: MacBook Pro 13", iPhone 6, Samsung Galaxy S20
-- OS: macOS Ventura, Windows 11
-- Browser: Chrome 106, Safari 11
+## Actual behavior
 
-**Demo**
-(Optional) Add screenshots or videos to help explain the problem.
+<!-- Add a clear and concise description of what is happening. -->
+<!-- Example -->
+<!-- Metric ... does not get captured. -->
 
-**Context**
-(Optional) Add any additional context: links etc.
+## Environment
+
+- **SDK version:**
+- **SDK instrumentations:**
+- **Device type:**
+- **Device name:**
+- **OS:**
+- **Browser:**
+
+<!-- Example -->
+<!-- - **SDK version:** 1.0.0 -->
+<!-- - **SDK instrumentations:** Web SDK, Web Tracing, React -->
+<!-- - **Device type:** desktop, tablet, mobile -->
+<!-- - **Device name:** MacBook Pro 13", iPhone 6, Samsung Galaxy S20 -->
+<!-- - **OS:** macOS Ventura, Windows 11 -->
+<!-- - **Browser:** Chrome 106, Safari 11 -->
+
+## Demo
+
+<!-- Optional -->
+<!-- Add screenshots or videos to help explain the problem. -->
+
+## Context
+
+<!-- Optional -->
+<!-- Add any additional context: links etc. -->

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a bug
+title: ''
+labels: 'T: bug'
+assignees: ''
+---
+
+**Description**
+Add a clear and concise description of what the bug is. Example: Capturing metrics manually does not work properly.
+
+**Steps to reproduce**
+
+1. Add Faro to the project
+2. Send a metric manually using the Faro API
+3. ...
+
+**Expected behavior**
+Add a clear and concise description of what is expected to happen. Example: The following metric should be captured ...
+
+**Actual behavior**
+Add a clear and concise description of what is happening. Example: Metric ... does not get captured.
+
+**Environment**
+
+- SDK version: 1.0.0
+- SDK instrumentations: Web SDK, Web Tracing, React
+- Device type: desktop, tablet, mobile
+- Device name: MacBook Pro 13", iPhone 6, Samsung Galaxy S20
+- OS: macOS Ventura, Windows 11
+- Browser: Chrome 106, Safari 11
+
+**Demo**
+(Optional) Add screenshots or videos to help explain the problem.
+
+**Context**
+(Optional) Add any additional context: links etc.

--- a/.github/ISSUE_TEMPLATE/CHANGE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/CHANGE_REQUEST.md
@@ -1,0 +1,18 @@
+---
+name: Change request
+about: Request a change of an existing feature
+title: ''
+labels: 'T: change'
+assignees: ''
+---
+
+**Description**
+Add a clear and concise description of what the change is. Example: The Web Vitals instrumentation needs to capture ...
+metric as well.
+
+**Proposed solution**
+(Optional) Add a clear and concise description of what should happen. Example: You can use ... library to capture the
+additional metrics.
+
+**Context**
+(Optional) Add any additional context: screenshots, videos, links etc.

--- a/.github/ISSUE_TEMPLATE/CHANGE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/CHANGE_REQUEST.md
@@ -2,17 +2,24 @@
 name: Change request
 about: Request a change of an existing feature
 title: ''
-labels: 'T: change'
+labels: 'change'
 assignees: ''
 ---
 
-**Description**
-Add a clear and concise description of what the change is. Example: The Web Vitals instrumentation needs to capture ...
-metric as well.
+## Description
 
-**Proposed solution**
-(Optional) Add a clear and concise description of what should happen. Example: You can use ... library to capture the
-additional metrics.
+<!-- Add a clear and concise description of what the change is. -->
+<!-- Example -->
+<!-- The Web Vitals instrumentation needs to capture ... metric as well. -->
 
-**Context**
-(Optional) Add any additional context: screenshots, videos, links etc.
+## Proposed solution
+
+<!-- Optional -->
+<!-- Add a clear and concise description of what should happen. -->
+<!-- Example -->
+<!-- You can use ... library to capture the additional metrics. -->
+
+## Context
+
+<!-- Optional -->
+<!-- Add any additional context: screenshots, videos, links etc. -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Request a new feature
+title: ''
+labels: 'T: feature'
+assignees: ''
+---
+
+**Description**
+Add a clear and concise description of what the feature is. Example: We need a new instrumentation in the Web SDK that
+captures data from ...
+
+**Proposed solution**
+(Optional) Add a clear and concise description of what should happen. Example: The instrumentation should capture the
+following data: ... from the ... API
+
+**Context**
+(Optional) Add any additional context: screenshots, videos, links etc.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -2,17 +2,24 @@
 name: Feature request
 about: Request a new feature
 title: ''
-labels: 'T: feature'
+labels: 'feature'
 assignees: ''
 ---
 
-**Description**
-Add a clear and concise description of what the feature is. Example: We need a new instrumentation in the Web SDK that
-captures data from ...
+## Description
 
-**Proposed solution**
-(Optional) Add a clear and concise description of what should happen. Example: The instrumentation should capture the
-following data: ... from the ... API
+<!-- Add a clear and concise description of what the feature is. -->
+<!-- Example -->
+<!-- We need a new instrumentation in the Web SDK that captures data from ... -->
 
-**Context**
-(Optional) Add any additional context: screenshots, videos, links etc.
+## Proposed solution
+
+<!-- Optional -->
+<!-- Add a clear and concise description of what should happen. -->
+<!-- Example -->
+<!-- The instrumentation should capture the following data: ... from the ... API. -->
+
+## Context
+
+<!-- Optional -->
+<!-- Add any additional context: screenshots, videos, links etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
-**What is this feature and why do we need it?**
+**Description**
 
-[Add a brief description of what the feature or update does.]
+Add a clear and concise description of what the PR does. Example: This PR adds support for auto instrumenting ... using
+the ... API...
 
-**Which issue(s) does this PR fix?**:
+**Fixes**
 
 Fixes #
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,18 @@
-**Description**
+## Description
 
-Add a clear and concise description of what the PR does. Example: This PR adds support for auto instrumenting ... using
-the ... API...
+<!-- Add a clear and concise description of what the PR does. -->
+<!-- Example -->
+<!-- This PR adds support for auto instrumenting ... using the ... API... -->
 
-**Fixes**
+## Fixes
 
 Fixes #
 
-**Checklist**:
+<!-- Every PR should have a reference to an issue as changes need to be discussed before they are implemented. -->
+<!-- Example -->
+<!-- Fixes #123456 -->
+
+## Checklist
 
 - [ ] Tests added
 - [ ] Changelog updated


### PR DESCRIPTION
**What is this feature and why do we need it?**

This PR brings templates for Github issues. I also changed the PR template a little bit to stay in sync with the new ones.

**Which issue(s) does this PR fix?**:

**Checklist**:

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
