### PR TITLE
chore(WebVitalsInstrumentation): change deprecated functions names

### DIFF
--- a/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
@@ -1,4 +1,4 @@
-import { getCLS, getFCP, getFID, getINP, getLCP, getTTFB } from 'web-vitals';
+import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals';
 
 import { BaseInstrumentation, VERSION } from '@grafana/faro-core';
 
@@ -7,12 +7,12 @@ export class WebVitalsInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
 
   static mapping = {
-    cls: getCLS,
-    fcp: getFCP,
-    fid: getFID,
-    inp: getINP,
-    lcp: getLCP,
-    ttfb: getTTFB,
+    cls: onCLS,
+    fcp: onFCP,
+    fid: onFID,
+    inp: onINP,
+    lcp: onLCP,
+    ttfb: onTTFB,
   };
 
   initialize(): void {


### PR DESCRIPTION
## Description
The `get` prefix of the function names to receive WebVitals is deprecated and changed to `on`.

## Fixes

Fixes #

Change deprecated function names to the new naming scheme.

Old:
```js
import { getCLS, getFCP, getFID, getINP, getLCP, getTTFB } from 'web-vitals';
```
New:
```js
import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals';
```

Fixes #106 

## Screenshots:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/47627413/216922745-26344d17-bec1-4ba7-b8bf-99e386760d42.png">


## Checklist

~- [ ] Tests added~
~- [ ] Changelog updated~
~- [ ] Documentation updated~
