### PR TITLE
Make single TransportItem transports backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 - Add: add option to provide additional error context in `pushError` api.
 - Fix: Use `globalThis` instead of `global` or `window` in case the SDK is used in webworkers.
 - Add: Add batch execution support for transports in core.
-- [BREAKING]: Transport.send now accepts a list of items to be sent instead of a single item.
+- Add: Transport.send now accepts a list of items to be sent instead of a single item.
 - Update: Update Vite version in Demo app
+
+- Deprecation notice: `Transport.send` supporting a single item is deprecated and will be
+  removed in v2
 
 ## 1.0.3 – 1.0.5
 

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -32,6 +32,10 @@ export class OtlpHttpTransport extends BaseTransport {
     return [tracesURL, logsURL].filter(Boolean);
   }
 
+  override isBatched(): boolean {
+    return true;
+  }
+
   send(items: TransportItem[]): void {
     const otelPayload = new OtelPayload(this.internalLogger);
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -296,6 +296,34 @@ The transports also support batch processing wiht the `batchEnabled` flag set to
 and a positive, non zero `batchSendTimeout`. The batch executor will group items that share the same `metas` together
 and call the `send` function for each group of signals.
 
+### Updating transports to support multiple items
+
+Currently the Transport interface supports implementations of the `send` function that accept either a `TransportItem`
+or an array of them. The former is deprecated and will be removed as of version 2. To update your transport:
+
+```ts
+export class MyTransport extends BaseTransport {
+  async send(item: TransportItem): Promise<void> {
+    // do something with the item
+  }
+}
+
+/* should be */
+
+export class MyTransport extends BaseTransport {
+  async send(items: TransportItem[]): Promise<void> {
+    // do something with the array of items
+    // all of them share the same metas
+  }
+
+  // This is required for the transports layer to differentiate
+  // between the two types of Transport implementations
+  override isBatched(): boolean {
+    return true;
+  }
+}
+```
+
 ## Unpatched console
 
 Some instrumentations might override the default console methods but Faro instance provides a way to access the

--- a/packages/core/src/testUtils/mockTransport.ts
+++ b/packages/core/src/testUtils/mockTransport.ts
@@ -17,6 +17,10 @@ export class MockTransport extends BaseTransport implements Transport {
     this.items.push(...items);
   }
 
+  override isBatched(): boolean {
+    return true;
+  }
+
   override getIgnoreUrls(): Patterns {
     return this.ignoreURLs;
   }

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -3,7 +3,14 @@ import { BaseExtension } from '../extensions';
 import type { Transport, TransportItem } from './types';
 
 export abstract class BaseTransport extends BaseExtension implements Transport {
-  abstract send(items: TransportItem[]): void | Promise<void>;
+  abstract send(items: TransportItem | TransportItem[]): void | Promise<void>;
+
+  isBatched(): boolean {
+    this.internalLogger.warn(
+      `Custom transports supporting a single TransportItem are deprecated. You should change your transport to accomondate an array of TransportItem. You can read how to upgrade your transports in the README.`
+    );
+    return false;
+  }
 
   getIgnoreUrls(): Array<string | RegExp> {
     return [];

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -107,7 +107,11 @@ export function initializeTransports(
 
     for (const transport of transports) {
       internalLogger.debug(`Transporting item using ${transport.name}\n`, items);
-      transport.send(filteredItems);
+      if (transport.isBatched()) {
+        transport.send(filteredItems);
+      } else {
+        filteredItems.forEach((item) => transport.send(item));
+      }
     }
   };
 

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -17,10 +17,12 @@ export interface TransportItem<P = APIEvent> {
 }
 
 export interface Transport extends Extension {
-  send(items: TransportItem[]): void | Promise<void>;
+  send(items: TransportItem | TransportItem[]): void | Promise<void>;
 
   // returns URLs to be ignored by tracing, to not cause a feedback loop
   getIgnoreUrls(): Patterns;
+  // returns wether the transport supports processing of a batches of items
+  isBatched(): boolean;
 }
 
 export type BodyKey = 'exceptions' | 'logs' | 'measurements' | 'traces' | 'events';

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -78,6 +78,10 @@ export class FetchTransport extends BaseTransport {
     return [this.options.url];
   }
 
+  override isBatched(): boolean {
+    return true;
+  }
+
   private getRetryAfterDate(response: Response): Date {
     const now = this.getNow();
     const retryAfterHeader = response.headers.get('Retry-After');


### PR DESCRIPTION
## Description

This pull request ensures that the implementations of the Transport interface that were accepting a single item in their `send` function, will work as expected. This type of Transports is getting deprecated instead and will be removed with v2

## Checklist

- [X] Tests added
- [ ] Changelog updated
- [X] Documentation updated
