### PR TITLE
add additional error context to excceptions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- Add: add option to provide additional error context in `pushError` api.
+
 ## 1.0.3 – 1.0.5
 
 - Add: Config option to include URLs for which requests shall have tracing headers added.

--- a/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
@@ -29,6 +29,9 @@ const item: TransportItem<ExceptionEvent> = {
       trace_id: 'trace-id',
       span_id: 'span-id',
     } as const,
+    context: {
+      additional: 'context',
+    },
   },
   meta: {
     view: {
@@ -230,6 +233,21 @@ const matchErrorLogRecord = {
                     },
                   ],
                 },
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      key: 'faro.error.context',
+      value: {
+        kvlistValue: {
+          values: [
+            {
+              key: 'additional',
+              value: {
+                stringValue: 'context',
               },
             },
           ],

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -130,6 +130,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
         toAttribute(SemanticAttributes.EXCEPTION_MESSAGE, payload.value),
         // toAttribute(SemanticAttributes.EXCEPTION_STACKTRACE, undefined),
         toAttribute('faro.error.stacktrace', payload.stacktrace),
+        toAttribute('faro.error.context', payload.context),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,
       spanId: payload.trace?.trace_id,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -94,6 +94,13 @@ The `api` property on the Faro instance contains all the necessary methods to pu
       },
     ],
   });
+
+  faro.api.pushError(new Error('This is a log with context'), {
+    context: {
+      message: 'React error boundary',
+      componentStackTrace: {...}
+    },
+  });
   ```
 
 ## Events

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -42,9 +42,15 @@ describe('api.exceptions', () => {
         },
       ];
 
+      const additionalContext = {
+        message: 'React error boundary',
+        componentStackTrace: { foo: 'bar' },
+      };
+
       api.pushError(new Error('test exception'), {
         stackFrames: frames,
         type: 'TestError',
+        context: additionalContext,
       });
 
       expect(transport.items).toHaveLength(1);
@@ -57,6 +63,7 @@ describe('api.exceptions', () => {
       expect(evt.type).toEqual('TestError');
       expect(evt.value).toEqual('test exception');
       expect(evt.stacktrace).toEqual({ frames });
+      expect(evt.context).toEqual(additionalContext);
     });
 
     it('error without overrides', () => {
@@ -159,6 +166,16 @@ describe('api.exceptions', () => {
         api.pushError(error, {
           skipDedupe: true,
         });
+        expect(transport.items).toHaveLength(2);
+      });
+
+      it("doesn't filter events with same message, same stacktrace, same type but different context", () => {
+        const error = new Error('test');
+
+        api.pushError(error, { context: { foo: 'bar' } });
+        expect(transport.items).toHaveLength(1);
+
+        api.pushError(error, { context: { bar: 'baz' } });
         expect(transport.items).toHaveLength(2);
       });
     });

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -34,7 +34,7 @@ export function initializeExceptionsAPI(
 
   const getStacktraceParser: ExceptionsAPI['getStacktraceParser'] = () => stacktraceParser;
 
-  const pushError: ExceptionsAPI['pushError'] = (error, { skipDedupe, stackFrames, type } = {}) => {
+  const pushError: ExceptionsAPI['pushError'] = (error, { skipDedupe, stackFrames, type, context } = {}) => {
     type = type || error.name || defaultExceptionType;
 
     const item: TransportItem<ExceptionEvent> = {
@@ -44,6 +44,7 @@ export function initializeExceptionsAPI(
         value: error.message,
         timestamp: getCurrentTimestamp(),
         trace: tracesApi.getTraceContext(),
+        context: context ?? {},
       },
       type: TransportItemType.EXCEPTION,
     };
@@ -60,6 +61,7 @@ export function initializeExceptionsAPI(
       type: item.payload.type,
       value: item.payload.value,
       stackTrace: item.payload.stacktrace,
+      context: item.payload.context,
     };
 
     if (!skipDedupe && config.dedupe && !isNull(lastPayload) && deepEqual(testingPayload, lastPayload)) {

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -1,3 +1,4 @@
+import type { BaseObject } from '../../utils';
 import type { TraceContext } from '../traces';
 
 export type StacktraceParser = (err: ExtendedError) => Stacktrace;
@@ -19,6 +20,8 @@ export interface Stacktrace {
   frames: ExceptionStackFrame[];
 }
 
+export type ExceptionContext = BaseObject;
+
 export interface ExceptionEvent {
   timestamp: string;
   type: string;
@@ -26,12 +29,14 @@ export interface ExceptionEvent {
 
   stacktrace?: Stacktrace;
   trace?: TraceContext;
+  context?: ExceptionContext;
 }
 
 export interface PushErrorOptions {
   skipDedupe?: boolean;
   stackFrames?: ExceptionStackFrame[];
   type?: string;
+  context?: ExceptionContext;
 }
 
 export interface ExceptionsAPI {


### PR DESCRIPTION
## Description

Add option to put extra context to exception logs.

I kept the API similar to Logs API where we add additional context via the options object.

[Cloud docs PR to show how to add additional error context](https://github.com/grafana/cloud-docs/pull/922).

## Fixes

Fixes #
Fixes #141 

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
