### PR TITLE
fix(web-sdk): disable keepalive when large payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000
+- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
 
 ## 1.2.0 – 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000
+
 ## 1.2.0 – 1.2.2
 
 - Feat: Detect if Faro is running inside K6 browser to distinguish between lab and field data (#263).
@@ -10,7 +12,6 @@
 - Deps: Dependency updates
 - Deps: CVE-2023-45133 - Babel vulnerable to arbitrary code execution when compiling specifically
   crafted malicious code
-- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Deps: Dependency updates
 - Deps: CVE-2023-45133 - Babel vulnerable to arbitrary code execution when compiling specifically
   crafted malicious code
+- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000
 
 ## 1.2.0
 

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -55,7 +55,7 @@ export class FetchTransport extends BaseTransport {
               : {}),
           },
           body,
-          keepalive: true,
+          keepalive: body.length <= 60_000,
           ...(restOfRequestOptions ?? {}),
         })
           .then((response) => {


### PR DESCRIPTION
## Why

Fetch limits payloads to 64 kibibytes when using the keepalive option by throwing a network error.

## What

Turn off keepalive when payload length is over 60_000. This allows the request to succeed with the caveat that it can still be canceled by the browser during page unload. This is a balanced compromise until a better solution is found.

## Links

Fixes #192

Standard
https://fetch.spec.whatwg.org/#http-network-or-cache-fetch

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
