### PR TITLE
Update internal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p align="left"><img src="docs/faro_logo.png" alt="Grafana Faro logo" width="400"></p>
 
 The Grafana Faro Web SDK can instrument frontend JavaScript applications to collect telemetry and forward it to the
-[Grafana Agent][grafana-agent-docs] (with app agent receiver integration enabled). Grafana Agent can then send this data
-to [Loki][grafana-logs] or [Tempo][grafana-traces].
+[Grafana Agent][grafana-agent-docs] (with app agent receiver integration enabled), to a Grafana Cloud instance or to a
+custom receiver. Grafana Agent can then send this data to [Loki][grafana-logs] or [Tempo][grafana-traces].
 
 The repository consists of multiple packages that can be combined depending on your requirements, as well as a
 [demo][faro-demo], which can be run by following the [README.md file][faro-demo-readme].

--- a/docs/sources/developer/architecture/components/api.md
+++ b/docs/sources/developer/architecture/components/api.md
@@ -55,7 +55,7 @@ pretty simple because all the logic is externalized to other packages like `web-
 Methods:
 
 - `getOTEL` - returns the OpenTelemetry instance if it is initialized
-- `getTraceContext` - return the OpenTelemetry context API
+- `getTraceContext` - returns the OpenTelemetry context API
 - `initOTEL` - initializes the OpenTelemetry instance
 - `isOTELInitialized` - returns whether the OpenTelemetry instance is initialized
 - `pushTraces` - sends traces
@@ -69,8 +69,8 @@ barebones.
 
 Methods:
 
-- `getSession` - return the current session meta value
-- `getView` - return the current view meta value
+- `getSession` - returns the current session meta value
+- `getView` - returns the current view meta value
 - `resetSession` - resets the session meta to an undefined state
 - `resetUser` - resets the user meta to an undefined state
 - `setSession` - replaces the session meta with a new one

--- a/docs/sources/developer/architecture/components/api.md
+++ b/docs/sources/developer/architecture/components/api.md
@@ -1,14 +1,14 @@
 # API
 
-The Faro API is the primary interface for end-users to interact with Faro. It is the central place where signals are
-sent to but it also contains helpers methods for other components like metas.
+The Faro API is the primary interface for end-users to interact with Faro. It is the central collector of signals, and
+also exposes helper methods for extensions such as metas.
 
 ## Signals
 
 ### Events
 
-Events are signals related to tracking various actions like mouse clicks as well as other events like transitioning to
-another page.
+Events are signals that can be used to record user interactions, such as mouse clicks, page navigation, or client-side
+application events like page transitions.
 
 Methods:
 
@@ -30,8 +30,8 @@ Methods:
 
 ### Logs
 
-Logs are signals which capture events that happen within the app itself. They do not have a business meaning but a
-technical meaning.
+Logs are signals which capture events that happen within the app itself. They do not have a business meaning but they
+have a use for operators as a means of troubleshooting or observing historic (or current) application behaviour.
 
 Methods:
 

--- a/docs/sources/developer/architecture/components/api.md
+++ b/docs/sources/developer/architecture/components/api.md
@@ -1,0 +1,78 @@
+# API
+
+The Faro API is the primary interface for end-users to interact with Faro. It is the central place where signals are
+sent to but it also contains helpers methods for other components like metas.
+
+## Signals
+
+### Events
+
+Events are signals related to tracking various actions like mouse clicks as well as other events like transitioning to
+another page.
+
+Methods:
+
+- `pushEvent` - sends an event
+
+### Exceptions
+
+Exceptions are signals that are represented by errors which occurred in an app.
+
+When an exception is sent, the API will pass it through a stacktrace parser to extract the relevant information from it.
+By default, the core package does not contain any stacktrace parsers and they are either provided by wrapper packages
+like `web-sdk` or by the user.
+
+Methods:
+
+- `changeStacktraceParser` - replaces the existing stacktrace parser with a new one
+- `getStacktraceParser` - returns the current stacktrace parser
+- `pushError` - sends an exception
+
+### Logs
+
+Logs are signals which capture events that happen within the app itself. They do not have a business meaning but a
+technical meaning.
+
+Methods:
+
+- `pushLog` - sends a log
+
+### Measurements
+
+Measurements are signals which can be seen as metrics.
+
+Methods:
+
+- `pushMeasurement` - sends a measurement
+
+### Traces
+
+Traces are a special type of signal which are used to track the behaviour of an app. Because Faro does not have an
+internal tracing mechanism, we rely on OpenTelemetry's tracing mechanism to provide this functionality. However,
+OpenTelemetry is quite a heavy system and we do not want to force users to use it. Therefore, the traces API is
+pretty simple because all the logic is externalized to other packages like `web-tracing`.
+
+Methods:
+
+- `getOTEL` - returns the OpenTelemetry instance if it is initialized
+- `getTraceContext` - return the OpenTelemetry context API
+- `initOTEL` - initializes the OpenTelemetry instance
+- `isOTELInitialized` - returns whether the OpenTelemetry instance is initialized
+- `pushTraces` - sends traces
+
+## Helpers
+
+### Metas
+
+Metas API leverages the metas SDK to provide a simple interface to interact with metas since the SDK is extremely
+barebones.
+
+Methods:
+
+- `getSession` - return the current session meta value
+- `getView` - return the current view meta value
+- `resetSession` - resets the session meta to an undefined state
+- `resetUser` - resets the user meta to an undefined state
+- `setSession` - replaces the session meta with a new one
+- `setUser` - replaces the user meta with a new one
+- `setView` - replaces the view meta with a new one

--- a/docs/sources/developer/architecture/components/api.md
+++ b/docs/sources/developer/architecture/components/api.md
@@ -48,9 +48,9 @@ Methods:
 ### Traces
 
 Traces are a special type of signal which are used to track the behaviour of an app. Because Faro does not have an
-internal tracing mechanism, we rely on OpenTelemetry's tracing mechanism to provide this functionality. However,
-OpenTelemetry is quite a heavy system and we do not want to force users to use it. Therefore, the traces API is
-pretty simple because all the logic is externalized to other packages like `web-tracing`.
+internal tracing mechanism, we rely on OpenTelemetry library to provide this functionality. However, OpenTelemetry is
+quite a heavy system and we do not want to force users to use it. Therefore, the traces API is pretty simple because all
+the logic is externalized to other packages like `web-tracing`.
 
 Methods:
 

--- a/docs/sources/developer/architecture/components/instrumentations.md
+++ b/docs/sources/developer/architecture/components/instrumentations.md
@@ -3,8 +3,8 @@
 Instrumentations are the data collectors in the Faro architecture. They are responsible for gathering the data from
 various APIs like the browesr APIs or by other means.
 
-By default, the core library does not provide any instrumentations out of the box and they are either provided by
-wrapper packages like `web-sdk` or by the user.
+The core library does not provide any instrumentations out of the box and they are either provided by wrapper packages
+like `web-sdk` or by the user.
 
 ## Instrumentations SDK
 
@@ -14,5 +14,5 @@ of the initialized instrumentations as well as adding others and removing existi
 Methods and properties:
 
 - `add()` - adds a new instrumentation
-- `remove()` - remove a specific instrumentation
-- `instrumentations` - the current list of initialized instrumentations
+- `remove()` - removes a specific instrumentation
+- `instrumentations` - accesses the current list of initialized instrumentations

--- a/docs/sources/developer/architecture/components/instrumentations.md
+++ b/docs/sources/developer/architecture/components/instrumentations.md
@@ -3,7 +3,7 @@
 Instrumentations are the data collectors in the Faro architecture. They are responsible for gathering the data from
 various APIs like the browesr APIs or by other means.
 
-By default, the core library does not provide any instrumentations out of the box and they are either prvovided by
+By default, the core library does not provide any instrumentations out of the box and they are either provided by
 wrapper packages like `web-sdk` or by the user.
 
 ## Instrumentations SDK

--- a/docs/sources/developer/architecture/components/instrumentations.md
+++ b/docs/sources/developer/architecture/components/instrumentations.md
@@ -1,0 +1,18 @@
+# Instrumentations
+
+Instrumentations are the data collectors in the Faro architecture. They are responsible for gathering the data from
+various APIs like the browesr APIs or by other means.
+
+By default, the core library does not provide any instrumentations out of the box and they are either prvovided by
+wrapper packages like `web-sdk` or by the user.
+
+## Instrumentations SDK
+
+The instrumentations SDK is the internal handler for the instrumentations component. It is responsible for keeping track
+of the initialized instrumentations as well as adding others and removing existing ones.
+
+Methods and properties:
+
+- `add()` - adds a new instrumentation
+- `remove()` - remove a specific instrumentation
+- `instrumentations` - the current list of initialized instrumentations

--- a/docs/sources/developer/architecture/components/internal-logger.md
+++ b/docs/sources/developer/architecture/components/internal-logger.md
@@ -1,0 +1,18 @@
+# Internal Logger
+
+The internal logger is a helper utility that is used to log messages from the library itself. Due to the fact that it
+relies on the unpatched console, the messages printed by the internal logger are not captured during autoinstrumentation
+of the `console` object.
+
+The internal logger is initialized imeddiately after the unpatched console is initialized. Similar to the unpatched
+console, it is also made available to all components that are initialized after it.
+
+Methods available within the internal logger:
+
+- `debug` - used to log verbose messages that are usually necessary during development
+- `info` - used to log messages that are useful for the end-user but are not vital for the day-to-day operations of the
+  Faro library
+- `warn` - used to log messages that are important for the end-user to be aware of but do not prevent the library from
+  working properly
+- `error` - used to log messages that are important for the end-user to be aware of and prevent the library from working
+  properly

--- a/docs/sources/developer/architecture/components/internal-logger.md
+++ b/docs/sources/developer/architecture/components/internal-logger.md
@@ -4,7 +4,7 @@ The internal logger is a helper utility that is used to log messages from the li
 relies on the unpatched console, the messages printed by the internal logger are not captured during autoinstrumentation
 of the `console` object.
 
-The internal logger is initialized imeddiately after the unpatched console is initialized. Similar to the unpatched
+The internal logger is initialized imediately after the unpatched console is initialized. Similar to the unpatched
 console, it is also made available to all components that are initialized after it.
 
 Methods available within the internal logger:

--- a/docs/sources/developer/architecture/components/internal-logger.md
+++ b/docs/sources/developer/architecture/components/internal-logger.md
@@ -1,8 +1,8 @@
 # Internal Logger
 
 The internal logger is a helper utility that is used to log messages from the library itself. Due to the fact that it
-relies on the unpatched console, the messages printed by the internal logger are not captured during autoinstrumentation
-of the `console` object.
+relies on the unpatched console, the messages printed by the internal logger are not captured during
+auto-instrumentation of the `console` object.
 
 The internal logger is initialized imediately after the unpatched console is initialized. Similar to the unpatched
 console, it is also made available to all components that are initialized after it.

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -1,0 +1,105 @@
+# Metas
+
+Metas are key-value properties that are sent with each payload.
+
+Metas can be either static metas that once defined they are not changing across a session but they can be also dynamic
+metas that are either computed automatically for each payload or they are changed programatically by the end-user.
+
+## Available Metas
+
+### App
+
+The `app` meta ties signals with a specific app and it should not be changed across a session. It is required during
+initialization and it is the responsability of the end-user to define it.
+
+Properties:
+
+- `name` - the name of the app
+- `version` - the version of the app
+- `release` - a release identifier for the app, like a commit hash, a build number or a Docker container tag
+- `environment` - the environment where the app is running, like `staging` or `production`
+
+### Browser
+
+The `browser` meta helps with identifying the environment where the app is running and it should not change across a
+session. Altough it is not handled automatically by the core package, nor it is the responsability of the end-user to
+define it. Wrapper packages like `web-sdk` should handle it.
+
+Properties:
+
+- `name` - the name of the browser
+- `version` - the version of the browser
+- `os` - the operating system name and version where the browser is running
+- `mobile` - a flag indication if the browser is running on a mobile device
+
+### Page
+
+The `page` meta helps developers identify the page where a specific signal is coming from. It is changing automatically
+across a session and even though it is not handled automatically by the core package, wrapper packages like `web-sdk`
+should handle it. But unlike other metas, it can be also overwritten by the end-user if they have a custom mechanism for
+tracking the current page.
+
+Properties:
+
+- `url` - the URL of the current page
+- `id` - the name of the browser
+- `attributes` - a key-value object with additional attributes about the current page
+
+### SDK
+
+The `sdk` meta defines the following properties about the Faro library itself:
+
+- `name` - the name of the core library
+- `version` - the version of the library
+- `integrations` - the list of instrumentations that are used, identified with by the name and the version
+
+The `sdk` meta is handled internally by the core package and the end-user should not change it.
+
+### Session
+
+The `session` meta is a static meta that is used to link signals between them. It is not handled automatically by the
+core package and wrapper packages like `web-sdk` can handle it automatically. But unlike other metas, it can be also
+overwritten by the end-user if they have a different way of defining what a session in.
+
+Properties
+
+- `id` - the name of the browser
+- `started` - the date when the session started
+- `attributes` - a key-value object with additional attributes about the session page
+
+### User
+
+The `user` meta ties signals with a specific user. It is not required but it can be provided during initialization as
+well as programatically once the Faro library was initialized.
+
+Properties:
+
+- `id` - the ID of the user
+- `username` - the username of the user
+- `email` - the user's email
+- `attributes` - a key-value object with additional attributes about the current user
+
+### View
+
+The `view` meta helps developers identify the view where a specific signal is coming from. Sometimes apps do not rely on
+URLs to define sections of it but on views. For example, a view can be a category called `auth` for that contains sign
+in and sign up pages. The `view` meta is not changing automatically across a session and even though it is not handled
+set automatically by the core package, wrapper packages like `web-sdk` should give a value default to it. But unlike
+other metas, it can be also overwritten by the end-user during initialization or programatically afterwards.
+
+Properties:
+
+- `name` - the name of the current view
+
+## Metas SDK
+
+The metas SDK is the internal handler for the metas component. It is responsible for keeping track of the current metas
+values as well as the getters for the dynamic metas.
+
+Methods and properties:
+
+- `add()` - adds a new meta
+- `remove()` - remove a specific meta
+- `addListener()` - adds a new listener
+- `removeListener()` - removes a specific listener
+- `value` - the current value of the static metas

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -2,8 +2,10 @@
 
 Metas are key-value properties that are sent with each payload.
 
-Metas can be either static metas that once defined they are not changing across a session but they can be also dynamic
-metas that are either computed automatically for each payload or they are changed programatically by the end-user.
+Metas can be either:
+
+- static - once defined, they are not changing across a session
+- dynamic - either computed automatically for each payload or they are changed programmatically by the end-user.
 
 ## Available Metas
 
@@ -59,18 +61,17 @@ The `sdk` meta is handled internally by the core package and the end-user should
 
 The `session` meta is a static meta that is used to link signals between them. It is not handled automatically by the
 core package and wrapper packages like `web-sdk` can handle it automatically. But unlike other metas, it can be also
-overwritten by the end-user if they have a different way of defining what a session in.
+overwritten by the end-user if they have a different way of defining what a session is.
 
 Properties
 
 - `id` - the name of the browser
-- `started` - the date when the session started
 - `attributes` - a key-value object with additional attributes about the session page
 
 ### User
 
 The `user` meta ties signals with a specific user. It is not required but it can be provided during initialization as
-well as programatically once the Faro library was initialized.
+well as programmatically once the Faro library was initialized.
 
 Properties:
 
@@ -81,11 +82,12 @@ Properties:
 
 ### View
 
-The `view` meta helps developers identify the view where a specific signal is coming from. Sometimes apps do not rely on
-URLs to define sections of it but on views. For example, a view can be a category called `auth` for that contains sign
-in and sign up pages. The `view` meta is not changing automatically across a session and even though it is not handled
-set automatically by the core package, wrapper packages like `web-sdk` should give a value default to it. But unlike
-other metas, it can be also overwritten by the end-user during initialization or programatically afterwards.
+The view meta lets developers define a view to associate signals occured within that view to it. This makes it easy to
+track specific sections in the UI which may dynamically change without any route changes. For example, a view can be a
+category called `auth` for that contains sign in and sign up pages. The `view` meta is not changing automatically across
+a session and even though it is not handled set automatically by the core package, wrapper packages like `web-sdk`
+should give a value default to it. But unlike other metas, it can be also overwritten by the end-user during
+initialization or programmatically afterwards.
 
 Properties:
 

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -4,8 +4,8 @@ Metas are key-value properties that are sent with each payload.
 
 Metas can be either:
 
-- static - once defined, they are not changing across a session
-- dynamic - either computed automatically for each payload or they are changed programmatically by the end-user.
+- static - once defined, they do not change across a session
+- dynamic - either computed automatically for each payload or they are changed programmatically by the end-user
 
 ## Available Metas
 
@@ -24,7 +24,7 @@ Properties:
 ### Browser
 
 The `browser` meta helps with identifying the environment where the app is running and it should not change across a
-session. Altough it is not handled automatically by the core package, nor it is the responsability of the end-user to
+session. Altough it is not handled automatically by the core package, nor is it the responsability of the end-user to
 define it. Wrapper packages like `web-sdk` should handle it.
 
 Properties:
@@ -36,7 +36,7 @@ Properties:
 
 ### Page
 
-The `page` meta helps developers identify the page where a specific signal is coming from. It is changing automatically
+The `page` meta helps developers identify the page where a specific signal is coming from. It changes automatically
 across a session and even though it is not handled automatically by the core package, wrapper packages like `web-sdk`
 should handle it. But unlike other metas, it can be also overwritten by the end-user if they have a custom mechanism for
 tracking the current page.
@@ -53,7 +53,7 @@ The `sdk` meta defines the following properties about the Faro library itself:
 
 - `name` - the name of the core library
 - `version` - the version of the library
-- `integrations` - the list of instrumentations that are used, identified with by the name and the version
+- `integrations` - the list of instrumentations that are used, identified by by the name and the version
 
 The `sdk` meta is handled internally by the core package and the end-user should not change it.
 
@@ -66,12 +66,12 @@ overwritten by the end-user if they have a different way of defining what a sess
 Properties
 
 - `id` - the name of the browser
-- `attributes` - a key-value object with additional attributes about the session page
+- `attributes` - a key-value object with additional attributes about the session
 
 ### User
 
-The `user` meta ties signals with a specific user. It is not required but it can be provided during initialization as
-well as programmatically once the Faro library was initialized.
+The `user` meta ties signals with a specific user. It is not required but it can be provided during initialization, or
+programmatically, once the Faro library was initialized.
 
 Properties:
 
@@ -82,12 +82,12 @@ Properties:
 
 ### View
 
-The view meta lets developers define a view to associate signals occured within that view to it. This makes it easy to
-track specific sections in the UI which may dynamically change without any route changes. For example, a view can be a
-category called `auth` for that contains sign in and sign up pages. The `view` meta is not changing automatically across
-a session and even though it is not handled set automatically by the core package, wrapper packages like `web-sdk`
-should give a value default to it. But unlike other metas, it can be also overwritten by the end-user during
-initialization or programmatically afterwards.
+The `view` meta lets developers define a view to associate with signals that occured within that view. This makes it
+easy to track specific sections in the UI which may dynamically change without any route changes. For example, a view
+can be a category called `auth` that contains sign in and sign up pages. The `view` meta is not changing automatically
+across a session and even though it is not handled automatically by the core package, wrapper packages like `web-sdk`
+should give a value default to it. Unlike other metas, it can be also overwritten by the end-user during initialization
+or programmatically afterwards.
 
 Properties:
 
@@ -101,7 +101,7 @@ values as well as the getters for the dynamic metas.
 Methods and properties:
 
 - `add()` - adds a new meta
-- `remove()` - remove a specific meta
+- `remove()` - removes a specific meta
 - `addListener()` - adds a new listener
 - `removeListener()` - removes a specific listener
-- `value` - the current value of the static metas
+- `value` - accesses the current value of the static metas

--- a/docs/sources/developer/architecture/components/transports.md
+++ b/docs/sources/developer/architecture/components/transports.md
@@ -1,10 +1,10 @@
 # Transports
 
 Transports are the final data processors in the Faro architecture. They are responsible for doing something with the
-data once it was collected by the instrumentations and processed by the internal API.
+data once it has been collected by the instrumentations and processed by the internal API.
 
-By default, the core library does not provide any transports out of the box and they are either provided by wrapper
-packages like `web-sdk` or by the user.
+The core library does not provide any transports out of the box. They are either provided by wrapper packages like
+`web-sdk` or by the user.
 
 ## Transports SDK
 
@@ -16,11 +16,11 @@ Methods and properties:
 - `add()` - adds a new transport
 - `addBeforeSendHook()` - adds a hook that is called before a signal is sent to each transport
 - `addIgnoreErrorsPatterns()` - adds a pattern that matches errors which should be ignored
-- `getBeforeSendHooks()` - return the list of hooks that are called before a signal is sent to each transport
+- `getBeforeSendHooks()` - returns the list of hooks that are called before a signal is sent to each transport
 - `execute()` - sends a signal to each registered transport
 - `isPaused()` - returns whether the transports are paused or not
 - `pause()` - pauses the transports
-- `remove()` - remove a specific transport
+- `remove()` - removes a specific transport
 - `removeBeforeSendHooks()` - removes a specific hook
-- `transports` - the current list of registered transports
+- `transports` - accesses the current list of registered transports
 - `unpause()` - unpauses the transports

--- a/docs/sources/developer/architecture/components/transports.md
+++ b/docs/sources/developer/architecture/components/transports.md
@@ -1,0 +1,26 @@
+# Transports
+
+Transports are the final data processors in the Faro architecture. They are responsible for doing something with the
+data once it was collected by the instrumentations and processed by the internal API.
+
+By default, the core library does not provide any transports out of the box and they are either prvovided by wrapper
+packages like `web-sdk` or by the user.
+
+## Transports SDK
+
+The transports SDK is the internal handler for the transports component. It is responsible for keeping track of the
+initialized transports as well as adding others, removing existing ones, pausing them etc.
+
+Methods and properties:
+
+- `add()` - adds a new transport
+- `addBeforeSendHook()` - adds a hook that is called before a signal is sent to each transport
+- `addIgnoreErrorsPatterns()` - adds a pattern that matches errors which should be ignored
+- `getBeforeSendHooks()` - return the list of hooks that are called before a signal is sent to each transport
+- `execute()` - sends a signal to each registered transport
+- `isPaused()` - returns whether the transports are paused or not
+- `pause()` - pauses the transports
+- `remove()` - remove a specific transport
+- `removeBeforeSendHooks()` - removes a specific hook
+- `transports` - the current list of registered transports
+- `unpause()` - unpauses the transports

--- a/docs/sources/developer/architecture/components/transports.md
+++ b/docs/sources/developer/architecture/components/transports.md
@@ -3,7 +3,7 @@
 Transports are the final data processors in the Faro architecture. They are responsible for doing something with the
 data once it was collected by the instrumentations and processed by the internal API.
 
-By default, the core library does not provide any transports out of the box and they are either prvovided by wrapper
+By default, the core library does not provide any transports out of the box and they are either provided by wrapper
 packages like `web-sdk` or by the user.
 
 ## Transports SDK

--- a/docs/sources/developer/architecture/components/unpatched-console.md
+++ b/docs/sources/developer/architecture/components/unpatched-console.md
@@ -1,8 +1,8 @@
 # Unpatched Console
 
 The unpatched console refers to an unmodified `console` object that is used for various purposes like defining the
-internal Faro logger (check below) or pointing out an alternative to the `console` object for the apps that are using
-a custom logger instead.
+internal Faro logger or pointing to an alternative to the `console` object for the apps that are using a custom logger
+instead.
 
 The unpatched console is the first thing that is initialized when initializing Faro. It is then made available to all
 components like internal logger, instrumentations etc.

--- a/docs/sources/developer/architecture/components/unpatched-console.md
+++ b/docs/sources/developer/architecture/components/unpatched-console.md
@@ -1,0 +1,8 @@
+# Unpatched Console
+
+The unpatched console refers to an unmodified `console` object that is used for various purposes like defining the
+internal Faro logger (check below) or pointing out an alternative to the `console` object for the apps that are using
+a custom logger instead.
+
+The unpatched console is the first thing that is initialized when initializing Faro. It is then made available to all
+components like internal logger, instrumentations etc.

--- a/docs/sources/developer/architecture/initialization.md
+++ b/docs/sources/developer/architecture/initialization.md
@@ -1,0 +1,85 @@
+# Initialization process
+
+The initialization process is pretty complex as it has to deal with a lot of components. Below is a step by step
+description of how is initialized under the hood.
+
+Please refer to the components documentation for more details about each component.
+
+## Core package
+
+### 1. Unpatched Console
+
+The first component that is initialized is the unpatched console. This is needed because it is needed by the internal
+logger component. By default, the unpatched console is initialized with the global `console` object but it can be
+overwritten by the user if is provided in the config object.
+
+### 2. Internal Logger
+
+The internal logger is initialized immediate after the unpatched console but before anything else happens because it
+is needed to print out debug messages. The internal logger relies on the unpatched console and not on the `console`
+object because the latter can be overwritten by instrumentations and we don't want to send those debug messages as
+signals.
+
+### Isolation check
+
+Before any other component is initialized, we run an isolation check.
+
+By default, Faro is a global singleton that can be initialized only once. However, multiple instances can be initialized
+by marking them as isolated using the `isolate` config option. This is useful in large applications that contain
+multiple sub-applications which should be instrumented independently.
+
+The process of isolation check is pretty easy: when a singleton Faro instance is initialized, we define it on the
+global object of the environment (either `window` in browsers or `global` in Node.js). If we detect that there is an
+instance already initialized, we stop the process here.
+
+However, the isolation mode should not be mistaken with global object exposure. The global object exposure is a way to
+make Faro available to the end-user on the global object. Two Faro instances can be instantiated as isolated but they
+can still be exposed on the global object independently of each other.
+
+### 3. Metas
+
+The metas are the next component that is initialized as they are required by all other subsequent components. The API
+requires it because whenever a signal is sent, the immediate meta values are added to it in order to keep them in sync.
+The instrumentations and transports require the metas for exposing them to the developers that are writing their own
+instrumentations and transports.
+
+However, the default metas values are not registered now (check the Initial values section below for more details).
+
+### 4. Transports
+
+The next component that is initialized is the transports components. It comes before the API component because the API
+is accessing it internally to pass the signals. However, the transports should also not be aware of the API component
+because they should not do anything with it.
+
+However, the transports passed in the config are not registered now (check the Initial values section below for more
+details).
+
+### 5. API
+
+The API is the next loaded component. It is initialized before the instrumentations component as the instrumentations
+require the API methods to be available in order to inject them in every instrumentation.
+
+### 6. Instrumentations
+
+The instrumentations component is the last component that is initialized. They are initialized after everything else
+since they do rely on the others. For example, the API methods are used to send signals, the metas are used to take
+decisions on they value etc.
+
+However, the instrumentations passed in the config are not registered now (check the Initial values section below for
+more details).
+
+### 7. The Faro SDK
+
+Once all the components are initialized, we can finally build the global `faro` object. This object is then exposed
+via the `faro` object that end-users can import from the npm package. The same object is also exposed on the global
+object if `preventGlobalExposure` config property was not passed. However, if the global object already contains a
+property with the same name, a warning message will be printed in the console but the process will continue.
+
+### Initial values
+
+Once all the components are initialized, we can finally register the initial values. The default metas are added first,
+then the transports and finally the instrumentations.
+
+## Web SDK
+
+## Tracing

--- a/docs/sources/developer/architecture/initialization.md
+++ b/docs/sources/developer/architecture/initialization.md
@@ -1,7 +1,7 @@
 # Initialization process
 
 The initialization process is pretty complex as it has to deal with a lot of components. Below is a step by step
-description of how is initialized under the hood.
+description of how it is initialized under the hood.
 
 Please refer to the components documentation for more details about each component.
 
@@ -63,7 +63,7 @@ require the API methods to be available in order to inject them in every instrum
 
 The instrumentations component is the last component that is initialized. They are initialized after everything else
 since they do rely on the others. For example, the API methods are used to send signals, the metas are used to take
-decisions on they value etc.
+decisions on the value etc.
 
 However, the instrumentations passed in the config are not registered now (check the Initial values section below for
 more details).

--- a/docs/sources/developer/architecture/initialization.md
+++ b/docs/sources/developer/architecture/initialization.md
@@ -7,13 +7,13 @@ Please refer to the components documentation for more details about each compone
 
 ## Core package
 
-### 1. Unpatched Console
+### [1. Unpatched Console][components-unpatched-console]
 
 The first component that is initialized is the unpatched console because it is needed because it is needed by the
 internal logger component. By default, the unpatched console is initialized with the global `console` object but it can
 be overwritten by the user if it is provided in the config object.
 
-### 2. Internal Logger
+### [2. Internal Logger][components-internal-logger]
 
 The internal logger is initialized immediately after the unpatched console but before anything else happens because it
 is needed to print out debug messages. The internal logger relies on the unpatched console and not on the `console`
@@ -36,38 +36,38 @@ However, the isolation mode should not be mistaken with global object exposure. 
 make Faro available to the end-user on the global object. Two Faro instances can be instantiated as isolated but they
 can still be exposed on the global object independently of each other.
 
-### 3. Metas
+### [3. Metas][components-metas]
 
 The metas are the next component that is initialized as they are required by all subsequent components. The API requires
 it because whenever a signal is sent, the immediate meta values are added to it in order to keep them in sync. The
 instrumentations and transports require the metas for exposing them to the developers that are writing their own
 instrumentations and transports.
 
-However, the default metas values are not registered at this stage (check the Initial values section below for more
-details).
+However, the default metas values are not registered at this stage (check the [Initial values][initial-values] section
+below for more details).
 
-### 4. Transports
+### [4. Transports][components-transports]
 
 The next component that is initialized is the transports components. It comes before the API component because the API
 is accessing it internally to pass the signals. However, the transports should also not be aware of the API component
 because they should not do anything with it.
 
-However, the transports passed in the config are not registered now (check the Initial values section below for more
-details).
+However, the transports passed in the config are not registered at this stage (check the
+[Initial values][initial-values] section below for more details).
 
-### 5. API
+### [5. API][components-api]
 
 The API is the next loaded component. It is initialized before the instrumentations component as the instrumentations
 require the API methods to be available in order to inject them in every instrumentation.
 
-### 6. Instrumentations
+### [6. Instrumentations][components-instrumentations]
 
 The instrumentations component is the last component that is initialized. They are initialized after everything else
 since they do rely on the others. For example, the API methods are used to send signals, the metas are used to take
 decisions on the value etc.
 
-However, the instrumentations passed in the config are not registered now (check the Initial values section below for
-more details).
+However, the instrumentations passed in the config are not registered at this stage (check the
+[Initial values][initial-values] section below for more details).
 
 ### 7. The Faro SDK
 
@@ -84,3 +84,11 @@ then the transports and finally the instrumentations.
 ## Web SDK
 
 ## Tracing
+
+[initial-values]: #initial-values
+[components-api]: ./components/api.md
+[components-instrumentations]: ./components/instrumentations.md
+[components-internal-logger]: ./components/internal-logger.md
+[components-metas]: ./components/metas.md
+[components-transports]: ./components/transports.md
+[components-unpatched-console]: ./components/unpatched-console.md

--- a/docs/sources/developer/architecture/initialization.md
+++ b/docs/sources/developer/architecture/initialization.md
@@ -9,13 +9,13 @@ Please refer to the components documentation for more details about each compone
 
 ### 1. Unpatched Console
 
-The first component that is initialized is the unpatched console. This is needed because it is needed by the internal
-logger component. By default, the unpatched console is initialized with the global `console` object but it can be
-overwritten by the user if is provided in the config object.
+The first component that is initialized is the unpatched console because it is needed because it is needed by the
+internal logger component. By default, the unpatched console is initialized with the global `console` object but it can
+be overwritten by the user if it is provided in the config object.
 
 ### 2. Internal Logger
 
-The internal logger is initialized immediate after the unpatched console but before anything else happens because it
+The internal logger is initialized immediately after the unpatched console but before anything else happens because it
 is needed to print out debug messages. The internal logger relies on the unpatched console and not on the `console`
 object because the latter can be overwritten by instrumentations and we don't want to send those debug messages as
 signals.
@@ -38,12 +38,13 @@ can still be exposed on the global object independently of each other.
 
 ### 3. Metas
 
-The metas are the next component that is initialized as they are required by all other subsequent components. The API
-requires it because whenever a signal is sent, the immediate meta values are added to it in order to keep them in sync.
-The instrumentations and transports require the metas for exposing them to the developers that are writing their own
+The metas are the next component that is initialized as they are required by all subsequent components. The API requires
+it because whenever a signal is sent, the immediate meta values are added to it in order to keep them in sync. The
+instrumentations and transports require the metas for exposing them to the developers that are writing their own
 instrumentations and transports.
 
-However, the default metas values are not registered now (check the Initial values section below for more details).
+However, the default metas values are not registered at this stage (check the Initial values section below for more
+details).
 
 ### 4. Transports
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,11 +1,11 @@
 # @grafana/faro-core
 
-Core package of Faro.
-
 _Warning_: currently pre-release and subject to frequent breaking changes. Use at your own risk.
 
-The entire architecture of the library is contained within this package. Out of the box, it doesn't collect any metrics,
-logs etc. but it offers an API to capture them.
+Core package of Faro.
+
+The entire architecture of the library is contained within this package. Out of the box, it doesn't collect any signals,
+but it provides the API to do it as well as multiple helper methods.
 
 ## Installation
 


### PR DESCRIPTION
## Description

This PR brings new internal docs for understanding the Faro internal architecture. This should help new joiners with understanding how Faro works.

Writing new transports and instrumentations docs will be provided in a separate PR.

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
