### PR TITLE
Fix typo "Farp" -> "Faro"

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -96,7 +96,7 @@ import { FaroRoute } from '@grafana/faro-react';
 
 // during render
 <Switch>
-  <FarpRoute path="/">
+  <FaroRoute path="/">
     <Home />
   </FaroRoute>
   {/* ... */}


### PR DESCRIPTION
## Description

Hey 👋  I noticed a tiny typo when reading the guide.

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
