### PR TITLE
236 prefix event names which are specific to faro to prevent naming collisions

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### FetchInstrumentation
 
-- [❗️Breaking❗️]: Events have been namespaced and renamed to prevent collisions with user defined events events.
+- [❗️Breaking❗️]: Events have been namespaced and renamed to prevent collisions with user defined events events. See [Readme](https://github.com/grafana/faro-web-sdk/blob/e998555bd7177b7edbebf98f804372b04b6c30e6/experimental/instrumentation-fetch/README.md#L8) for more information.
 
 ### PerformanceTimelineInstrumentation
+
+- [❗️Breaking❗️]: The performance has been namespaced and renamed to prevent collisions with user defined events events. See Readme for more information.
 
 ## 1.1.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+### FetchInstrumentation
+
+- [❗️Breaking❗️]: Events have been namespaced and renamed to prevent collisions with user defined events events.
+
+### PerformanceTimelineInstrumentation
+
 ## 1.1.0
 
 - Add: Experimental package for Fetch instrumentation.

--- a/experimental/instrumentation-fetch/README.md
+++ b/experimental/instrumentation-fetch/README.md
@@ -1,11 +1,20 @@
 # @grafana/instrumentation-fetch
 
-Faro instrumentation of the JavaScript [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API
+Faro instrumentation of the JavaScript [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API.
 
 ❗️*Warning*: this package is experimental and may be subject to frequent and breaking changes.
 Use at your own risk.❗️
 
 ## Installation and Usage
+
+Add the instrumentation as outlined below.
+The instrumentation send the following events alongside respective request/response data like HTTP
+headers and other response properties like status codes the requests url and more.
+
+Event names are:
+
+- `faro.fetch.resolved` for resolved requests.
+- `faro.fetch.rejected` for rejected requests.
 
 ```ts
 // index.ts

--- a/experimental/instrumentation-fetch/src/constants.ts
+++ b/experimental/instrumentation-fetch/src/constants.ts
@@ -9,8 +9,8 @@ interface StringResponse {
 }
 
 export const fetchGlobalObjectKey = 'fetch';
-export const resolvedFetchEventName = 'Resolved fetch';
-export const rejectedFetchEventName = 'Rejected fetch';
+export const resolvedFetchEventName = 'faro.fetch.resolved';
+export const rejectedFetchEventName = 'faro.fetch.rejected';
 
 export const responseProperties = (response: Partial<Response>): StringResponse => {
   return {

--- a/experimental/instrumentation-performance-timeline/README.md
+++ b/experimental/instrumentation-performance-timeline/README.md
@@ -29,6 +29,8 @@ initializeFaro({
 The FaroPerformanceTimeline instrumentation is able to track all entry types as defined by
 [PerformanceEntry: entryType property](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType).
 
+For each Performance Entry it sends an event named `faro.performanceEntry`
+
 By default we track entries of type
 [navigation](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming)
 and [resource](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.test.ts
@@ -303,13 +303,13 @@ describe('PerformanceTimelineInstrumentation', () => {
 
     expect(mockPushEvent).toHaveBeenNthCalledWith(
       1,
-      'performanceEntry',
+      'faro.performanceEntry',
       matchNavigationAndResourceEntriesTestResults[0]
     );
 
     expect(mockPushEvent).toHaveBeenNthCalledWith(
       2,
-      'performanceEntry',
+      'faro.performanceEntry',
       matchNavigationAndResourceEntriesTestResults[2]
     );
   });
@@ -408,6 +408,6 @@ describe('PerformanceTimelineInstrumentation', () => {
     );
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenCalledWith('performanceEntry', { serverTiming: '[]' });
+    expect(mockPushEvent).toHaveBeenCalledWith('faro.performanceEntry', { serverTiming: '[]' });
   });
 });

--- a/experimental/instrumentation-performance-timeline/src/instrumentation.ts
+++ b/experimental/instrumentation-performance-timeline/src/instrumentation.ts
@@ -113,7 +113,7 @@ export class PerformanceTimelineInstrumentation extends BaseInstrumentation {
         pEntry = modifiedEntry;
       }
 
-      this.api.pushEvent('performanceEntry', this.objectValuesToString(pEntry));
+      this.api.pushEvent('faro.performanceEntry', this.objectValuesToString(pEntry));
     }
 
     // Dropped entries count is only available in chrome (03/03/2024)


### PR DESCRIPTION
## Description
To prevent naming collisions with user defined RUM events to the best extend possible, let's namespace internal Faro events. 
For example `performanceEntry` will become `faro.performanceEntry`.

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
