### PR TITLE
fix: move node version in Dockerfile to current lts (v18)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v18
+lts/hydrogen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 ARG DEMO_DEMO_PATH
 ARG DEMO_PACKAGES_CORE_PATH


### PR DESCRIPTION
## Why
We recently updated the Node version to the current LTS release (lts/hydrogen, v18) but did not update the node version used in the Dockerfile which still used Node 16.

Strangely the built didn't fail when testing it.

## What
* Update Dockerfile to use Node 18 (node:18-alpine)
* Be more explicit about node lts version in nvmrc.

## Links
[Issue](https://github.com/grafana/faro-web-sdk/issues/350)

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
