### PR TITLE
chore(docs): Add missing destructuring assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Next
 
-- Add config option to include URLs for which requests shall have tracing headers added.
-- Fixes where TracingInstrumentation broke fetch requests with relative URLs are broken on sub-pages.
+- Adds: Config option to include URLs for which requests shall have tracing headers added.
+- Fixes: TracingInstrumentation broke fetch requests with relative URLs are broken on sub-pages.
+- Fixes: Missing destructuring assignment in Browser quick start tutorial.
 
 ## 1.0.1 - 1.0.2
 

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -236,7 +236,7 @@ const resource = Resource.default().merge(
 
 const provider = new WebTracerProvider({ resource });
 
-provider.addSpanProcessor(new FaroSessionSpanProcessor(new BatchSpanProcessor(new FaroTraceExporter({ faro }))));
+provider.addSpanProcessor(new FaroSessionSpanProcessor(new BatchSpanProcessor(new FaroTraceExporter({ ...faro }))));
 
 provider.register({
   propagator: new W3CTraceContextPropagator(),


### PR DESCRIPTION
## Description
In the `quickl-start-browser` tutorial for adding Faro with OpenTelemetry support, we instantiated `new FaroTraceExporter({ faro })`.
This does not work because  the`FaroTraceExporter` receives `api` as the only constructor parameter and we forgit to add the destructuring assignment like this `new FaroTraceExporter({ ...faro })`.



## Fixes

Fixes #

Slightly related to: #160
A user had some problems because he referred to this example.


## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
