### PR TITLE
change: remove sdk meta from default metas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 - Fix: Disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
 - Fix: Add 'isK6Browser' field to k6 meta object (#361)
-- Change: The sdk meta has been removed from default metas to reduce beacon payload size. [If users
-  need that meta, it can still be added as outlined in the docs.](https://github.com/grafana/faro-web-sdk/blob/adda57314381c7d945d8647eee2841d173571281/docs/sources/developer/architecture/components/metas.md#L52)
-  ()
+- Breaking❗️: The sdk meta now only contains the version number of Faro. This is to reduce beacon payload size.
+  [If users need the full data including all integrations, it can be added as outlined in the docs.](https://github.com/grafana/faro-web-sdk/blob/adda57314381c7d945d8647eee2841d173571281/docs/sources/developer/architecture/components/metas.md#L52)(#370)
 
 ## 1.2.0 - 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix: Disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
 - Fix: Add 'isK6Browser' field to k6 meta object (#361)
+- Change: The sdk meta has been removed from default metas to reduce beacon payload size. [If users
+  need that meta, it can still be added as outlined in the docs.](https://github.com/grafana/faro-web-sdk/blob/adda57314381c7d945d8647eee2841d173571281/docs/sources/developer/architecture/components/metas.md#L52)
+  ()
 
 ## 1.2.0 - 1.2.2
 

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -12,7 +12,7 @@ Metas can be either:
 ### App
 
 The `app` meta ties signals with a specific app and it should not be changed across a session. It is required during
-initialization and it is the responsability of the end-user to define it.
+initialization and it is the responsibility of the end-user to define it.
 
 Properties:
 
@@ -24,7 +24,7 @@ Properties:
 ### Browser
 
 The `browser` meta helps with identifying the environment where the app is running and it should not change across a
-session. Altough it is not handled automatically by the core package, nor is it the responsability of the end-user to
+session. Altough it is not handled automatically by the core package, nor is it the responsibility of the end-user to
 define it. Wrapper packages like `web-sdk` should handle it.
 
 Properties:
@@ -49,17 +49,20 @@ Properties:
 
 ### SDK
 
-The optional `sdk` meta defines the following properties about the Faro library itself:
+By default the sdk meta contain only the version install Faro script, no information about configured
+integrations. This works fine because in Faro we always update all package together so they are always
+on teh same version number.
+
+For debugging purposes you can get get information about Faro and installed integrations by adding
+the `metaSdk` object.
+
+The `metaSdk` meta defines the following properties about the Faro library itself:
 
 - `name` - the name of the core library
 - `version` - the version of the library
 - `integrations` - the list of instrumentations that are used, identified by by the name and the version
 
-The sdk meta is not attached to by default. This is because it is not related to RUM data and mostly
-useful for debugging purposes and we want to avoid an unnecessary increase of the beacon request size.
-
-If the meta is needed it can be added via Faro initialization by importing the `metaSdk` and adding
-it to the `metas` list.
+Example:
 
 ```ts
 import { sdkMeta } from '@grafana/faro-web-sdk';

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -49,13 +49,30 @@ Properties:
 
 ### SDK
 
-The `sdk` meta defines the following properties about the Faro library itself:
+The optional `sdk` meta defines the following properties about the Faro library itself:
 
 - `name` - the name of the core library
 - `version` - the version of the library
 - `integrations` - the list of instrumentations that are used, identified by by the name and the version
 
-The `sdk` meta is handled internally by the core package and the end-user should not change it.
+The sdk meta is not attached to by default. This is because it is not related to RUM data and mostly
+useful for debugging purposes and we want to avoid an unnecessary increase of the beacon request size.
+
+If the meta is needed it can be added via Faro initialization by importing the `metaSdk` and adding
+it to the `metas` list.
+
+```ts
+import { sdkMeta } from '@grafana/faro-web-sdk';
+
+initializeFaro({
+    ...
+    metas: [sdkMeta],
+});
+
+```
+
+Note:
+The `sdk` meta creation is handled internally by the core package and the end-user should not change it.
 
 ### Session
 

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -1,16 +1,9 @@
 import type { Faro } from '../sdk';
-import { VERSION } from '../version';
 
 import type { Meta } from './types';
 
 export function registerInitialMetas(faro: Faro): void {
-  const initial: Meta = {
-    sdk: {
-      name: '@grafana/faro-core',
-      version: VERSION,
-      integrations: faro.config.instrumentations.map(({ name, version }) => ({ name, version })),
-    },
-  };
+  const initial: Meta = {};
 
   const session = faro.config.experimentalSessions?.session ?? faro.config.session;
   if (session) {

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -1,9 +1,14 @@
 import type { Faro } from '../sdk';
+import { VERSION } from '../version';
 
 import type { Meta } from './types';
 
 export function registerInitialMetas(faro: Faro): void {
-  const initial: Meta = {};
+  const initial: Meta = {
+    sdk: {
+      version: VERSION,
+    },
+  };
 
   const session = faro.config.experimentalSessions?.session ?? faro.config.session;
   if (session) {

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -18,7 +18,7 @@ export {
 } from './instrumentations';
 export type { ConsoleInstrumentationOptions, ErrorEvent, ExtendedPromiseRejectionEvent } from './instrumentations';
 
-export { browserMeta, createSession, defaultMetas, defaultViewMeta, pageMeta } from './metas';
+export { browserMeta, createSession, defaultMetas, defaultViewMeta, pageMeta, sdkMeta } from './metas';
 
 export { ConsoleTransport, FetchTransport } from './transports';
 export type {

--- a/packages/web-sdk/src/metas/index.ts
+++ b/packages/web-sdk/src/metas/index.ts
@@ -7,3 +7,5 @@ export { pageMeta } from './page';
 export { createSession } from './session';
 
 export { defaultViewMeta } from './view';
+
+export { sdkMeta } from './sdk';

--- a/packages/web-sdk/src/metas/sdk/index.ts
+++ b/packages/web-sdk/src/metas/sdk/index.ts
@@ -1,0 +1,1 @@
+export { sdkMeta } from './meta';

--- a/packages/web-sdk/src/metas/sdk/meta.ts
+++ b/packages/web-sdk/src/metas/sdk/meta.ts
@@ -1,0 +1,10 @@
+import { faro, VERSION } from '@grafana/faro-core';
+import type { Meta, MetaItem } from '@grafana/faro-core';
+
+export const sdkMeta: MetaItem<Pick<Meta, 'sdk'>> = () => ({
+  sdk: {
+    name: '@grafana/faro-core',
+    version: VERSION,
+    integrations: faro.config.instrumentations.map(({ name, version }) => ({ name, version })),
+  },
+});


### PR DESCRIPTION
## Why

The information conveyed by the SDK meta has no relevance for RUM. 
Since the meta is sent with each beacon requests —and contains long strings—it unnecessarily adds to each requests payload size.

We reduced the default content of the sdkMeta to only contain the version number of the library. 
This can be done in that way because we always update all Faro packages to the same version number.

## What
* Remove the sdk meta from the default metas.
* Provide sdkMeta as a separate export so users can add it via the init function.

**Example:**
```ts
import { sdkMeta } from '@grafana/faro-web-sdk';

initializeFaro({
  url: ...,
  ...
  metas: [sdkMeta],
});
```

## Links
[GH Issue](https://github.com/grafana/faro-web-sdk/issues/305)
[Related discussion](https://github.com/grafana/faro-web-sdk/discussions/271)

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
