### PR TITLE
Remove type module from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-beta5
+
+- Remove type module from package.json in web-tracing package
+
 ## 1.0.0-beta4
 
 - Add support for CDN

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -21,7 +21,6 @@
     "url": "https://github.com/grafana/faro-web-sdk.git",
     "directory": "packages/web-tracing"
   },
-  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/web-tracing/rollup.config.js
+++ b/packages/web-tracing/rollup.config.js
@@ -1,3 +1,3 @@
-import { getRollupConfigBase } from '../../rollup.config.base.js';
+const { getRollupConfigBase } = require('../../rollup.config.base.js');
 
-export default getRollupConfigBase('webTracing');
+module.exports = getRollupConfigBase('webTracing');


### PR DESCRIPTION
## Description

Remove the `"type": "module"` property from `package.json` in `web-tracing` package to avoid having bundling issues.

## Fixes

Fixes #82

## Checklist

- [x] Changelog updated
