### PR TITLE
Fix: Only use Resource relevant Metas to decide to create a new ResourceLog or add item to the respective existing one. 

### DIFF
--- a/packages/web-sdk/src/transports/otlp/payload/OtelPayload.test.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/OtelPayload.test.ts
@@ -82,6 +82,14 @@ describe('OtelPayload', () => {
 
     otelPayload.addResourceItem({
       ...transportItem,
+      meta: {
+        ...transportItem.meta,
+        // Page meta is NOT used to create the Resource object.
+        // This is to ensure hat we do only diff Resource related metas when defining if item belongs to a Resource we've already created.
+        page: {
+          id: '123',
+        },
+      },
       payload: {
         ...transportItem.payload,
         name: 'event-name-2',

--- a/packages/web-sdk/src/transports/otlp/payload/OtelPayload.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/OtelPayload.ts
@@ -1,12 +1,13 @@
-import { deepEqual, InternalLogger, Meta, TransportItem, TransportItemType } from '@grafana/faro-core';
+import { deepEqual, InternalLogger, TransportItem, TransportItemType } from '@grafana/faro-core';
 
 import { initLogsTransform, LogsTransform } from './transform';
+import type { ResourceMetas } from './transform/types';
 import type { ResourceLog } from './transform';
 import type { OtelTransportPayload } from './types';
 
 interface ResourceLogsMetaMap {
   resourceLog: ResourceLog;
-  meta: Meta;
+  resourceMetas: ResourceMetas;
 }
 
 export class OtelPayload {
@@ -31,8 +32,14 @@ export class OtelPayload {
   }
 
   addResourceItem(transportItem: TransportItem): void {
-    const { type, meta } = transportItem;
     const { toLogRecord, toResourceLog } = this.initLogsTransform;
+    const { type, meta } = transportItem;
+
+    const currentItemResourceMetas: ResourceMetas = {
+      browser: meta.browser,
+      sdk: meta.sdk,
+      app: meta.app,
+    } as const;
 
     try {
       switch (type) {
@@ -40,8 +47,8 @@ export class OtelPayload {
         case TransportItemType.EXCEPTION:
         case TransportItemType.EVENT:
         case TransportItemType.MEASUREMENT:
-          const resourceLogWithMeta = this.resourceLogsWithMetas.find(({ meta }) =>
-            deepEqual(transportItem.meta, meta)
+          const resourceLogWithMeta = this.resourceLogsWithMetas.find(({ resourceMetas }) =>
+            deepEqual(currentItemResourceMetas, resourceMetas)
           );
 
           if (resourceLogWithMeta) {
@@ -52,7 +59,7 @@ export class OtelPayload {
           } else {
             this.resourceLogsWithMetas.push({
               resourceLog: toResourceLog(transportItem),
-              meta,
+              resourceMetas: currentItemResourceMetas,
             });
           }
 

--- a/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
@@ -19,7 +19,7 @@ import type { InternalLogger } from '@grafana/faro-core';
 
 import { isAttribute, toAttribute, toAttributeValue } from '../attribute';
 
-import type { LogRecord, LogsTransform, LogTransportItem, Resource, ScopeLog } from './types';
+import type { LogRecord, LogsTransform, LogTransportItem, Resource, ResourceMetas, ScopeLog } from './types';
 
 /**
  * Seems currently to be missing in the semantic-conventions npm package.
@@ -46,7 +46,7 @@ export function initLogsTransform(internalLogger: InternalLogger): LogsTransform
   }
 
   function toResource(transportItem: LogTransportItem): Readonly<Resource> {
-    const { browser, sdk, app } = transportItem.meta;
+    const { browser, sdk, app }: ResourceMetas = transportItem.meta;
 
     return {
       attributes: [

--- a/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
@@ -125,8 +125,8 @@ export function initLogsTransform(internalLogger: InternalLogger): LogsTransform
       body,
       attributes: [
         ...getCommonLogAttributes(meta),
-        toAttribute('event.name', payload.name), // No prefix because this is a semantic attribute. But event.name constant is currently missing in sematic-conventions npm package
-        toAttribute('event.domain', payload.domain), // No prefix because this is a semantic attribute. But event.domain constant is currently missing in sematic-conventions npm package
+        toAttribute('event.name', payload.name), // This is a semantic attribute. But event.name constant is currently missing in sematic-conventions npm package
+        toAttribute('event.domain', payload.domain), // This is a semantic attribute. But event.domain constant is currently missing in sematic-conventions npm package
         toAttribute('event.attributes', payload.attributes),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,

--- a/packages/web-sdk/src/transports/otlp/payload/transform/types.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/transform/types.ts
@@ -1,6 +1,6 @@
 import type { IKeyValue } from '@opentelemetry/otlp-transformer';
 
-import type { APIEvent, TransportItem } from '@grafana/faro-core';
+import type { APIEvent, Meta, TransportItem } from '@grafana/faro-core';
 
 export interface Resource {
   attributes: IKeyValue[];
@@ -36,3 +36,5 @@ export type LogsTransform = {
   toScopeLog: (transportItem: LogTransportItem) => ScopeLog;
   toLogRecord: (transportItem: LogTransportItem) => LogRecord;
 };
+
+export type ResourceMetas = Pick<Meta, 'app' | 'browser' | 'sdk'>;


### PR DESCRIPTION
## Description

Only use Resource relevant Metas to decide to create a new ResourceLog or add item to the respective existing one. 

## Fixes
We accidentally used the whole Meta Object to find out (via diff) if a ScopeLog already exists for the given Meta.
But the default Meta contains much more Metas as used to define the Otel Resource. 
This lead to a case where a new ScopeLog is created because non Otel Resource relevant Metas have changed.

So even if the Resource relevant metas i. e.  MetaBrowser, MetaSDK and MetaApp did not change, a new ResourceLog was created because some of the other Metas changed.

## Checklist

- [x] Tests aligned to cover that use case 
- [ ] Changelog updated
- [ ] Documentation updated
