### PR TITLE
fix: add correct binary name for grafana agent

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - '${AGENT_CONFIG_PATH_LOCAL}:${AGENT_CONFIG_PATH}'
       - 'demo_demo_logs:${AGENT_LOGS_PATH}'
     entrypoint:
-      - '/bin/agent'
+      - '/bin/grafana-agent'
       - '-config.file=${AGENT_CONFIG_PATH}/${AGENT_CONFIG_FILE}'
       - '-config.expand-env'
       - '-config.enable-read-api'


### PR DESCRIPTION
## Why

In a former PR the binary name of the Grafana Agent got changed back to the old version.
With [Grafana Agent version 31](https://grafana.com/docs/agent/v0.31/upgrade-guide/#v0310) the agent binary was renamed from `agent` to `grafana-agent`

## What
Add the correct binary name to docker-compose file

## Links


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
