### PR TITLE
chore: update release docs

### DIFF
--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -1,11 +1,11 @@
 # Releasing
 
-To release a new version, run `npx lerna version` on the main branch.
+To release a new version, run `npx lerna version --force-publish` on the main branch.
 It will ask some questions, bump package versions, tag & push.
 CI will pick it up from there and publish to npm.
 
 **Note:**
-Before calling `npx lerna version` always ensure that your local main branch is 1:1 with origin/main.
+Before calling `npx lerna version --force-publish` always ensure that your local main branch is 1:1 with origin/main.
 
 - Do `git pull` the main branch
 - Check `git status` to double check if you have any unpushed changes


### PR DESCRIPTION
## Description

For a Faro release we always update the version of all package, even if the packages had no changes.
To ensure Lerna is updating all package version add `--force-publish` to teh update call.

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
