### PR TITLE
Core: Use `globalThis` rather than `window`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Add: add option to provide additional error context in `pushError` api.
+- Fix: Use `globalThis` instead of `global` or `window` in case the SDK is used in webworkers.
 
 ## 1.0.3 – 1.0.5
 

--- a/packages/core/src/globalObject/globalObject.ts
+++ b/packages/core/src/globalObject/globalObject.ts
@@ -1,10 +1,16 @@
 import type { Faro, internalGlobalObjectKey } from '../sdk';
 
-export type GlobalObject<T = typeof window | typeof global> = T & {
+export type GlobalObject<T = typeof globalThis | typeof global | typeof self> = T & {
   [label: string]: Faro;
 
   [internalGlobalObjectKey]: Faro;
 };
 
 // This does not uses isUndefined method because it will throw an error in non-browser environments
-export const globalObject = (typeof window === 'undefined' ? global : window) as GlobalObject;
+export const globalObject = (typeof globalThis !== 'undefined'
+  ? globalThis
+  : typeof global !== 'undefined'
+  ? global
+  : typeof self !== 'undefined'
+  ? self
+  : undefined) as unknown as GlobalObject;


### PR DESCRIPTION
## Description

This PR changes the `GlobalObject` to be computed from `globalThis`, `global` and `self`, rather than sticking to `global` if `window` is not defined. 

Background: I am currently building a browser extension, which uses webworkers to run background tasks. Those webworkers don't have a `global` nor a `window` object. The current implementation in core fails and leads to errors. By using `globalThis` the issue can be mitigated, as `globalThis` is present in Node, where it points to `global`, in a usual browser window, where it points to `window` and in webworkers, where it points to `self` (I think).

I just went with this check I implemented because that is also what was used in Typescript:
https://github.com/microsoft/TypeScript/blob/v4.6.4/src/compiler/corePublic.ts#L119-L122

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
