### PR TITLE
feat: preview of new session manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Feat: preview of the new session tracking capabilities (#374).
+
 ## 1.2.4
 
 - Breaking: The sdk meta now only contains the version number of Faro. This is to reduce beacon payload size.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -25,7 +25,7 @@ export interface Config<P = APIEvent> {
   // TODO: Deprecate?
   session?: MetaSession;
   // TODO: rename to "sessions" once feature is ready. Do not use in any prod envs!
-  experimentalSessions?: {
+  sessionTracking?: {
     enabled?: boolean;
     persistent?: boolean;
     session?: MetaSession;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -22,9 +22,7 @@ export interface Config<P = APIEvent> {
 
   beforeSend?: BeforeSendHook<P>;
   ignoreErrors?: Patterns;
-  // TODO: Deprecate?
   session?: MetaSession;
-  // TODO: rename to "sessions" once feature is ready. Do not use in any prod envs!
   sessionTracking?: {
     enabled?: boolean;
     persistent?: boolean;

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -11,8 +11,8 @@ export function registerInitialMetas(faro: Faro): void {
   };
 
   let session = faro.config.session;
-  if (faro.config.experimentalSessions?.enabled) {
-    session = faro.config.experimentalSessions.session!;
+  if (faro.config.sessionTracking?.enabled) {
+    session = faro.config.sessionTracking.session!;
   }
 
   if (session) {

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -1,5 +1,6 @@
 import { isFunction } from '@grafana/faro-core';
 
+import type { MetaSession } from '..';
 import type { FaroUserSession } from '../instrumentations/session';
 import {
   MAX_SESSION_PERSISTENCE_TIME,
@@ -77,25 +78,77 @@ describe('userSessions config', () => {
     removeItemSpy.mockRestore();
   });
 
-  it('creates new session meta for non tracked sessions.', () => {
+  it('creates new session meta for legacy sessions.', () => {
     const mockSessionMeta = { id: 'new-session' };
     jest.spyOn(createSession, 'createSession').mockReturnValueOnce(mockSessionMeta);
 
     const config = makeCoreConfig({ url: 'http://example.com/my-collector', app: {} });
 
-    expect(config?.sessionTracking).toBeTruthy();
+    expect(config?.session).toStrictEqual(mockSessionMeta);
+  });
+
+  it('creates session meta with id and attributes provided via the initial session property.', () => {
+    const mockSessionMeta: MetaSession = {
+      id: 'new-session',
+      attributes: {
+        foo: 'bar',
+      },
+    };
+
+    const config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      sessionTracking: {
+        enabled: true,
+        session: mockSessionMeta,
+      },
+    });
+
+    expect(config?.sessionTracking?.session).toStrictEqual(mockSessionMeta);
+  });
+
+  it('creates new session meta for browser with no faro session stored in web storage.', () => {
+    const mockSessionMeta = { id: 'new-session' };
+    jest.spyOn(createSession, 'createSession').mockReturnValueOnce(mockSessionMeta);
+
+    let config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      sessionTracking: {
+        enabled: true,
+      },
+    });
+
+    expect(config?.sessionTracking?.session).toStrictEqual(mockSessionMeta);
+
+    // for persistent sessions
+    jest.spyOn(createSession, 'createSession').mockReturnValueOnce(mockSessionMeta);
+    config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      sessionTracking: {
+        enabled: true,
+        persistent: true,
+      },
+    });
+
     expect(config?.sessionTracking?.session).toStrictEqual(mockSessionMeta);
   });
 
   it('creates session meta with id from persisted session for valid tracked session which is within maxSessionPersistenceTime.', () => {
-    // jest.spyOn(createSession, 'createSession').mockReturnValueOnce(mockSessionMeta);
-
     const mockSessionId = 'new-session';
+    const mockAttributes = {
+      foo: 'bar',
+    };
 
     mockStorage[STORAGE_KEY] = JSON.stringify({
       sessionId: mockSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      sessionMeta: {
+        id: '123',
+        attributes: mockAttributes,
+      },
     } as FaroUserSession);
 
     jest.advanceTimersByTime(SESSION_INACTIVITY_TIME - 1);
@@ -104,11 +157,13 @@ describe('userSessions config', () => {
       url: 'http://example.com/my-collector',
       app: {},
       sessionTracking: {
+        enabled: true,
         persistent: true,
       },
     });
 
     expect(config?.sessionTracking?.session?.id).toBe(mockSessionId);
+    expect(config?.sessionTracking?.session?.attributes).toStrictEqual(mockAttributes);
   });
 
   it('creates new session meta with new sessionId for invalid tracked session which is within maxSessionPersistenceTime.', () => {
@@ -127,6 +182,7 @@ describe('userSessions config', () => {
       url: 'http://example.com/my-collector',
       app: {},
       sessionTracking: {
+        enabled: true,
         persistent: true,
       },
     });
@@ -151,6 +207,7 @@ describe('userSessions config', () => {
       url: 'http://example.com/my-collector',
       app: {},
       sessionTracking: {
+        enabled: true,
         persistent: true,
       },
     });

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -83,8 +83,8 @@ describe('userSessions config', () => {
 
     const config = makeCoreConfig({ url: 'http://example.com/my-collector', app: {} });
 
-    expect(config?.experimentalSessions).toBeTruthy();
-    expect(config?.experimentalSessions?.session).toStrictEqual(mockSessionMeta);
+    expect(config?.sessionTracking).toBeTruthy();
+    expect(config?.sessionTracking?.session).toStrictEqual(mockSessionMeta);
   });
 
   it('creates session meta with id from persisted session for valid tracked session which is within maxSessionPersistenceTime.', () => {
@@ -103,12 +103,12 @@ describe('userSessions config', () => {
     const config = makeCoreConfig({
       url: 'http://example.com/my-collector',
       app: {},
-      experimentalSessions: {
+      sessionTracking: {
         persistent: true,
       },
     });
 
-    expect(config?.experimentalSessions?.session?.id).toBe(mockSessionId);
+    expect(config?.sessionTracking?.session?.id).toBe(mockSessionId);
   });
 
   it('creates new session meta with new sessionId for invalid tracked session which is within maxSessionPersistenceTime.', () => {
@@ -126,12 +126,12 @@ describe('userSessions config', () => {
     const config = makeCoreConfig({
       url: 'http://example.com/my-collector',
       app: {},
-      experimentalSessions: {
+      sessionTracking: {
         persistent: true,
       },
     });
 
-    expect(config?.experimentalSessions?.session?.id).toBe(mockSessionMeta.id);
+    expect(config?.sessionTracking?.session?.id).toBe(mockSessionMeta.id);
   });
 
   it('Deletes persisted session if maxSessionPersistenceTime is reached and creates new session meta.', () => {
@@ -150,13 +150,13 @@ describe('userSessions config', () => {
     const config = makeCoreConfig({
       url: 'http://example.com/my-collector',
       app: {},
-      experimentalSessions: {
+      sessionTracking: {
         persistent: true,
       },
     });
 
     expect(mockStorage[STORAGE_KEY]).toBeUndefined();
 
-    expect(config?.experimentalSessions?.session?.id).toBe(mockSessionMeta.id);
+    expect(config?.sessionTracking?.session?.id).toBe(mockSessionMeta.id);
   });
 });

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -9,7 +9,7 @@ import {
 } from '@grafana/faro-core';
 import type { Config, MetaSession, Transport } from '@grafana/faro-core';
 
-import type { MetaItem } from '..';
+import { faro, type MetaItem } from '..';
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { PersistentSessionsManager } from '../instrumentations/session/sessionManager';
@@ -68,7 +68,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     return initialMetas;
   }
 
-  return {
+  const config: Config = {
     app: browserConfig.app,
     batching: {
       ...defaultBatchingConfig,
@@ -105,6 +105,13 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     user: browserConfig.user,
     view: browserConfig.view ?? defaultViewMeta,
   };
+
+  if (config.sessionTracking?.enabled) {
+    delete config.session;
+    faro.internalLogger.info('Session tracking is enabled. Removing legacy session object from config.');
+  }
+
+  return config;
 }
 
 function createSessionMeta(sessionsConfig: Config['sessionTracking']): MetaSession {

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -91,12 +91,12 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     ignoreErrors: browserConfig.ignoreErrors,
 
     // The new session management feature is a PoC and still under development and IS NOT READY for any production use!
-    experimentalSessions: {
+    sessionTracking: {
       // TODO: will be true on release
       enabled: false,
       ...defaultSessionPersistenceConfig,
-      session: createSessionMeta(browserConfig.experimentalSessions),
-      ...browserConfig.experimentalSessions,
+      session: createSessionMeta(browserConfig.sessionTracking),
+      ...browserConfig.sessionTracking,
     },
 
     // TODO: deprecate/remove old init code or maybe rename to legacy_session?
@@ -107,7 +107,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
   };
 }
 
-function createSessionMeta(sessionsConfig: Config['experimentalSessions']): MetaSession {
+function createSessionMeta(sessionsConfig: Config['sessionTracking']): MetaSession {
   const _sessionsConfig = { ...defaultSessionPersistenceConfig, ...sessionsConfig };
 
   let sessionId;

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -44,7 +44,7 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         // Works with the new session config?
-        experimentalSessions: {
+        sessionTracking: {
           session,
           enabled: true,
           persistent: false,
@@ -78,7 +78,7 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         // Works with the new session config?
-        experimentalSessions: {
+        sessionTracking: {
           enabled: true,
           persistent: true,
           session,
@@ -114,7 +114,7 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         // Works with the new session config?
-        experimentalSessions: {
+        sessionTracking: {
           enabled: true,
           persistent: true,
           session,
@@ -137,7 +137,7 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         // Works with the new session config?
-        experimentalSessions: {
+        sessionTracking: {
           enabled: false,
           persistent: true,
           session,

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -28,7 +28,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
   private getSessionManagerInstanceByConfiguredStrategy(
     initialSessionId?: string
   ): PersistentSessionsManager | VolatileSessionsManager | null {
-    if (this.config.experimentalSessions?.persistent && isLocalStorageAvailable) {
+    if (this.config.sessionTracking?.persistent && isLocalStorageAvailable) {
       return new PersistentSessionsManager(initialSessionId);
     }
 
@@ -45,7 +45,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
     this.sendSessionStartEvent(this.metas.value);
     this.metas.addListener(this.sendSessionStartEvent.bind(this));
 
-    if (this.config.experimentalSessions?.enabled) {
+    if (this.config.sessionTracking?.enabled) {
       const sessionManager = this.getSessionManagerInstanceByConfiguredStrategy(this.metas.value.session?.id);
 
       if (sessionManager != null) {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -26,7 +26,7 @@ describe('Persistent Sessions Manager.', () => {
     getItemSpy = jest.spyOn(global.Storage.prototype, 'getItem').mockImplementation((key) => mockStorage[key] ?? null);
 
     const config = mockConfig({
-      experimentalSessions: {
+      sessionTracking: {
         persistent: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -26,7 +26,7 @@ describe('Volatile Sessions Manager.', () => {
     getItemSpy = jest.spyOn(global.Storage.prototype, 'getItem').mockImplementation((key) => mockStorage[key] ?? null);
 
     const config = mockConfig({
-      experimentalSessions: {
+      sessionTracking: {
         persistent: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -95,7 +95,7 @@ describe('sessionManagerUtils', () => {
     const mockOnSessionChange = jest.fn();
 
     const config = mockConfig({
-      experimentalSessions: {
+      sessionTracking: {
         onSessionChange: mockOnSessionChange,
       },
     });
@@ -151,7 +151,7 @@ describe('sessionManagerUtils', () => {
     const mockOnSessionChange = jest.fn();
 
     const config = mockConfig({
-      experimentalSessions: {
+      sessionTracking: {
         onSessionChange: mockOnSessionChange,
       },
       session: currentSessionMeta,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -59,10 +59,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
       storeUserSession(newSession);
 
       faro.api?.setSession(newSession.sessionMeta);
-      faro.config.experimentalSessions?.onSessionChange?.(
-        sessionFromStorage?.sessionMeta ?? null,
-        newSession.sessionMeta!
-      );
+      faro.config.sessionTracking?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
     }
   };
 }

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -182,7 +182,7 @@ describe('FetchTransport', () => {
             url: 'http://example.com/collect',
           }),
         ],
-        experimentalSessions: {
+        sessionTracking: {
           enabled: true,
           session: { id: '123' },
         },

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -50,7 +50,7 @@ export class FetchTransport extends BaseTransport {
             'Content-Type': 'application/json',
             ...(headers ?? {}),
             ...(apiKey ? { 'x-api-key': apiKey } : {}),
-            ...(this.config.experimentalSessions?.enabled && this.metas.value.session?.id
+            ...(this.config.sessionTracking?.enabled && this.metas.value.session?.id
               ? { 'x-faro-session-id': this.metas.value.session?.id }
               : {}),
           },


### PR DESCRIPTION
## Why
We want to release the new session management capabilities so users can already use it if they like.
The current (legacy) session object will be removed from the Faro config as of 2024/01/01. 

It also fixes an issue that session from session storage were not picked up on initialize.
 
## What
* Rename the new session config object
* Remove legacy session object if new session management is enabled
* Fix: createSessionMeta() didn't pick up session from session storage (only from local storage)

## Links
[Documentation PR](https://github.com/grafana/website/pull/16343)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
