### PR TITLE
Faro patch release to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.0.1
 
 - Have FetchTransport consume response body. Otherwise requests are not considered closed
+- Fix a bug where View and Session Instrumentation had wrong version applied
+- Use Change to use the new functions names from WebVitals instead of the deprecated ones
 
 ## 1.0.0
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-demo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Demo of Faro",
   "license": "Apache-2.0",
   "author": "Grafana Labs",
@@ -34,10 +34,10 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^1.0.0",
-    "@grafana/faro-react": "^1.0.0",
-    "@grafana/faro-web-sdk": "^1.0.0",
-    "@grafana/faro-web-tracing": "^1.0.0",
+    "@grafana/faro-core": "^1.0.1",
+    "@grafana/faro-react": "^1.0.1",
+    "@grafana/faro-web-sdk": "^1.0.1",
+    "@grafana/faro-web-tracing": "^1.0.1",
     "@opentelemetry/api": "^1.4.0",
     "@opentelemetry/core": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.35.0",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*",
     "demo"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core package of Faro.",
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Faro package that enables easier integration in projects built with React.",
   "keywords": [
     "observability",
@@ -51,8 +51,8 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^1.0.0",
-    "@grafana/faro-web-tracing": "^1.0.0",
+    "@grafana/faro-web-sdk": "^1.0.1",
+    "@grafana/faro-web-tracing": "^1.0.1",
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Faro instrumentations, metas, transports for web.",
   "keywords": [
     "observability",
@@ -51,7 +51,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^1.0.0",
+    "@grafana/faro-core": "^1.0.1",
     "ua-parser-js": "^1.0.32",
     "web-vitals": "^3.1.1"
   },

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-tracing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Faro web tracing implementation.",
   "keywords": [
     "observability",
@@ -51,7 +51,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^1.0.0",
+    "@grafana/faro-web-sdk": "^1.0.1",
     "@opentelemetry/api": "^1.4.0",
     "@opentelemetry/context-zone": "^1.9.0",
     "@opentelemetry/core": "^1.9.0",


### PR DESCRIPTION
## Description
Prepare Faro patch release to v1.0.1

## Changes
- Have FetchTransport consume response body. Otherwise requests are not considered closed
- Fix a bug where View and Session Instrumentation had wrong version applied
- Use Change to use the new functions names from WebVitals instead of the deprecated ones

## Checklist

~- [ ] Tests added~
- [x] Changelog updated
~- [ ] Documentation updated~
