### PR TITLE
Demo app crashes when user has an ad-blocker activated

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "yarn serve:dev",
+    "start": "yarn serve:prod",
+    "dev": "yarn serve:dev",
     "serve:dev": "nodemon src/server/index.ts",
     "serve:prod": "cross-env NODE_ENV=production node --experimental-specifier-resolution=node --experimental-loader ./dist/server/otel.js dist/server/index.js",
     "build": "run-p build:*",


### PR DESCRIPTION
## Description

Demo app crashes when user has an ad-blocker activated.

In the video you see first how the menu expands when clicking the hamburger menu.
Next, after activating the ad-blocker, the menu doesn't expand anymore.

Browser console shows a Vite server error:`http://localhost:5173/node_modules/.vite/deps/web-vitals.js?v=9a30861b`

The Vite server could not download an asset which was blocked by an ad-blocker.
This is a weird behavior of the Vite dev server an there is no fix for that as disabling the ad-blocker.
See [Vite Docs - "Browser extensions"](https://vitejs.dev/guide/troubleshooting.html#browser-extensions)

Solution:
Start the Vite in prod mode (node-env set to production). 

Changes:
* Use prod strict on start: `"start": "yarn serve:prod",`
* Add dev script for easy starting the dev server for local development. `"dev": "yarn serve:dev",`


## Videos
### Before

https://user-images.githubusercontent.com/47627413/233658628-7fd66c73-8dc6-47f7-b74e-5a61555dad39.mov

### After



https://user-images.githubusercontent.com/47627413/233658838-689de66f-1af4-4c94-831c-528b2b20ffca.mov


## Fixes

Fixes #168 


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
