### PR TITLE
docker-compose: fix grafana-agent path

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - '${AGENT_CONFIG_PATH_LOCAL}:${AGENT_CONFIG_PATH}'
       - 'demo_demo_logs:${AGENT_LOGS_PATH}'
     entrypoint:
-      - '/bin/agent'
+      - '/bin/grafana-agent'
       - '-config.file=${AGENT_CONFIG_PATH}/${AGENT_CONFIG_FILE}'
       - '-config.expand-env'
       - '-config.enable-read-api'


### PR DESCRIPTION
## Description

The path has changed upstream to /bin/grafana-agent

## Fixes

Fixes running the demo application and other uses of the docker-compose environment


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
