### PR TITLE
chore: prepare release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.2.1
+
 - Feat: Detect if Faro is running inside K6 browser to distinguish between lab and field data (#263).
 - Feat: Enable users to configure per-error boundary `pushError` behavior.
 - Deps: Upgrade project to use the current Node LTS version (lts/hydrogen, v18)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.2.0 – 1.2.1
+
 ### FetchInstrumentation
 
 - Change: fetch instrumentation log attribute "statusText" is now "status_text"

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -79,6 +79,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     eventDomain: browserConfig.eventDomain ?? defaultEventDomain,
     ignoreErrors: browserConfig.ignoreErrors,
 
+    // The new session management feature is a PoC and still under development and IS NOT READY for any production use!
     experimentalSessions: {
       // TODO: will be true on release
       enabled: false,


### PR DESCRIPTION
## Why

prepare release 1.2.1

## What
* Update CHANGELOGs
* Add note that new session management is in PoC state and not meant for production use

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
