### PR TITLE
fix: don't overwrite customer session attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Next
 
-- Fix: Disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353)
-- Fix: Add 'isK6Browser' field to k6 meta object (#361)
+- Fix: Disable keepalive in web-sdk fetch transport when the payload length is over 60_000 (#353).
+- Fix: Add 'isK6Browser' field to k6 meta object (#361).
 - Breaking: The sdk meta now only contains the version number of Faro. This is to reduce beacon payload size.
   [If users need the full data including all integrations, it can be added as outlined in the docs.](https://github.com/grafana/faro-web-sdk/blob/adda57314381c7d945d8647eee2841d173571281/docs/sources/developer/architecture/components/metas.md#L52)(#370)
 - Feature: new experimental session manager which can be configured to use persistent or volatile
-  sessions. ( #359)
+  sessions (#359).
+- Fix: user provided session attributes were not sent (#372).
 
 ## 1.2.0 - 1.2.2
 

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -10,7 +10,11 @@ export function registerInitialMetas(faro: Faro): void {
     },
   };
 
-  const session = faro.config.experimentalSessions?.session ?? faro.config.session;
+  let session = faro.config.session;
+  if (faro.config.experimentalSessions?.enabled) {
+    session = faro.config.experimentalSessions.session!;
+  }
+
   if (session) {
     faro.api.setSession(session);
   }

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -44,8 +44,8 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         // Works with the new session config?
-        session,
         experimentalSessions: {
+          session,
           enabled: true,
           persistent: false,
         },


### PR DESCRIPTION
## Why

Session attributes provided on initialize were not added to the meta.

## What
This happened due to the implementation of the (future) new session manager.
What happened was that the `createSessionMeta` called internally by the new session manager created a new session object. 

The meta initializer checked if this new object exists and if so, uses the new session meta instead of the current one provided by the user.


## Links

Session Attributes are not being sent #371

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
