### PR TITLE
chore: explain how to add additional config options

### DIFF
--- a/experimental/instrumentation-performance-timeline/README.md
+++ b/experimental/instrumentation-performance-timeline/README.md
@@ -71,11 +71,18 @@ Alongside the default entry types the example adds entries to track
 new PerformanceTimelineInstrumentation({
   observeEntryTypes: [
     ...DEFAULT_PERFORMANCE_TIMELINE_ENTRY_TYPES,
-    { type: 'event', durationThreshold: 16, buffered: true },
+    { type: 'event', buffered: true },
     { type: 'mark',  buffered: true },
     { type: 'measure', , buffered: true },
   ],
 }),
+```
+
+Additionally you can add all config properties a respective PerformanceEntry provides.
+For example if you want to change the duration threshold for `PerformanceEventTiming`.
+
+```ts
+{ type: 'event', durationThreshold: 96, buffered: true },
 ```
 
 Note:


### PR DESCRIPTION
## Description
Update docs to reflect that all config props for a PerformanceEntry can be used with Faro too. 

## Fixes

Fixes #176 

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
