### PR TITLE
chore: add brands array for browsers supporting `userAgentData.

### DIFF
--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -50,6 +50,11 @@ export interface MetaPage {
   attributes?: MetaAttributes;
 }
 
+interface NavigatorUABrandVersion {
+  brand?: string;
+  version?: string;
+}
+
 export interface MetaBrowser {
   name?: string;
   version?: string;
@@ -57,6 +62,7 @@ export interface MetaBrowser {
   mobile?: boolean;
   userAgent?: string;
   language?: string;
+  brands?: NavigatorUABrandVersion[] | string;
 }
 
 export interface MetaView {

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -1,6 +1,6 @@
 import { UAParser } from 'ua-parser-js';
 
-import type { Meta, MetaItem } from '@grafana/faro-core';
+import type { Meta, MetaBrowser, MetaItem } from '@grafana/faro-core';
 
 export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
   const parser = new UAParser();
@@ -9,6 +9,7 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
   const userAgent = parser.getUA();
   const language = navigator.language;
   const mobile = navigator.userAgent.includes('Mobi');
+  const brands = getBrands();
   const unknown = 'unknown';
 
   return {
@@ -19,6 +20,19 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       userAgent: userAgent ?? unknown,
       language: language ?? unknown,
       mobile,
+      brands: brands ?? unknown,
     },
   };
+
+  function getBrands(): MetaBrowser['brands'] | undefined {
+    if (!name || !version) {
+      return undefined;
+    }
+
+    if ('userAgentData' in navigator) {
+      return (navigator.userAgentData as any).brands;
+    }
+
+    return undefined;
+  }
 };

--- a/packages/web-sdk/src/transports/otlp/payload/transform/toResourceLog.test.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/transform/toResourceLog.test.ts
@@ -19,6 +19,11 @@ const item: Readonly<TransportItem<LogEvent>> = {
       mobile: false,
       userAgent: 'browser-ua-string',
       language: 'browser-language',
+      brands: [
+        { brand: 'Google Chrome', version: '111' },
+        { brand: 'Not(A:Brand', version: '8' },
+        { brand: 'Chromium', version: '111' },
+      ],
     },
     sdk: {
       name: 'integration-web-sdk-name',
@@ -57,6 +62,69 @@ const matchResourcePayload = {
     {
       key: 'browser.language',
       value: { stringValue: 'browser-language' },
+    },
+    {
+      key: 'browser.brands',
+      value: {
+        arrayValue: {
+          values: [
+            {
+              kvlistValue: {
+                values: [
+                  {
+                    key: 'brand',
+                    value: {
+                      stringValue: 'Google Chrome',
+                    },
+                  },
+                  {
+                    key: 'version',
+                    value: {
+                      stringValue: '111',
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              kvlistValue: {
+                values: [
+                  {
+                    key: 'brand',
+                    value: {
+                      stringValue: 'Not(A:Brand',
+                    },
+                  },
+                  {
+                    key: 'version',
+                    value: {
+                      stringValue: '8',
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              kvlistValue: {
+                values: [
+                  {
+                    key: 'brand',
+                    value: {
+                      stringValue: 'Chromium',
+                    },
+                  },
+                  {
+                    key: 'version',
+                    value: {
+                      stringValue: '111',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
     },
     {
       key: 'browser.os',

--- a/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
+++ b/packages/web-sdk/src/transports/otlp/payload/transform/transform.ts
@@ -207,8 +207,8 @@ function toResource(transportItem: TransportItem): Readonly<Resource> {
       toAttribute(SemanticBrowserAttributes.BROWSER_MOBILE, browser?.mobile),
       toAttribute(SemanticBrowserAttributes.BROWSER_USER_AGENT, browser?.userAgent),
       toAttribute(SemanticBrowserAttributes.BROWSER_LANGUAGE, browser?.language),
+      toAttribute(SemanticBrowserAttributes.BROWSER_BRANDS, browser?.brands),
       toAttribute('browser.os', browser?.os),
-      // toAttribute(SemanticBrowserAttributes.BROWSER_BRANDS, browser?.brands),
       toAttribute('browser.name', browser?.name),
       toAttribute('browser.version', browser?.version),
 


### PR DESCRIPTION
## Description

Add the `browser.brands` property as defined by the[ Otel Semantic Attributes spec for browsers](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/browser/).

**Note:**
This information is received from [navigator.userAgentData.brands which currently is only suppported in Chromium based browsers](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/brands#browser_compatibility).


### Current proposal: 
The current proposal adds browser.brands only for those browsers which support the `userAgentData` API.
For others browsers the property will be set to `unknown` as it is for the other properties in `BrowserMeta`

### Alternatives
**1. Always add brands.**
 For browser which do not support `userAgentData` we add `[{brand: name, version: version}]`. Pro: the property always as value added and no unknown states. Con: browsers supporting the flag add a few more items to the list which may lead to inconsistencies in the data we sent.

**2. Never add brands**
Simply wait till all browsers implement `userAgentData`
Pro: no additional work for use. Con: not aligned with Otel spec when using OtlpHttpTransport
 
## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
