### PR TITLE
Clean up batch processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 - Add: Transport.send now accepts a list of items to be sent instead of a single item.
 - Update: Update Vite version in Demo app
 
-- Deprecation notice: `Transport.send` supporting a single item is deprecated and will be
-  removed in v2
-
 ## 1.0.3 – 1.0.5
 
 - Add: Config option to include URLs for which requests shall have tracing headers added.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -296,10 +296,11 @@ The transports also support batch processing wiht the `batchEnabled` flag set to
 and a positive, non zero `batchSendTimeout`. The batch executor will group items that share the same `metas` together
 and call the `send` function for each group of signals.
 
-### Updating transports to support multiple items
+### Batched transports
 
 Currently the Transport interface supports implementations of the `send` function that accept either a `TransportItem`
-or an array of them. The former is deprecated and will be removed as of version 2. To update your transport:
+or an array of them. The latter is useful when you want to batch process signals with your custom transport. In order
+to achieve this, you should override the `isBatched` method of the BaseTransport.
 
 ```ts
 export class MyTransport extends BaseTransport {
@@ -310,7 +311,7 @@ export class MyTransport extends BaseTransport {
 
 /* should be */
 
-export class MyTransport extends BaseTransport {
+export class MyBatchedTransport extends BaseTransport {
   async send(items: TransportItem[]): Promise<void> {
     // do something with the array of items
     // all of them share the same metas

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -6,9 +6,6 @@ export abstract class BaseTransport extends BaseExtension implements Transport {
   abstract send(items: TransportItem | TransportItem[]): void | Promise<void>;
 
   isBatched(): boolean {
-    this.internalLogger.warn(
-      `Custom transports supporting a single TransportItem are deprecated. You should change your transport to accomondate an array of TransportItem. You can read how to upgrade your transports in the README.`
-    );
     return false;
   }
 

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -102,15 +102,34 @@ export function initializeTransports(
     return filteredItems;
   };
 
-  const send = (items: TransportItem[]) => {
+  const batchedSend = (items: TransportItem[]) => {
     const filteredItems = applyBeforeSendHooks(items);
 
+    if (filteredItems.length === 0) {
+      return;
+    }
+
     for (const transport of transports) {
-      internalLogger.debug(`Transporting item using ${transport.name}\n`, items);
+      internalLogger.debug(`Transporting item using ${transport.name}\n`, filteredItems);
       if (transport.isBatched()) {
         transport.send(filteredItems);
-      } else {
-        filteredItems.forEach((item) => transport.send(item));
+      }
+    }
+  };
+
+  const instantSend = (item: TransportItem) => {
+    const [filteredItem] = applyBeforeSendHooks([item]);
+
+    if (filteredItem === undefined) {
+      return;
+    }
+
+    for (const transport of transports) {
+      internalLogger.debug(`Transporting item using ${transport.name}\n`, filteredItem);
+      if (!transport.isBatched()) {
+        transport.send(filteredItem);
+      } else if (!config.batching?.enabled) {
+        transport.send([filteredItem]);
       }
     }
   };
@@ -118,21 +137,32 @@ export function initializeTransports(
   let batchExecutor: BatchExecutor | undefined;
 
   if (config.batching?.enabled) {
-    batchExecutor = new BatchExecutor(send, {
+    batchExecutor = new BatchExecutor(batchedSend, {
       sendTimeout: config.batching.sendTimeout,
       itemLimit: config.batching.itemLimit,
       paused,
     });
   }
 
+  // Send a signal to the appropriate transports
+  //
+  // 1. If SDK is paused, early return
+  // 2. If batching is not enabled send the signal to all transports
+  //    instantly.
+  // 3i. If batching is enabled, enqueue the signal
+  // 3ii. Send the signal instantly to all un-batched transports
   const execute: Transports['execute'] = (item) => {
-    if (!paused) {
-      if (config.batching?.enabled && batchExecutor !== undefined) {
-        batchExecutor.addItem(item);
-      } else {
-        send([item]);
-      }
+    if (paused) {
+      return;
     }
+
+    if (!config.batching?.enabled) {
+      instantSend(item);
+      return;
+    }
+
+    batchExecutor?.addItem(item);
+    instantSend(item);
   };
 
   const getBeforeSendHooks: Transports['getBeforeSendHooks'] = () => [...beforeSendHooks];


### PR DESCRIPTION
## Description

After some suggestions by @bfmatei, there might be cases of transports that require instantaneous execution of the signal (such as a WebSocket, a Console or any stream). To that end, this commit removes the deprecation notice of the un-batched transports and instead changes the core logic which is responsible for sending the item.
## Fixes

## Checklist

- [ ] Tests added
- [X] Changelog updated
- [X] Documentation updated
