### PR TITLE
Fix: remove $(pwd) from faro-web-sdk_demo_demo_logs path

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -54,6 +54,12 @@ docker compose --profile demo up -d
 
 This will automatically install dependencies, build the demo and start it in `development` mode.
 
+To stop everything, run:
+
+```shell
+docker compose --profile demo down
+```
+
 ## Instrumentation
 
 There is various data that is captured in this app. Some data is captured manually while other data is automatically

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -136,7 +136,7 @@ volumes:
     driver: 'local'
     driver_opts:
       type: 'none'
-      device: '${PWD}/${DEMO_DEMO_PATH}/${DEMO_SERVER_LOGS_PATH}'
+      device: '${DEMO_DEMO_PATH}/${DEMO_SERVER_LOGS_PATH}'
       o: 'bind'
   demo_demo_node_modules:
   demo_core_dist:


### PR DESCRIPTION
## Description

This PR removes $(pwd) component from the faro-web-sdk_demo_demo_logs volume.

if `faro-web-sdk_demo_demo_logs` volume is setup incorrectly due to `docker compose --profile demo up -d` being run in `demo/` subfolder (where that instruction is given), it will not be possible to fix it without running 
```
docker volume rm faro-web-sdk_demo_demo_logs
```
and recreating the volume by running `docker compose` in the root of the repository.

To reproduce the issue
```bash
cd demo/
docker volume rm faro-web-sdk_demo_demo_logs
docker compose --profile demo up -d
docker inspect faro-web-sdk_demo_demo_logs | grep "demo/demo" #will show the incorrectly computed path
docker compose down
```
Verified by repeating the above instructions + getting no output with this patch applied.

## Fixes

Fixes #158 

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
