### PR TITLE
Add browserslist to faro packages

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/experimental/instrumentation-fetch/.browserslistrc
+++ b/experimental/instrumentation-fetch/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -53,5 +53,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -53,5 +53,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    ".browserslistrc",
+    "dist",
+    "README.md",
+    "LICENSE"
+  ]
 }

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -53,6 +53,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/experimental/instrumentation-performance-timeline/.browserslistrc
+++ b/experimental/instrumentation-performance-timeline/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -53,5 +53,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "README.md",
     "LICENSE"
@@ -53,6 +54,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/experimental/transport-otlp-http/.browserslistrc
+++ b/experimental/transport-otlp-http/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -53,5 +53,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "README.md",
     "LICENSE"
@@ -53,6 +54,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -89,5 +89,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   },
-  "browserslist": [ "defaults and supports es6-module", "maintained node versions" ]
+  "browserslist": [ "supports es6-module" ]
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,5 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -88,5 +88,6 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
-  }
+  },
+  "browserslist": [ "defaults and supports es6-module", "maintained node versions" ]
 }

--- a/packages/core/.browserslistrc
+++ b/packages/core/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "README.md",
     "LICENSE"
@@ -60,6 +61,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,5 +60,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/packages/react/.browserslistrc
+++ b/packages/react/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "README.md",
     "LICENSE"
@@ -67,6 +68,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,5 +67,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/packages/web-sdk/.browserslistrc
+++ b/packages/web-sdk/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -24,6 +24,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "globals.ts",
     "README.md",
@@ -61,6 +62,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -61,5 +61,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "browserslist": [ "supports es6-module" ]
 }

--- a/packages/web-tracing/.browserslistrc
+++ b/packages/web-tracing/.browserslistrc
@@ -1,0 +1,1 @@
+supports es6-module

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -25,6 +25,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
+    ".browserslistrc",
     "dist",
     "README.md",
     "LICENSE"
@@ -72,7 +73,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "418b7f9ae1d5e6397404d4d6a1938ee557b8575c",
-  "browserslist": [ "supports es6-module" ]
+  }
 }

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -73,5 +73,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "418b7f9ae1d5e6397404d4d6a1938ee557b8575c"
+  "gitHead": "418b7f9ae1d5e6397404d4d6a1938ee557b8575c",
+  "browserslist": [ "supports es6-module" ]
 }


### PR DESCRIPTION
## Description

In order to indicate to downstream consumers the compile targets to allow polyfilling, this change adds the browserslist entries to each package.json of the provided packages in the repo.

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
