### PR TITLE
chore: align version scheme to have the same version for all packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.3 – 1.0.4
+## 1.0.3 – 1.0.5
 
 - Add: Config option to include URLs for which requests shall have tracing headers added.
 - Fix: TracingInstrumentation broke fetch requests with relative URLs are broken on sub-pages.

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -4,11 +4,6 @@ To release a new version, run `npx lerna version` on the main branch.
 It will ask some questions, bump package versions, tag & push.
 CI will pick it up from there and publish to npm.
 
-Important:\
-
-1. The version of experimental or beta packages will be set independently.
-2. The version of all other (stable) will be increased to the same version for all of these packages.
-
 **Note:**
 Before calling `npx lerna version` always ensure that your local main branch is 1:1 with origin/main.
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+- Change: Align versioning scheme to have the same version for all Faro Web-SDK packages.
+
 ## 1.0.0.beta.0 - 1.0.0.beta.1
 
 - Add: Experimental package for Open Telemetry compliant HTTP transport.

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "experimental/*",
     "demo"
   ],
-  "version": "independent",
+  "version": "1.0.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
## Description

Chnage version scheme back to the "single version for all packages approach"

## Fixes
Tested indepednent versionoing with the addition of experimental packages. 
Which only leads to maintenance overhead, greater source for compatibility problems and confusion for customers about which versions will work together. 

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
