### PR TITLE
Remove OTel user-interaction instrumentation from the default set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Remove: Remove OTel user-interaction instrumentation from the default set (#215)
+
 ## 1.1.0
 
 - Add: add option to provide additional error context in `pushError` api.

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -60,7 +60,6 @@
     "@opentelemetry/instrumentation": "^0.37.0",
     "@opentelemetry/instrumentation-document-load": "^0.32.0",
     "@opentelemetry/instrumentation-fetch": "^0.37.0",
-    "@opentelemetry/instrumentation-user-interaction": "^0.32.1",
     "@opentelemetry/instrumentation-xml-http-request": "^0.37.0",
     "@opentelemetry/otlp-transformer": "^0.37.0",
     "@opentelemetry/resources": "^1.11.0",

--- a/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
+++ b/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
@@ -1,7 +1,6 @@
 import type { InstrumentationOption } from '@opentelemetry/instrumentation';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
-import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
 import type { MatchUrlDefinitions } from './types';
@@ -23,6 +22,5 @@ export function getDefaultOTELInstrumentations(
     new DocumentLoadInstrumentation(),
     new FetchInstrumentation(options),
     new XMLHttpRequestInstrumentation(options),
-    new UserInteractionInstrumentation(),
   ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,15 +1991,6 @@
     "@types/pg" "8.6.1"
     "@types/pg-pool" "2.0.3"
 
-"@opentelemetry/instrumentation-user-interaction@^0.32.1":
-  version "0.32.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.32.1.tgz#654c0352c2f7d5bb6cc21f07f9ec56f18f2cc854"
-  integrity sha512-27we7cENzEtO2oCRiEkYG4cFe1v94ybeLvM+5jqNDkZF7UY0GlctCW+jvqf569Z3Gs7yHrakO2sZf4EMEfTFWg==
-  dependencies:
-    "@opentelemetry/core" "^1.8.0"
-    "@opentelemetry/instrumentation" "^0.35.1"
-    "@opentelemetry/sdk-trace-web" "^1.8.0"
-
 "@opentelemetry/instrumentation-winston@^0.31.1":
   version "0.31.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.1.tgz#4c666cb36a6d2ca1cb319c0280a3ca16ba5608ed"


### PR DESCRIPTION
## Description

This instrumentation is very chatty and should only be enabled when needed. It is not needed for the default set of instrumentations.

## Fixes

Fixes #

<!-- Every PR should have a reference to an issue as changes need to be discussed before they are implemented. -->
<!-- Example -->
<!-- Fixes #123456 -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
