### PR TITLE
Add `errorOptions` prop to `FaroErrorBoundary` to allow per-boundary configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Feat: Enable users to configure per-error boundary `pushError` behavior.
 
 ## 1.2.0
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,7 @@ _Warning_: currently pre-release and subject to frequent breaking changes. Use a
 
 Out of the box, the package provides you the following features:
 
-- Error Boundary - Provides additional stacktrace for errors
+- Error Boundary - Provides additional stacktrace for errors and configuration options for pushError behavior
 - Component Profiler - Capture every re-render of a component, the un/mounting time etc.
 - Router (v4-v6) integration - Send events for all route changes
 - SSR support
@@ -73,6 +73,27 @@ or
 import { withErrorBoundary } from '@grafana/faro-react';
 
 export default withErrorBoundary(App);
+```
+
+#### pushErrorOptions prop
+
+```tsx
+
+import { FaroErrorBoundary, PushErrorOptions } from '@grafana/faro-react';
+
+const pushErrorOptions: PushErrorOptions = {
+  type: "Custom Error Type"
+  context: {
+    foo: "bar",
+    baz: "qux"
+  },
+  // ...
+}
+
+// during render
+<FaroErrorBoundary pushErrorOptions={pushErrorOptions}>
+  <App />
+</FaroErrorBoundary>;
 ```
 
 ### Router

--- a/packages/react/src/errorBoundary/FaroErrorBoundary.tsx
+++ b/packages/react/src/errorBoundary/FaroErrorBoundary.tsx
@@ -43,7 +43,7 @@ export class FaroErrorBoundary extends Component<FaroErrorBoundaryProps, FaroErr
 
     this.props.beforeCapture?.(errorWithComponentStack);
 
-    api.pushError(errorWithComponentStack);
+    api.pushError(errorWithComponentStack, this.props.errorOptions);
 
     this.props.onError?.(errorWithComponentStack);
 

--- a/packages/react/src/errorBoundary/FaroErrorBoundary.tsx
+++ b/packages/react/src/errorBoundary/FaroErrorBoundary.tsx
@@ -43,7 +43,7 @@ export class FaroErrorBoundary extends Component<FaroErrorBoundaryProps, FaroErr
 
     this.props.beforeCapture?.(errorWithComponentStack);
 
-    api.pushError(errorWithComponentStack, this.props.errorOptions);
+    api.pushError(errorWithComponentStack, this.props.pushErrorOptions);
 
     this.props.onError?.(errorWithComponentStack);
 

--- a/packages/react/src/errorBoundary/types.ts
+++ b/packages/react/src/errorBoundary/types.ts
@@ -15,7 +15,7 @@ export interface FaroErrorBoundaryProps {
   onMount?: VoidFunction;
   onReset?: (error: Error | null) => void;
   onUnmount?: (error: Error | null) => void;
-  errorOptions?: PushErrorOptions;
+  pushErrorOptions?: PushErrorOptions;
 }
 
 export interface FaroErrorBoundaryState {

--- a/packages/react/src/errorBoundary/types.ts
+++ b/packages/react/src/errorBoundary/types.ts
@@ -1,4 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
+import type { PushErrorOptions } from '@grafana/faro-web-sdk';
 
 export type ReactNodeRender = () => ReactNode;
 
@@ -14,6 +15,7 @@ export interface FaroErrorBoundaryProps {
   onMount?: VoidFunction;
   onReset?: (error: Error | null) => void;
   onUnmount?: (error: Error | null) => void;
+  errorOptions?: PushErrorOptions;
 }
 
 export interface FaroErrorBoundaryState {


### PR DESCRIPTION
## Why

This enhancement allows for per-boundary configuration of `pushError` behavior. This enables greater customization of error reporting behaviors on a per-error boundary basis, simplifying the process of setting up different error reporting behaviors for different parts of the application.

## What

An optional `errorOptions` prop is added to the `FaroErrorBoundary` and the corresponding `FaroErrorBoundaryProps` interface in order to allow custom `options` objects to be passed to the `faro.api.pushError` calls made by that error boundary's `componentDidCatch`. 

## Links

https://github.com/hubmapconsortium/portal-ui/pull/3266#discussion_r1329245791

## Checklist

There did not appear to be tests for the react integration, but I added documentation for the new prop to the readme and queued up the item into the next release in the changelog.

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
