### PR TITLE
chore: update node version to current release (>= 18)

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -13,33 +13,33 @@ trigger:
 
 steps:
   - name: install-dependencies
-    image: node:lts-stretch
+    image: node:lts-bookworm
     commands:
       - yarn install --frozen-lockfile
 
   - name: build
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - install-dependencies
     commands:
       - yarn build
 
   - name: lint
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
       - yarn quality:lint
 
   - name: circular-dependencies-test
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
       - yarn quality:circular-deps
 
   - name: unit-tests
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
@@ -77,33 +77,33 @@ trigger:
 
 steps:
   - name: install-dependencies
-    image: node:lts-stretch
+    image: node:lts-bookworm
     commands:
       - yarn install --frozen-lockfile
 
   - name: build
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - install-dependencies
     commands:
       - yarn build
 
   - name: lint
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
       - yarn quality:lint
 
   - name: circular-dependencies-test
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
       - yarn quality:circular-deps
 
   - name: unit-tests
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - build
     commands:
@@ -119,7 +119,7 @@ steps:
       IS_TEST: 1
 
   - name: publish
-    image: node:lts-stretch
+    image: node:lts-bookworm
     depends_on:
       - lint
       - circular-dependencies-test


### PR DESCRIPTION
## Why

Drone.yaml used node version `lts-stretch` which pointed to the old node lts which is not supported anymore
 
## What
- In drone.yaml change node version from `node:lts-stretch` to `node:lts-bookworm`


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
