### PR TITLE
fix: add correct span_id and add context to log

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### PerformanceTimelineInstrumentation
 
 - Add: beforeEmit hook to make it possible to mutate performance entries.
-
-#### Breaking Changes
-
-- Remove: `skipEntries` entries are no removed in favor of the `beforeEmit` hook. You can find an
+- [❗️Breaking❗️] Remove: `skipEntries` entries are no removed in favor of the `beforeEmit` hook. You can find an
   [example how to skip entries in the README.](https://github.com/grafana/faro-web-sdk/blob/a83d2e56b7289ea81a1d0f87c03f73d04bd44e38/experimental/instrumentation-performance-timeline/README.md#example-skip-backforward-navigation-and-page-reloads-to-remove-non-human-visible-navigation)
+
+### OtlpHttpTransport
+
+- Fix: add correct span_id when transforming Faro to Otlp model.
+- Fix: add additional log context to logs.
 
 ## 1.0.5
 

--- a/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
@@ -237,11 +237,14 @@ const matchErrorLogRecord = {
       },
     },
   ],
+
+  traceId: 'trace-id',
+  spanId: 'span-id',
 } as const;
 
 describe('toErrorLogRecord', () => {
   it('Builds resource payload object for given transport item.', () => {
     const errorLogRecord = getLogTransforms(mockInternalLogger).toScopeLog(item).logRecords[0];
-    expect(errorLogRecord).toMatchObject(matchErrorLogRecord);
+    expect(errorLogRecord).toEqual(matchErrorLogRecord);
   });
 });

--- a/experimental/transport-otlp-http/src/payload/transform/toEventLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toEventLogRecord.test.ts
@@ -180,11 +180,16 @@ const matchEventLogRecord = {
       },
     },
   ],
+  body: {
+    stringValue: 'event-name',
+  },
+  traceId: 'trace-id',
+  spanId: 'span-id',
 } as const;
 
 describe('toEventLogRecord', () => {
   it('Builds resource payload object for given transport item.', () => {
     const eventLogRecord = getLogTransforms(mockInternalLogger).toScopeLog(item).logRecords[0];
-    expect(eventLogRecord).toMatchObject(matchEventLogRecord);
+    expect(eventLogRecord).toEqual(matchEventLogRecord);
   });
 });

--- a/experimental/transport-otlp-http/src/payload/transform/toLogLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toLogLogRecord.test.ts
@@ -6,7 +6,7 @@ import { getLogTransforms } from './transform';
 const item: TransportItem<LogEvent> = {
   type: TransportItemType.LOG,
   payload: {
-    context: {},
+    context: { foo: 'bar' },
     level: LogLevel.INFO,
     message: 'Faro was initialized',
     timestamp: '2023-01-27T09:53:01.035Z',
@@ -151,12 +151,29 @@ const matchLogLogRecord = {
         },
       },
     },
+    {
+      key: 'faro.log.context',
+      value: {
+        kvlistValue: {
+          values: [
+            {
+              key: 'foo',
+              value: {
+                stringValue: 'bar',
+              },
+            },
+          ],
+        },
+      },
+    },
   ],
+  traceId: 'trace-id',
+  spanId: 'span-id',
 } as const;
 
 describe('toLogLogRecord', () => {
   it('Builds resource payload object for given transport item.', () => {
     const logLogRecord = getLogTransforms(mockInternalLogger).toScopeLog(item).logRecords[0];
-    expect(logLogRecord).toMatchObject(matchLogLogRecord);
+    expect(logLogRecord).toEqual(matchLogLogRecord);
   });
 });

--- a/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
@@ -159,6 +159,9 @@ const matchMeasurementLogRecord = {
       value: { doubleValue: 213.7000000011176 },
     },
   ],
+
+  traceId: 'trace-id',
+  spanId: 'span-id',
 } as const;
 
 describe('toMeasurementLogRecord', () => {

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -93,9 +93,11 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
       severityNumber: 10,
       severityText: 'INFO2',
       body,
-      attributes: getCommonLogAttributes(meta),
+      attributes: [...getCommonLogAttributes(meta), toAttribute('faro.log.context', payload.context)].filter(
+        isAttribute
+      ),
       traceId: payload.trace?.trace_id,
-      spanId: payload.trace?.trace_id,
+      spanId: payload.trace?.span_id,
     } as const;
   }
 
@@ -114,7 +116,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
         toAttribute('event.attributes', payload.attributes),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,
-      spanId: payload.trace?.trace_id,
+      spanId: payload.trace?.span_id,
     } as const;
   }
 
@@ -132,7 +134,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
         toAttribute('faro.error.stacktrace', payload.stacktrace),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,
-      spanId: payload.trace?.trace_id,
+      spanId: payload.trace?.span_id,
     } as const;
   }
 
@@ -150,7 +152,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
         toAttribute('measurement.value', measurementValue),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,
-      spanId: payload.trace?.trace_id,
+      spanId: payload.trace?.span_id,
     } as const;
   }
 

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -34,7 +34,14 @@ const otelTransportPayload: OtelTransportPayload['resourceLogs'] = [
             body: {
               stringValue: 'hi',
             },
-            attributes: [],
+            attributes: [
+              {
+                key: 'faro.log.context',
+                value: {
+                  kvlistValue: { values: [] },
+                },
+              },
+            ],
           } as LogRecord,
         ],
       },
@@ -81,6 +88,8 @@ describe('OtlpHttpTransport', () => {
     transport.send(v);
 
     expect(fetch).toHaveBeenCalledTimes(1);
+
+    // \"attributes\":[{\"key\":\"faro.log.context\",\"value\":{\"kvlistValue\":{\"values\":[]}}}]
 
     expect(fetch).toHaveBeenCalledWith(url, {
       body: JSON.stringify(payload),
@@ -252,7 +261,14 @@ describe('OtlpHttpTransport', () => {
                   body: {
                     stringValue: 'hi',
                   },
-                  attributes: [],
+                  attributes: [
+                    {
+                      key: 'faro.log.context',
+                      value: {
+                        kvlistValue: { values: [] },
+                      },
+                    },
+                  ],
                 } as LogRecord,
                 {
                   timeUnixNano: 1674813181035000000,
@@ -261,7 +277,14 @@ describe('OtlpHttpTransport', () => {
                   body: {
                     stringValue: 'foo',
                   },
-                  attributes: [],
+                  attributes: [
+                    {
+                      key: 'faro.log.context',
+                      value: {
+                        kvlistValue: { values: [] },
+                      },
+                    },
+                  ],
                 } as LogRecord,
               ],
             },


### PR DESCRIPTION
## Description

- Assign `payload.trace?.span_id` instead of `spanId: payload.trace?.trace_id` 
- Add `context` to LogLogRecord attributes  array


## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
