### PR TITLE
chore: add support check for performance observer

### DIFF
--- a/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
@@ -390,4 +390,42 @@ describe('PerformanceTimelineInstrumentation', () => {
       matchNavigationAndResourceEntriesTestResults[2]
     );
   });
+
+  it('Stop initialization of the instrument and show a message if PerformanceObserver is not supported by the browser', () => {
+    delete (global as any).PerformanceObserver;
+    delete (global as any).Performance;
+
+    const instrumentation = new PerformanceTimelineInstrumentation();
+
+    const mockInfo = jest.fn();
+    instrumentation.internalLogger = { ...mockInternalLogger, info: mockInfo };
+
+    const validateIfObservedEntryTypesSupportedByBrowserMock = jest.fn();
+    jest
+      .spyOn(instrumentation, 'validateIfObservedEntryTypesSupportedByBrowser' as any)
+      .mockImplementation(validateIfObservedEntryTypesSupportedByBrowserMock);
+
+    const setIgnoredUrlsMock = jest.fn();
+    jest.spyOn(instrumentation, 'setIgnoredUrls' as any).mockImplementation(setIgnoredUrlsMock);
+
+    const configureResourceTimingBufferMock = jest.fn();
+    jest
+      .spyOn(instrumentation, 'configureResourceTimingBuffer' as any)
+      .mockImplementation(configureResourceTimingBufferMock);
+
+    const registerPerformanceObserverMock = jest.fn();
+    jest
+      .spyOn(instrumentation, 'registerPerformanceObserver' as any)
+      .mockImplementation(registerPerformanceObserverMock);
+
+    const observeMock = jest.fn();
+    jest.spyOn(instrumentation, 'observe' as any).mockImplementation(observeMock);
+    instrumentation.initialize();
+
+    expect(mockInfo).toHaveBeenCalledTimes(1);
+    expect(validateIfObservedEntryTypesSupportedByBrowserMock).toHaveBeenCalledTimes(0);
+    expect(setIgnoredUrlsMock).toHaveBeenCalledTimes(0);
+    expect(configureResourceTimingBufferMock).toHaveBeenCalledTimes(0);
+    expect(observeMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.ts
@@ -45,6 +45,15 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
   }
 
   initialize(): void {
+    const isPerformanceObserverSupported = 'PerformanceObserver' in window;
+
+    if (!isPerformanceObserverSupported) {
+      this.internalLogger.info(
+        `Browser does not support PerformanceObserver, stopping initialization of PerformanceTimelineInstrumentation`
+      );
+      return undefined;
+    }
+
     this.validateIfObservedEntryTypesSupportedByBrowser();
     // Need to set ignored URLs here to ensure that instrumentations are already available
     this.setIgnoredUrls();

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.ts
@@ -49,7 +49,7 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
 
     if (!isPerformanceObserverSupported) {
       this.internalLogger.info(
-        `Browser does not support PerformanceObserver, stopping initialization of PerformanceTimelineInstrumentation`
+        'Browser does not support PerformanceObserver, stopping initialization of PerformanceTimelineInstrumentation'
       );
       return undefined;
     }


### PR DESCRIPTION
## Description

Add check if PerformaceObserver is supported. 
In case a browser does not have support, stop initialization of the instrument.

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
