### PR TITLE
Add option to configure URLs which should include trace header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- Add config option to include URLs for which requests shall have tracing headers added.
+
 ## 1.0.1 - 1.0.2
 
 - Have FetchTransport consume response body. Otherwise requests are not considered closed

--- a/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
+++ b/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
@@ -4,11 +4,25 @@ import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
-export function getDefaultOTELInstrumentations(ignoreUrls: Array<string | RegExp> = []): InstrumentationOption[] {
+import type { MatchUrlDefinitions } from './types';
+
+type DefaultInstrumentationsOptions = {
+  ignoreUrls?: MatchUrlDefinitions;
+  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
+};
+
+const initialIntrumentationsOptions = {
+  ignoreUrls: [],
+  propagateTraceHeaderCorsUrls: [],
+};
+
+export function getDefaultOTELInstrumentations(
+  options: DefaultInstrumentationsOptions = initialIntrumentationsOptions
+): InstrumentationOption[] {
   return [
     new DocumentLoadInstrumentation(),
-    new FetchInstrumentation({ ignoreUrls }),
-    new XMLHttpRequestInstrumentation({ ignoreUrls }),
+    new FetchInstrumentation(options),
+    new XMLHttpRequestInstrumentation(options),
     new UserInteractionInstrumentation(),
   ];
 }

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -63,7 +63,12 @@ export class TracingInstrumentation extends BaseInstrumentation {
     });
 
     registerInstrumentations({
-      instrumentations: options.instrumentations ?? getDefaultOTELInstrumentations(this.getIgnoreUrls()),
+      instrumentations:
+        options.instrumentations ??
+        getDefaultOTELInstrumentations({
+          ignoreUrls: this.getIgnoreUrls(),
+          propagateTraceHeaderCorsUrls: this.options.instrumentationOptions?.propagateTraceHeaderCorsUrls,
+        }),
     });
 
     this.api.initOTEL(trace, context);

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -15,4 +15,9 @@ export interface TracingInstrumentationOptions {
   contextManager?: ContextManager;
   instrumentations?: InstrumentationOption[];
   spanProcessor?: SpanProcessor;
+  instrumentationOptions?: {
+    propagateTraceHeaderCorsUrls: MatchUrlDefinitions;
+  };
 }
+
+export type MatchUrlDefinitions = Array<string | RegExp>;


### PR DESCRIPTION
## Description

When using the Faro/Otel TraceInstrumentation people need to configure the (cors) URLs for which requests shall have trace headers added.

Currently this is not obvious from our docs and it's not possible to configure this directly via `TracingInstrumentation`.

Currently people need to re-add the standard Otel Instruments we are using in the TracingInstrumentationand and add the config there.
 
```ts
new TracingInstrumentation({
        instrumentations: [
          new DocumentLoadInstrumentation(),
          new FetchInstrumentation({
            ignoreUrls: ["the-collector-url"],
            propagateTraceHeaderCorsUrls: [
              new RegExp("https://foo.com/*")
            ]
          }),
          new XMLHttpRequestInstrumentation({
            ignoreUrls: ["the-collector-url"],
            propagateTraceHeaderCorsUrls: [
              new RegExp("https://foo.com/*")
            ]
          }),
          new UserInteractionInstrumentation()
        ]
      }),
```
 
Since this use case is quite common we added a config option to add  the `propagateTraceHeaderCorsUrls` list.

```ts
 new TracingInstrumentation({
        instrumentationOptions: {
          propagateTraceHeaderCorsUrls: […],
        },
      }),
```

The docs are updated with docs PR [Update Faro tracing docs to reflect new API #790 ](https://github.com/grafana/cloud-docs/pull/790)

## Fixes

Fixes #131 (partly) and #144 

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
