### PR TITLE
chore: move forced grpc resolution to demo package

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -39,6 +39,7 @@
     "@grafana/faro-react": "^1.1.2",
     "@grafana/faro-web-sdk": "^1.1.2",
     "@grafana/faro-web-tracing": "^1.1.2",
+    "@grpc/grpc-js": "^1.8.17",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/core": "^1.11.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.37.0",
@@ -97,5 +98,8 @@
     "nodemon": "^2.0.20",
     "touch": "^3.1.0",
     "vite": "^4.3.9"
+  },
+  "resolutions": {
+    "@grpc/grpc-js": "^1.8.17"
   }
 }

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -53,7 +53,6 @@
   },
   "dependencies": {
     "@grafana/faro-web-sdk": "^1.1.2",
-    "@grpc/grpc-js": "^1.8.17",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/context-zone": "^1.11.0",
     "@opentelemetry/core": "^1.11.0",
@@ -69,8 +68,7 @@
     "@opentelemetry/semantic-conventions": "^1.11.0"
   },
   "resolutions": {
-    "@opentelemetry/api-metrics": "^0.29.1",
-    "@grpc/grpc-js": "^1.8.17"
+    "@opentelemetry/api-metrics": "^0.29.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,15 +525,7 @@
     eslint-plugin-react-hooks "4.6.0"
     typescript "4.8.4"
 
-"@grpc/grpc-js@^1.7.1":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.4.tgz#316674e8905e2dd310d8aa60331e05b32584e6ad"
-  integrity sha512-oaETBotls7FTBpySg5dhyUCyXSxSeCMmkBBXHXG1iw57MiNoB6D7VRhkrXYbwyHM3Q3Afjp4KlsBX0Zb+ELZXw==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/node" ">=12.12.47"
-
-"@grpc/grpc-js@^1.8.17":
+"@grpc/grpc-js@^1.7.1", "@grpc/grpc-js@^1.8.17":
   version "1.8.17"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.17.tgz#a3a2f826fc033eae7d2f5ee41e0ab39cee948838"
   integrity sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==
@@ -1843,10 +1835,10 @@
   dependencies:
     "@octokit/openapi-types" "^14.0.0"
 
-"@opentelemetry/api-metrics@^0.29.1", "@opentelemetry/api-metrics@^0.33.0":
-  version "0.29.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz#daa823e0965754222b49a6ae6133df8b39ff8fd2"
-  integrity sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==
+"@opentelemetry/api-metrics@^0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz#753d355289b7811ad254d6e5b0193bd1b9f23ab0"
+  integrity sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 


### PR DESCRIPTION
## Description
We released a new Faro version because of a critical CVE where we first thought the web-tracing package is affected.
But I discovered that only the demo is affected. Web-Tracing doesn't have a dependency to exporter-trace-otlp-grpc.

This PR removes the dependency from the web-tracing package and adds it to the demo package 

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
