### PR TITLE
chore: only observe supported entry types

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### PerformanceTimelineInstrumentation
 
 - Add: beforeEmit hook to make it possible to mutate performance entries.
+- Add: only observe entry types which are supported by the visitors browser.
 - [❗️Breaking❗️] Remove: `skipEntries` entries are no removed in favor of the `beforeEmit` hook. You can find an
   [example how to skip entries in the README.](https://github.com/grafana/faro-web-sdk/blob/a83d2e56b7289ea81a1d0f87c03f73d04bd44e38/experimental/instrumentation-performance-timeline/README.md#example-skip-backforward-navigation-and-page-reloads-to-remove-non-human-visible-navigation)
 

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
@@ -212,7 +212,7 @@ describe('PerformanceTimelineInstrumentation', () => {
     expect(maxResourceTimingBufferSize).toBe(500);
 
     const observeEntryTypes = (instrumentation as any).observeEntryTypes;
-    expect(observeEntryTypes).toMatchObject([
+    expect(observeEntryTypes).toEqual([
       { buffered: true, type: 'navigation' },
       { buffered: true, type: 'resource' },
     ]);
@@ -232,7 +232,7 @@ describe('PerformanceTimelineInstrumentation', () => {
     expect(maxResourceTimingBufferSize).toBe(2000);
 
     const observeEntryTypes = (instrumentation as any).observeEntryTypes;
-    expect(observeEntryTypes).toMatchObject([
+    expect(observeEntryTypes).toEqual([
       { buffered: true, type: 'navigation' },
       { buffered: true, type: 'resource' },
       { buffered: true, type: 'event' },
@@ -244,12 +244,12 @@ describe('PerformanceTimelineInstrumentation', () => {
   });
 
   it('Show message if entry type is not supported by browser', () => {
-    const instrumentation = new PerformanceTimelineInstrumentation({
-      observeEntryTypes: [{ buffered: true, type: 'foo' }],
-    });
+    const supportedType = { buffered: true, type: 'navigation' };
+    const unsupportedType = { buffered: true, type: 'unsupported-entry' };
 
-    const observeEntryTypes = (instrumentation as any).observeEntryTypes;
-    expect(observeEntryTypes).toMatchObject([{ buffered: true, type: 'foo' }]);
+    const instrumentation = new PerformanceTimelineInstrumentation({
+      observeEntryTypes: [unsupportedType, supportedType],
+    });
 
     const mockInfo = jest.fn();
     instrumentation.internalLogger = { ...mockInternalLogger, info: mockInfo };
@@ -259,6 +259,9 @@ describe('PerformanceTimelineInstrumentation', () => {
     instrumentation.initialize();
 
     expect(mockInfo).toHaveBeenCalledTimes(1);
+
+    const observeEntryTypes = (instrumentation as any).observeEntryTypes;
+    expect(observeEntryTypes).toEqual([supportedType]);
   });
 
   it('Observe entries based on "observeEntryTypes" option', () => {
@@ -292,7 +295,7 @@ describe('PerformanceTimelineInstrumentation', () => {
     const mockPushEvent = jest.fn();
     api.pushEvent = mockPushEvent;
 
-    expect((instrumentation as any).ignoredUrls).toMatchObject(ignoredUrls);
+    expect((instrumentation as any).ignoredUrls).toEqual(ignoredUrls);
 
     instrumentation.handlePerformanceEntry({ getEntries: () => navigationAndResourceEntries } as any, null as any, 0);
 

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.ts
@@ -54,7 +54,8 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
   }
 
   private validateIfObservedEntryTypesSupportedByBrowser() {
-    const unsupportedEntryTypes = [];
+    const unsupportedEntryTypes: string[] = [];
+
     for (const entryType of this.observeEntryTypes) {
       if (!PerformanceObserver.supportedEntryTypes.includes(entryType.type)) {
         unsupportedEntryTypes.push(entryType.type);
@@ -62,7 +63,15 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
     }
 
     if (unsupportedEntryTypes.length > 0) {
-      this.internalLogger.info('The following entryTypes are not supported by this browser');
+      this.observeEntryTypes = this.observeEntryTypes.filter(
+        (entryType) => !unsupportedEntryTypes.includes(entryType.type)
+      );
+
+      this.internalLogger.info(
+        `The following entryTypes are not supported by this browser: ${unsupportedEntryTypes}. Observing only supported entryTypes which are: ${this.observeEntryTypes.map(
+          ({ type }) => type
+        )}`
+      );
     }
   }
 
@@ -74,7 +83,7 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
     performance.setResourceTimingBufferSize(this.resourceTimingBufferSize);
     performance.addEventListener('resourcetimingbufferfull', () => {
       this.internalLogger.info(
-        `Resource Timing Buffer is FULL! Increasing buffer size to ${this.maxResourceTimingBufferSize}.`
+        `Resource Timing Buffer is full! Increasing buffer size to ${this.maxResourceTimingBufferSize}.`
       );
       performance.setResourceTimingBufferSize(this.maxResourceTimingBufferSize);
     });


### PR DESCRIPTION
## Description

Remove entry types which are not supported by the browser so that we only observe supported entry types.

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
