### PR TITLE
Fix: wrong version for Session and View instrumentations

### DIFF
--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -1,6 +1,4 @@
-import { VERSION } from 'ua-parser-js';
-
-import { BaseInstrumentation, Conventions, Meta, MetaSession } from '@grafana/faro-core';
+import { BaseInstrumentation, Conventions, Meta, MetaSession, VERSION } from '@grafana/faro-core';
 
 // all this does is send SESSION_START event
 export class SessionInstrumentation extends BaseInstrumentation {

--- a/packages/web-sdk/src/instrumentations/view/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/view/instrumentation.ts
@@ -1,6 +1,4 @@
-import { VERSION } from 'ua-parser-js';
-
-import { BaseInstrumentation, Conventions, Meta, MetaView } from '@grafana/faro-core';
+import { BaseInstrumentation, Conventions, Meta, MetaView, VERSION } from '@grafana/faro-core';
 
 // all this does is send VIEW_CHANGED event
 export class ViewInstrumentation extends BaseInstrumentation {


### PR DESCRIPTION
## Description

The Session and View Instrumentation had a wrong sdk version attached.

## Fixes

This happened due to a wrong import of the VERSION constant.

Fixes issue #100 

## Screenshots
### Before
<img width="403" alt="Screenshot 2023-02-06 at 17 03 13" src="https://user-images.githubusercontent.com/47627413/217022756-5a8a5c4b-5eab-4b23-b207-7d11ed887491.png">

### After
<img width="414" alt="Screenshot 2023-02-06 at 16 54 38" src="https://user-images.githubusercontent.com/47627413/217022813-45c1e9a2-5023-4561-ad59-36daf97f566d.png">


## Checklist
- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
