### PR TITLE
119 upgrade docker compose tempo config to use tempo 2x

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
   tempo:
     env_file:
       - './.env'
-    image: 'grafana/tempo:latest'
+    image: 'grafana/tempo:2.0.0'
     volumes:
       - '${TEMPO_CONFIG_PATH_LOCAL}:${TEMPO_CONFIG_PATH}'
     command:

--- a/infra/tempo/config/tempo.yaml
+++ b/infra/tempo/config/tempo.yaml
@@ -1,6 +1,3 @@
-metrics_generator_enabled: true
-search_enabled: true
-
 multitenancy_enabled: false
 
 server:
@@ -49,11 +46,11 @@ storage:
     backend: 'local' # backend configuration to use
     block:
       bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
-      index_downsample_bytes: 1000 # number of bytes per index record
-      encoding: 'zstd' # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+      v2_index_downsample_bytes: 1000 # number of bytes per index record
+      v2_encoding: 'zstd' # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     wal:
       path: '/tmp/tempo/wal' # where to store the the wal locally
-      encoding: 'snappy' # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+      v2_encoding: 'snappy' # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     local:
       path: '/tmp/tempo/blocks'
     pool:


### PR DESCRIPTION
## Description

* Align `tempo.yaml` to [new breaking changes coming with `Tempo v2.0.0`](https://github.com/grafana/tempo/releases)
* Pin Tempo version in `docker-compose.yaml` to avoid issues with future breaking changes

## Fixes

Fixes #119 

## Checklist

~- [ ] Tests added~
~- [ ] Changelog updated~
~- [ ] Documentation updated~
