### PR TITLE
252 oltphttptransport resulting in 400 response status

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -6,9 +6,6 @@ import { getEnvConfig, getPublicEnvConfig } from './src/common';
 export default defineConfig(({ mode }) => {
   return {
     plugins: [react()],
-    resolve: {
-      preserveSymlinks: true, // TODO - remove once fetch instrumentation is published to NPM
-    },
     server: {
       watch: {
         awaitWriteFinish: true,

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### FaroOtlpHttpTransport
+
+1 [fix]: The outer shape of the payload was not correct which lead to 400 response status codes ([#252](https://github.com/grafana/faro-web-sdk/issues/252)).
+
 ## 1.1.3
 
 ### FetchInstrumentation

--- a/experimental/transport-otlp-http/src/payload/OtelPayload.ts
+++ b/experimental/transport-otlp-http/src/payload/OtelPayload.ts
@@ -1,13 +1,12 @@
 import { InternalLogger, TraceEvent, TransportItem, TransportItemType } from '@grafana/faro-core';
 
 import { getLogTransforms, getTraceTransforms, LogsTransform, TraceTransform } from './transform';
-import type { ResourceLogs } from './transform';
-import type { ResourceSpans } from './transform/types';
+import type { ResourceLogs, ResourceSpans } from './transform/types';
 import type { OtelTransportPayload } from './types';
 
 export class OtelPayload {
-  private resourceLogs: ResourceLogs[];
-  private resourceSpans = [] as ResourceSpans[];
+  private resourceLogs: ResourceLogs;
+  private resourceSpans = [] as ResourceSpans;
 
   private getLogTransforms: LogsTransform;
   private getTraceTransforms: TraceTransform;

--- a/experimental/transport-otlp-http/src/payload/index.ts
+++ b/experimental/transport-otlp-http/src/payload/index.ts
@@ -1,3 +1,11 @@
-export type { OtelTransportPayload } from './types';
-export type { LogRecord, LogTransportItem, Resource, ResourceLogs, Scope, ScopeLog } from './transform/index';
 export { OtelPayload } from './OtelPayload';
+export type {
+  LogRecord,
+  LogTransportItem,
+  Resource,
+  ResourceLog,
+  ResourceLogs,
+  Scope,
+  ScopeLog,
+} from './transform/index';
+export type { Logs, OtelTransportPayload, Traces } from './types';

--- a/experimental/transport-otlp-http/src/payload/transform/index.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/index.ts
@@ -1,10 +1,12 @@
 export { getLogTransforms, getTraceTransforms } from './transform';
 export type {
   LogRecord,
-  LogsTransform,
   LogTransportItem,
-  Resource,
   ResourceLogs,
+  LogsTransform,
+  Resource,
+  ResourceLog,
+  ResourceSpan,
   ResourceSpans,
   Scope,
   ScopeLog,

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -24,9 +24,9 @@ import type {
   LogsTransform,
   LogTransportItem,
   Resource,
-  ResourceLogs,
+  ResourceLog,
   ResourceMeta,
-  ResourceSpans,
+  ResourceSpan,
   ScopeLog,
   TraceTransform,
 } from './types';
@@ -46,7 +46,7 @@ const SemanticBrowserAttributes = {
 } as const;
 
 export function getLogTransforms(internalLogger: InternalLogger): LogsTransform {
-  function toResourceLog(transportItem: LogTransportItem): ResourceLogs {
+  function toResourceLog(transportItem: LogTransportItem): ResourceLog {
     const resource = toResource(transportItem);
 
     return {
@@ -186,7 +186,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
 }
 
 export function getTraceTransforms(_internalLogger?: InternalLogger): TraceTransform {
-  function toResourceSpan(transportItem: TransportItem<TraceEvent>): ResourceSpans {
+  function toResourceSpan(transportItem: TransportItem<TraceEvent>): ResourceSpan {
     const resource = toResource(transportItem);
     const scopeSpans = transportItem.payload.resourceSpans?.[0]?.scopeSpans;
 

--- a/experimental/transport-otlp-http/src/payload/transform/types.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/types.ts
@@ -31,26 +31,30 @@ export interface ScopeSpan {
   logRecords: LogRecord[];
 }
 
-export interface ResourceLogs {
+export interface ResourceLog {
   resource: Resource;
   scopeLogs: ScopeLog[];
 }
 
-export interface ResourceSpans extends Omit<IResourceSpans, 'resource'> {
+export type ResourceLogs = ResourceLog[];
+
+export interface ResourceSpan extends Omit<IResourceSpans, 'resource'> {
   resource: Resource;
 }
+
+export type ResourceSpans = ResourceSpan[];
 
 export type LogTransportItem = TransportItem<Exclude<APIEvent, 'TraceEvent'>>;
 export type TraceTransportItem = TransportItem<TraceEvent>;
 
 export type LogsTransform = {
-  toResourceLog: (transportItem: LogTransportItem) => ResourceLogs;
+  toResourceLog: (transportItem: LogTransportItem) => ResourceLog;
   toScopeLog: (transportItem: LogTransportItem) => ScopeLog;
   toLogRecord: (transportItem: LogTransportItem) => LogRecord;
 };
 
 export type TraceTransform = {
-  toResourceSpan: (transportItem: TransportItem<TraceEvent>) => ResourceSpans;
+  toResourceSpan: (transportItem: TransportItem<TraceEvent>) => ResourceSpan;
 };
 
 export type ResourceMeta = Pick<Meta, 'app' | 'browser' | 'sdk'>;

--- a/experimental/transport-otlp-http/src/payload/types.ts
+++ b/experimental/transport-otlp-http/src/payload/types.ts
@@ -1,6 +1,9 @@
-import type { ResourceLogs } from './transform';
+import type { ResourceLogs, ResourceSpans } from './transform';
 
 export interface OtelTransportPayload {
-  readonly resourceLogs: Readonly<ResourceLogs[]>;
-  readonly resourceSpans: Readonly<unknown[]>;
+  readonly resourceLogs: Readonly<ResourceLogs>;
+  readonly resourceSpans: Readonly<ResourceSpans>;
 }
+
+export type Logs = Pick<OtelTransportPayload, 'resourceLogs'>;
+export type Traces = Pick<OtelTransportPayload, 'resourceSpans'>;

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -1,7 +1,7 @@
 import { LogEvent, LogLevel, TraceEvent, TransportItem, TransportItemType, VERSION } from '@grafana/faro-core';
 import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
 
-import type { LogRecord, OtelTransportPayload } from './payload';
+import type { LogRecord, Logs } from './payload';
 import { OtlpHttpTransport } from './transport';
 
 const logTransportItem: TransportItem<LogEvent> = {
@@ -15,39 +15,41 @@ const logTransportItem: TransportItem<LogEvent> = {
   meta: {},
 } as const;
 
-const otelTransportPayload: OtelTransportPayload['resourceLogs'] = [
-  {
-    resource: {
-      attributes: [],
-    },
-    scopeLogs: [
-      {
-        scope: {
-          name: '@grafana/faro-web-sdk',
-          version: VERSION,
-        },
-        logRecords: [
-          {
-            timeUnixNano: 1674813181035000000,
-            severityNumber: 10,
-            severityText: 'INFO2',
-            body: {
-              stringValue: 'hi',
-            },
-            attributes: [
-              {
-                key: 'faro.log.context',
-                value: {
-                  kvlistValue: { values: [] },
-                },
-              },
-            ],
-          } as LogRecord,
-        ],
+const otelTransportPayload: Logs = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [],
       },
-    ],
-  },
-];
+      scopeLogs: [
+        {
+          scope: {
+            name: '@grafana/faro-web-sdk',
+            version: VERSION,
+          },
+          logRecords: [
+            {
+              timeUnixNano: 1674813181035000000,
+              severityNumber: 10,
+              severityText: 'INFO2',
+              body: {
+                stringValue: 'hi',
+              },
+              attributes: [
+                {
+                  key: 'faro.log.context',
+                  value: {
+                    kvlistValue: { values: [] },
+                  },
+                },
+              ],
+            } as LogRecord,
+          ],
+        },
+      ],
+    },
+  ],
+};
 
 const traceTransportItem: TransportItem<TraceEvent> = {
   type: TransportItemType.TRACE,
@@ -76,7 +78,7 @@ describe('OtlpHttpTransport', () => {
       v: traceTransportItem,
       type: 'resourceSpans',
       url: 'https://www.example.com/v1/traces',
-      payload: [{ resource: { attributes: [] }, scopeSpans: [] }],
+      payload: { resourceSpans: [{ resource: { attributes: [] }, scopeSpans: [] }] },
     },
   ])('Sends $type over fetch to its configured endpoint.', ({ v, url, payload }) => {
     const transport = new OtlpHttpTransport({
@@ -242,55 +244,57 @@ describe('OtlpHttpTransport', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
 
     expect(fetch).toHaveBeenCalledWith('https://www.example.com/v1/logs', {
-      body: JSON.stringify([
-        {
-          resource: {
-            attributes: [],
-          },
-          scopeLogs: [
-            {
-              scope: {
-                name: '@grafana/faro-web-sdk',
-                version: VERSION,
-              },
-              logRecords: [
-                {
-                  timeUnixNano: 1674813181035000000,
-                  severityNumber: 10,
-                  severityText: 'INFO2',
-                  body: {
-                    stringValue: 'hi',
-                  },
-                  attributes: [
-                    {
-                      key: 'faro.log.context',
-                      value: {
-                        kvlistValue: { values: [] },
-                      },
-                    },
-                  ],
-                } as LogRecord,
-                {
-                  timeUnixNano: 1674813181035000000,
-                  severityNumber: 10,
-                  severityText: 'INFO2',
-                  body: {
-                    stringValue: 'foo',
-                  },
-                  attributes: [
-                    {
-                      key: 'faro.log.context',
-                      value: {
-                        kvlistValue: { values: [] },
-                      },
-                    },
-                  ],
-                } as LogRecord,
-              ],
+      body: JSON.stringify({
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [],
             },
-          ],
-        },
-      ]),
+            scopeLogs: [
+              {
+                scope: {
+                  name: '@grafana/faro-web-sdk',
+                  version: VERSION,
+                },
+                logRecords: [
+                  {
+                    timeUnixNano: 1674813181035000000,
+                    severityNumber: 10,
+                    severityText: 'INFO2',
+                    body: {
+                      stringValue: 'hi',
+                    },
+                    attributes: [
+                      {
+                        key: 'faro.log.context',
+                        value: {
+                          kvlistValue: { values: [] },
+                        },
+                      },
+                    ],
+                  } as LogRecord,
+                  {
+                    timeUnixNano: 1674813181035000000,
+                    severityNumber: 10,
+                    severityText: 'INFO2',
+                    body: {
+                      stringValue: 'foo',
+                    },
+                    attributes: [
+                      {
+                        key: 'faro.log.context',
+                        value: {
+                          kvlistValue: { values: [] },
+                        },
+                      },
+                    ],
+                  } as LogRecord,
+                ],
+              },
+            ],
+          },
+        ],
+      }),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -78,7 +78,7 @@ export class OtlpHttpTransport extends BaseTransport {
           return undefined;
         }
 
-        const body = JSON.stringify(value);
+        const body = JSON.stringify({ [key]: value });
 
         const { requestOptions, apiKey } = this.options;
         const { headers, ...restOfRequestOptions } = requestOptions ?? {};


### PR DESCRIPTION
## Why
The `faro-transport-otlp-http` used the wrong OTLP structure when sending the respective signals
The problem happened in the `OtlpHttpTransport.class` when iterating over the `OtelTransportPayload` object.

The `OtelTransportPayload` object has the following structure:
```ts
export interface OtelTransportPayload {
  readonly resourceLogs: Readonly<ResourceLogs>;
  readonly resourceSpans: Readonly<ResourceSpans>;
}
```

In the `sendPayload` method in `OtlpHttpTransport` we iterate over the object and do some signal specific configuration before sending the signal.

The respective loop looks like this:
```ts
   for (const [key, value] of Object.entries(payload)) { ... }
```

When stringifying the signal payload to attach it to the requests body we did:
```ts  
const body = JSON.stringify(value); // this removed the outer part 
```
Which removed the outer part so we only sent an array instead of an object.

The solution is to (re)-build the correct otel payload like:
```ts
const body = JSON.stringify({ [key]: value }); // ---> const body = JSON.stringify({ resourceLogs: ResourceLogs })
```

## What
* (Re-) Build the correct otel payload before sending it (`const body = JSON.stringify({ [key]: value });`)
* Add new types for `ResourceLogs` and `ResourceSpans` for better readability
* Remove the left over `resolve` object from `vite.config` in demo 

## Links
### Relevant OTLP Specs
* [logs.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/81a296f9dba23e32d77f46d58c8ea4244a2157a6/opentelemetry/proto/logs/v1/logs.proto#L44)
* [logs.example](https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/logs.json)
* [trace.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/81a296f9dba23e32d77f46d58c8ea4244a2157a6/opentelemetry/proto/trace/v1/trace.proto#L44)
* [trace.example](https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/trace.json)

## Screenshots
### Now
<img width="235" alt="Screenshot 2023-08-21 at 15 11 04" src="https://github.com/grafana/faro-web-sdk/assets/47627413/e8060f4c-1710-4e0c-a2f1-00ad424bccd4">
<img width="237" alt="Screenshot 2023-08-21 at 15 10 24" src="https://github.com/grafana/faro-web-sdk/assets/47627413/a39f106e-fadf-4f9d-a041-dfaca567426b">


### Before
<img width="245" alt="Screenshot 2023-08-21 at 15 09 16" src="https://github.com/grafana/faro-web-sdk/assets/47627413/18605290-a218-431e-85c9-164a95e8475f">
<img width="249" alt="Screenshot 2023-08-21 at 15 09 03" src="https://github.com/grafana/faro-web-sdk/assets/47627413/0487862b-d779-477c-a1d4-d2703bc891e9">


## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
