### PR TITLE
adding isK6Browser to k6 meta payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Next
 
-- Fix: disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
+- Fix: Disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
+- Fix: Add 'isK6Browser' field to k6 meta object (#361)
 
-## 1.2.0 – 1.2.2
+## 1.2.0 - 1.2.2
 
 - Feat: Detect if Faro is running inside K6 browser to distinguish between lab and field data (#263).
 - Feat: Enable users to configure per-error boundary `pushError` behavior.

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -17,7 +17,7 @@ describe('defaultMetas', () => {
     expect(config).toBeTruthy();
     expect(config?.metas).toHaveLength(3);
     expect(config?.metas.map((item) => (isFunction(item) ? item() : item))).toContainEqual({
-      k6: {},
+      k6: { isK6Browser: true },
     });
 
     delete (global as any).k6;
@@ -26,7 +26,7 @@ describe('defaultMetas', () => {
   it('does not include K6Meta in defaultMetas for non-k6 (field) sessions', () => {
     expect(defaultMetas).toHaveLength(2);
     expect(defaultMetas.map((item) => (isFunction(item) ? item() : item))).not.toContainEqual({
-      k6: {},
+      k6: { isK6Browser: true },
     });
   });
 });

--- a/packages/web-sdk/src/metas/k6/meta.ts
+++ b/packages/web-sdk/src/metas/k6/meta.ts
@@ -2,6 +2,8 @@ import type { Meta, MetaItem } from '@grafana/faro-core';
 
 export const k6Meta: MetaItem<Pick<Meta, 'k6'>> = () => {
   return {
-    k6: {},
+    k6: {
+      isK6Browser: true,
+    },
   };
 };


### PR DESCRIPTION
needed in order for the collector to properly unmarshal the k6 meta object 