### PR TITLE
254 make it possible to provide extra attributes to the measurements meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Next
 
+- Feat: Provide option in measurement API to add contextual attributes ([#254](https://github.com/grafana/faro-web-sdk/issues/254))
+
 ## 1.1.4
 
-- [FIX]: CVE-2022-25878 - protobufjs Prototype Pollution vulnerability (#249)
+- Fix: CVE-2022-25878 - protobufjs Prototype Pollution vulnerability (#249)
 
 ## 1.1.3
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### FaroOtlpHttpTransport
 
-1 [fix]: The outer shape of the payload was not correct which lead to 400 response status codes ([#252](https://github.com/grafana/faro-web-sdk/issues/252)).
+- Fix: The outer shape of the payload was not correct which lead to 400 response status codes ([#252](https://github.com/grafana/faro-web-sdk/issues/252)).
 
 ## 1.1.3
 

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -151,6 +151,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
         toAttribute('measurement.type', payload.type),
         toAttribute('measurement.name', measurementName),
         toAttribute('measurement.value', measurementValue),
+        toAttribute('faro.measurement.context', payload.context),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,
       spanId: payload.trace?.span_id,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -177,6 +177,16 @@ The `api` property on the Faro instance contains all the necessary methods to pu
     },
     { skipDedupe: true }
   );
+
+  faro.api.pushMeasurement(
+    {
+      type: 'custom',
+      values: {
+        my_custom_metric: Math.random(),
+      },
+    },
+    { context: { hello: 'world' } }
+  );
   ```
 
 ## Traces

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -22,7 +22,7 @@ export function initializeExceptionsAPI(
 ): ExceptionsAPI {
   internalLogger.debug('Initializing exceptions API');
 
-  let lastPayload: Pick<ExceptionEvent, 'type' | 'value' | 'stacktrace'> | null = null;
+  let lastPayload: Pick<ExceptionEvent, 'type' | 'value' | 'stacktrace' | 'context'> | null = null;
 
   stacktraceParser = config.parseStacktrace ?? stacktraceParser;
 

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -39,6 +39,38 @@ describe('api.measurements', () => {
         expect(transport.items).toHaveLength(1);
       });
 
+      it('filters the same measurement with the same context', () => {
+        const measurement = {
+          type: 'custom',
+          values: {
+            a: 1,
+          },
+        };
+
+        const context = { foo: 'bar' };
+
+        api.pushMeasurement(measurement, { context });
+        expect(transport.items).toHaveLength(1);
+
+        api.pushMeasurement(measurement, { context });
+        expect(transport.items).toHaveLength(1);
+      });
+
+      it("doesn't filter events with different context", () => {
+        const measurement = {
+          type: 'custom',
+          values: {
+            a: 1,
+          },
+        };
+
+        api.pushMeasurement(measurement, { context: { foo: 'bar' } });
+        expect(transport.items).toHaveLength(1);
+
+        api.pushMeasurement(measurement, { context: { bar: 'baz' } });
+        expect(transport.items).toHaveLength(2);
+      });
+
       it("doesn't filter measurements with same type and partially same values", () => {
         const measurement1 = {
           type: 'custom',

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -19,9 +19,9 @@ export function initializeMeasurementsAPI(
 ): MeasurementsAPI {
   internalLogger.debug('Initializing measurements API');
 
-  let lastPayload: Pick<MeasurementEvent, 'type' | 'values'> | null = null;
+  let lastPayload: Pick<MeasurementEvent, 'type' | 'values' | 'context'> | null = null;
 
-  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload, { skipDedupe } = {}) => {
+  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload, { skipDedupe, context } = {}) => {
     try {
       const item: TransportItem<MeasurementEvent> = {
         type: TransportItemType.MEASUREMENT,
@@ -29,6 +29,7 @@ export function initializeMeasurementsAPI(
           ...payload,
           trace: tracesApi.getTraceContext(),
           timestamp: payload.timestamp ?? getCurrentTimestamp(),
+          context: context ?? {},
         },
         meta: metas.value,
       };
@@ -36,6 +37,7 @@ export function initializeMeasurementsAPI(
       const testingPayload = {
         type: item.payload.type,
         values: item.payload.values,
+        context: item.payload.context,
       };
 
       if (!skipDedupe && config.dedupe && !isNull(lastPayload) && deepEqual(testingPayload, lastPayload)) {

--- a/packages/core/src/api/measurements/types.ts
+++ b/packages/core/src/api/measurements/types.ts
@@ -1,20 +1,23 @@
 import type { TraceContext } from '../traces';
 
+export type MeasurementContext = Record<string, string>;
+
 export interface MeasurementEvent<V extends { [label: string]: number } = { [label: string]: number }> {
   type: string;
   values: V;
 
   timestamp: string;
   trace?: TraceContext;
+  context?: MeasurementContext;
 }
 
 export interface PushMeasurementOptions {
   skipDedupe?: boolean;
+  context?: MeasurementContext;
 }
 
 export interface MeasurementsAPI {
   pushMeasurement: (
-    // TODO: change this back once we have aligned the measurement event types: See: https://github.com/grafana/faro-web-sdk/issues/110
     payload: Omit<MeasurementEvent, 'timestamp'> & Partial<Pick<MeasurementEvent, 'timestamp'>>,
     options?: PushMeasurementOptions
   ) => void;


### PR DESCRIPTION
## Why
The measurement API lags support of adding contextual attributes.

Note:
This requires changes or udates to the following components as well:
* Grafana Agent
* Faro Receiver
* Docs (Website)

❗️Important❗️
Do not merge/release this PR until the Agent and Receivers changes have been merged and released.
 

## What
Introduce an optional `context` object to pass with the `PushMeasurementOptions` object. Similar to the Logs and Errors APIs. 

## Links
* [PR Receiver (merged)](https://github.com/grafana/app-o11y-kwl-endpoint/pull/262) 
* [PR Agent](https://github.com/grafana/agent/pull/4975)
* [PR Docs](https://github.com/grafana/website/pull/15059)


## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
