### PR TITLE
fix: narrow LogContext and ExceptionContext types.

### DIFF
--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -44,7 +44,7 @@ describe('api.exceptions', () => {
 
       const additionalContext = {
         message: 'React error boundary',
-        componentStackTrace: { foo: 'bar' },
+        componentStackTrace: 'componentStackTrace',
       };
 
       api.pushError(new Error('test exception'), {

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -1,4 +1,3 @@
-import type { BaseObject } from '../../utils';
 import type { TraceContext } from '../traces';
 
 export type StacktraceParser = (err: ExtendedError) => Stacktrace;
@@ -20,7 +19,9 @@ export interface Stacktrace {
   frames: ExceptionStackFrame[];
 }
 
-export type ExceptionContext = BaseObject;
+export type ExceptionContext = {
+  [key: string]: string;
+};
 
 export interface ExceptionEvent {
   timestamp: string;

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -19,9 +19,7 @@ export interface Stacktrace {
   frames: ExceptionStackFrame[];
 }
 
-export type ExceptionContext = {
-  [key: string]: string;
-};
+export type ExceptionContext = Record<string, string>;
 
 export interface ExceptionEvent {
   timestamp: string;

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -57,7 +57,7 @@ describe('api.logs', () => {
 
         api.pushLog(['test'], {
           context: {
-            a: 1,
+            a: '1',
           },
         });
         expect(transport.items).toHaveLength(2);

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -1,7 +1,9 @@
-import type { BaseObject, LogLevel } from '../../utils';
+import type { LogLevel } from '../../utils';
 import type { TraceContext } from '../traces';
 
-export type LogContext = BaseObject;
+export type LogContext = {
+  [key: string]: string;
+};
 
 export interface LogEvent {
   context: LogContext;

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -1,9 +1,7 @@
 import type { LogLevel } from '../../utils';
 import type { TraceContext } from '../traces';
 
-export type LogContext = {
-  [key: string]: string;
-};
+export type LogContext = Record<string, string>;
 
 export interface LogEvent {
   context: LogContext;


### PR DESCRIPTION
## Description

**Why**
The Faro Receiver defines the type for `LogContext` and `ErrorContext` as a string to map.
Whereas the Web-SDK defines it as type `BaseObject` which is nearly `any` type.

**What**
Narrow `LogContext` and `ErrorContext` down to string to string map.


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated