### PR TITLE
chore: remove `started` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added export for `genShortID` function in `core`, `web-sdk` and `react` packages
 - Fixed span timings
 - Updated dependencies
+- Remove `started` property from `MetaSession` interface
 
 ## 1.0.0-beta6
 

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -41,7 +41,6 @@ export interface MetaUser {
 
 export interface MetaSession {
   id?: string;
-  started?: string;
   attributes?: MetaAttributes;
 }
 


### PR DESCRIPTION
## Description

With this PR we remove the `started` property from the `MetaSession` interface. 
This is because the `collector` does accept this property. 

It is also not used anywhere in the web-sdk so it is save to remove it.

## Fixes
#98 Remove started property from session meta

## Checklist

- ~[ ] Tests added~
- [x] Changelog updated
- [x] Documentation updated [Docs PR](https://github.com/grafana/cloud-docs/pull/616)
