### PR TITLE
Add x-faro-session header to identify client session to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Feat: Add x-faro-session header to identify client session id to server
+  for fetch & xhr instrumentations (#377)
+
 ## 1.2.5
 
 - Feat: New session tracking capabilities (optional, disabled by default) where users can choose to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 - Feat: Add x-faro-session header to identify client session id to server
-  for fetch & xhr instrumentations (#377)
+  for fetch and xhr instrumentations (#377)
 
 ## 1.2.5
 

--- a/experimental/instrumentation-fetch/README.md
+++ b/experimental/instrumentation-fetch/README.md
@@ -43,7 +43,8 @@ fetch(...) // Use fetch as normal - telemetry data is sent to your Faro endpoint
 
 In order to prepare backend correlation, this instrumentation adds the following headers to each
 request that server-side instrumentation can use as context:
-* `x-faro-session` - the client-side session id
+
+- `x-faro-session` - the client-side session id
 
 ## Planned Development
 

--- a/experimental/instrumentation-fetch/README.md
+++ b/experimental/instrumentation-fetch/README.md
@@ -39,6 +39,12 @@ initializeFaro({
 fetch(...) // Use fetch as normal - telemetry data is sent to your Faro endpoint
 ```
 
+## Backend correlation
+
+In order to prepare backend correlation, this instrumentation adds the following headers to each
+request that server-side instrumentation can use as context:
+* `x-faro-session` - the client-side session id
+
 ## Planned Development
 
 - Additional functionality to correlate frontend requests with backend actions

--- a/experimental/instrumentation-fetch/src/constants.ts
+++ b/experimental/instrumentation-fetch/src/constants.ts
@@ -12,6 +12,13 @@ export const fetchGlobalObjectKey = 'fetch';
 export const resolvedFetchEventName = 'faro.fetch.resolved';
 export const rejectedFetchEventName = 'faro.fetch.rejected';
 
+export const serverTimingHeader = 'server-timing';
+export const faroRumHeader = 'x-faro-session';
+
+export const makeFaroRumHeaderValue = (sessionId: string): string => {
+  return `session_id=${sessionId}`;
+}
+
 export const responseProperties = (response: Partial<Response>): StringResponse => {
   return {
     body_used: response.bodyUsed?.toString() ?? '',

--- a/experimental/instrumentation-fetch/src/constants.ts
+++ b/experimental/instrumentation-fetch/src/constants.ts
@@ -17,7 +17,7 @@ export const faroRumHeader = 'x-faro-session';
 
 export const makeFaroRumHeaderValue = (sessionId: string): string => {
   return `session_id=${sessionId}`;
-}
+};
 
 export const responseProperties = (response: Partial<Response>): StringResponse => {
   return {

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,6 +1,6 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
-import { SessionInstrumentation } from '@grafana/faro-web-sdk';
+import { makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 import { makeFaroRumHeaderValue } from './constants';
 import { FetchInstrumentation } from './instrumentation';
@@ -41,7 +41,9 @@ describe('FetchInstrumentation', () => {
 
     const sessionInstrumentation = new SessionInstrumentation();
 
-    const faroInstance = initializeFaro(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }));
+    const faroInstance = initializeFaro(
+      makeCoreConfig(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }))!
+    );
     const sessionId = faroInstance.api.getSession()!.id as string;
     expect(sessionId).not.toBe('');
 

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,8 +1,8 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
 
-import { FetchInstrumentation } from './instrumentation';
 import { makeFaroRumHeaderValue } from './constants';
+import { FetchInstrumentation } from './instrumentation';
 
 describe('FetchInstrumentation', () => {
   it('initialize FetchInstrumentation with default options', () => {

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,9 +1,10 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
 
+import { SessionInstrumentation } from '@grafana/faro-web-sdk';
+
 import { makeFaroRumHeaderValue } from './constants';
 import { FetchInstrumentation } from './instrumentation';
-import { SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 describe('FetchInstrumentation', () => {
   it('initialize FetchInstrumentation with default options', () => {

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -2,6 +2,7 @@ import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
 
 import { FetchInstrumentation } from './instrumentation';
+import {makeFaroRumHeaderValue} from "./constants";
 
 describe('FetchInstrumentation', () => {
   it('initialize FetchInstrumentation with default options', () => {
@@ -37,7 +38,9 @@ describe('FetchInstrumentation', () => {
       testing: true,
     });
 
-    initializeFaro(mockConfig({ instrumentations: [instrumentation] }));
+    const sessionId = 'test-session-id';
+
+    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId } }));
 
     const parseActualResult = (res: { init?: RequestInit | undefined; request: Request }) => {
       return {
@@ -72,7 +75,9 @@ describe('FetchInstrumentation', () => {
       request: {
         method: 'GET',
         url: 'https://example.com/',
-        headers: new Headers({}),
+        headers: new Headers({
+          'x-faro-session': makeFaroRumHeaderValue(sessionId),
+        }),
         destination: '',
         referrerPolicy: '',
         mode: 'cors',
@@ -93,7 +98,9 @@ describe('FetchInstrumentation', () => {
       testing: true,
     });
 
-    initializeFaro(mockConfig({ instrumentations: [instrumentation] }));
+    const sessionId = 'test-session-id';
+
+    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: {id: sessionId} }));
 
     const fetchSpy = jest.spyOn(global, 'fetch');
 

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -2,7 +2,7 @@ import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
 
 import { FetchInstrumentation } from './instrumentation';
-import {makeFaroRumHeaderValue} from "./constants";
+import { makeFaroRumHeaderValue } from './constants';
 
 describe('FetchInstrumentation', () => {
   it('initialize FetchInstrumentation with default options', () => {
@@ -100,7 +100,7 @@ describe('FetchInstrumentation', () => {
 
     const sessionId = 'test-session-id';
 
-    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: {id: sessionId} }));
+    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId } }));
 
     const fetchSpy = jest.spyOn(global, 'fetch');
 

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -3,6 +3,7 @@ import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
 
 import { makeFaroRumHeaderValue } from './constants';
 import { FetchInstrumentation } from './instrumentation';
+import { SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 describe('FetchInstrumentation', () => {
   it('initialize FetchInstrumentation with default options', () => {
@@ -38,9 +39,11 @@ describe('FetchInstrumentation', () => {
       testing: true,
     });
 
-    const sessionId = 'test-session-id';
+    const sessionInstrumentation = new SessionInstrumentation();
 
-    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId } }));
+    const faroInstance = initializeFaro(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }));
+    const sessionId = faroInstance.api.getSession()!.id as string;
+    expect(sessionId).not.toBe('');
 
     const parseActualResult = (res: { init?: RequestInit | undefined; request: Request }) => {
       return {

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -36,7 +36,8 @@ describe('FetchInstrumentation', () => {
     const instrumentation = new FetchInstrumentation({
       testing: true,
     });
-    instrumentation.initialize();
+
+    initializeFaro(mockConfig({ instrumentations: [instrumentation] }));
 
     const parseActualResult = (res: { init?: RequestInit | undefined; request: Request }) => {
       return {

--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,6 +1,5 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils/mockConfig';
-
 import { SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 import { makeFaroRumHeaderValue } from './constants';

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -2,7 +2,8 @@ import { BaseInstrumentation, faro, globalObject, VERSION } from '@grafana/faro-
 
 import {
   faroRumHeader,
-  fetchGlobalObjectKey, makeFaroRumHeaderValue,
+  fetchGlobalObjectKey,
+  makeFaroRumHeaderValue,
   parseHeaders,
   rejectedFetchEventName,
   resolvedFetchEventName,

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -85,9 +85,10 @@ export class FetchInstrumentation extends BaseInstrumentation {
       initCopy.body = body;
     }
 
-    // add faroRumHeader to the request headers
-    if (faro.api.getSession() !== undefined && faro.api.getSession()!.id !== undefined) {
-      request.headers.append(faroRumHeader, makeFaroRumHeaderValue(faro.api.getSession()!.id as string));
+    // add Faro RUM header to the request headers
+    const sessionId = faro.api.getSession()?.id;
+    if (sessionId !== null) {
+      request.headers.append(faroRumHeader, makeFaroRumHeaderValue(sessionId as string));
     }
 
     return { init, request };

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -89,7 +89,7 @@ export class FetchInstrumentation extends BaseInstrumentation {
     // add Faro RUM header to the request headers
     const sessionId = faro.api.getSession()?.id;
     if (sessionId != null) {
-      request.headers.append(faroRumHeader, makeFaroRumHeaderValue(sessionId as string));
+      request.headers.append(faroRumHeader, makeFaroRumHeaderValue(sessionId));
     }
 
     return { init, request };

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -88,7 +88,7 @@ export class FetchInstrumentation extends BaseInstrumentation {
 
     // add Faro RUM header to the request headers
     const sessionId = faro.api.getSession()?.id;
-    if (sessionId !== null) {
+    if (sessionId != null) {
       request.headers.append(faroRumHeader, makeFaroRumHeaderValue(sessionId as string));
     }
 

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -1,7 +1,8 @@
 import { BaseInstrumentation, faro, globalObject, VERSION } from '@grafana/faro-core';
 
 import {
-  fetchGlobalObjectKey,
+  faroRumHeader,
+  fetchGlobalObjectKey, makeFaroRumHeaderValue,
   parseHeaders,
   rejectedFetchEventName,
   resolvedFetchEventName,
@@ -82,6 +83,11 @@ export class FetchInstrumentation extends BaseInstrumentation {
     const request = new Request(input, initCopy);
     if (body) {
       initCopy.body = body;
+    }
+
+    // add faroRumHeader to the request headers
+    if (faro.api.getSession() !== undefined && faro.api.getSession()!.id !== undefined) {
+      request.headers.append(faroRumHeader, makeFaroRumHeaderValue(faro.api.getSession()!.id as string));
     }
 
     return { init, request };

--- a/experimental/instrumentation-xhr/README.md
+++ b/experimental/instrumentation-xhr/README.md
@@ -34,3 +34,9 @@ const req = new XMLHttpRequest();
 req.open('GET', '...');
 req.send(); // use XHR as normal - telemetry data is sent to your Faro endpoint
 ```
+
+## Backend correlation
+
+In order to prepare backend correlation, this instrumentation adds the following headers to each
+request that server-side instrumentation can use as context:
+* `x-faro-session` - the client-side session id

--- a/experimental/instrumentation-xhr/README.md
+++ b/experimental/instrumentation-xhr/README.md
@@ -39,4 +39,5 @@ req.send(); // use XHR as normal - telemetry data is sent to your Faro endpoint
 
 In order to prepare backend correlation, this instrumentation adds the following headers to each
 request that server-side instrumentation can use as context:
-* `x-faro-session` - the client-side session id
+
+- `x-faro-session` - the client-side session id

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -72,7 +72,8 @@ describe('XHRInstrumentation', () => {
     xhr.open('GET', 'https://example.com');
     xhr.send();
 
-    expect(transport.items).toHaveLength(0);
+    // We expect one item because the session instrumentation is enabled
+    expect(transport.items).toHaveLength(1);
     expect(fetchSpySend).toHaveBeenCalledTimes(1);
 
     // if URL ignored, don't inject faro session header

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -1,6 +1,6 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
-import { SessionInstrumentation } from '@grafana/faro-web-sdk';
+import { makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 import { XHRInstrumentation } from './instrumentation';
 import { faroRumHeader, makeFaroRumHeaderValue } from './types';
@@ -31,7 +31,9 @@ describe('XHRInstrumentation', () => {
     const instrumentation = new XHRInstrumentation({});
 
     const sessionInstrumentation = new SessionInstrumentation();
-    const faroInstance = initializeFaro(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }));
+    const faroInstance = initializeFaro(
+      makeCoreConfig(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }))!
+    );
 
     const sessionId = faroInstance.api.getSession()!.id as string;
     expect(sessionId).not.toBe('');
@@ -60,7 +62,9 @@ describe('XHRInstrumentation', () => {
     const fetchSpySetRequestHeader = jest.spyOn(instrumentation, 'originalSetRequestHeader');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');
     const faro = initializeFaro(
-      mockConfig({ instrumentations: [instrumentation, sessionInstrumentation], transports: [transport] })
+      makeCoreConfig(
+        mockConfig({ instrumentations: [instrumentation, sessionInstrumentation], transports: [transport] })
+      )!
     );
     faro.pause();
 

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -2,7 +2,7 @@ import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { XHRInstrumentation } from './instrumentation';
-import {faroRumHeader, makeFaroRumHeaderValue} from "./types";
+import { faroRumHeader, makeFaroRumHeaderValue } from './types';
 
 describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation with default options', () => {
@@ -55,7 +55,9 @@ describe('XHRInstrumentation', () => {
 
     const fetchSpySetRequestHeader = jest.spyOn(instrumentation, 'originalSetRequestHeader');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');
-    const faro = initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId }, transports: [transport] }));
+    const faro = initializeFaro(
+      mockConfig({ instrumentations: [instrumentation], session: { id: sessionId }, transports: [transport] })
+    );
     faro.pause();
 
     const xhr = new XMLHttpRequest();

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -3,6 +3,7 @@ import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { XHRInstrumentation } from './instrumentation';
 import { faroRumHeader, makeFaroRumHeaderValue } from './types';
+import {SessionInstrumentation} from "@grafana/faro-web-sdk";
 
 describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation with default options', () => {
@@ -29,8 +30,11 @@ describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation and send XHR request', () => {
     const instrumentation = new XHRInstrumentation({});
 
-    const sessionId = 'test-session-id';
-    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId } }));
+    const sessionInstrumentation = new SessionInstrumentation();
+    const faroInstance = initializeFaro(mockConfig({ instrumentations: [instrumentation, sessionInstrumentation] }));
+
+    const sessionId = faroInstance.api.getSession()!.id as string;
+    expect(sessionId).not.toBe('');
 
     const fetchSpyOpen = jest.spyOn(instrumentation, 'originalOpen');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -1,6 +1,5 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
-
 import { SessionInstrumentation } from '@grafana/faro-web-sdk';
 
 import { XHRInstrumentation } from './instrumentation';

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -1,9 +1,10 @@
 import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
+import { SessionInstrumentation } from '@grafana/faro-web-sdk';
+
 import { XHRInstrumentation } from './instrumentation';
 import { faroRumHeader, makeFaroRumHeaderValue } from './types';
-import {SessionInstrumentation} from "@grafana/faro-web-sdk";
 
 describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation with default options', () => {

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -53,14 +53,14 @@ describe('XHRInstrumentation', () => {
   });
 
   it('initialize XHRInstrumentation and send XHR request to ignoredUrl', () => {
-    const sessionId = 'test-session-id';
+    const sessionInstrumentation = new SessionInstrumentation();
     const transport = new MockTransport();
     const instrumentation = new XHRInstrumentation({ ignoredUrls: ['https://example.com'] });
 
     const fetchSpySetRequestHeader = jest.spyOn(instrumentation, 'originalSetRequestHeader');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');
     const faro = initializeFaro(
-      mockConfig({ instrumentations: [instrumentation], session: { id: sessionId }, transports: [transport] })
+      mockConfig({ instrumentations: [instrumentation, sessionInstrumentation], transports: [transport] })
     );
     faro.pause();
 

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -2,6 +2,7 @@ import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { XHRInstrumentation } from './instrumentation';
+import {faroRumHeader, makeFaroRumHeaderValue} from "./types";
 
 describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation with default options', () => {
@@ -28,10 +29,12 @@ describe('XHRInstrumentation', () => {
   it('initialize XHRInstrumentation and send XHR request', () => {
     const instrumentation = new XHRInstrumentation({});
 
-    initializeFaro(mockConfig({ instrumentations: [instrumentation] }));
+    const sessionId = 'test-session-id';
+    initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId } }));
 
     const fetchSpyOpen = jest.spyOn(instrumentation, 'originalOpen');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');
+    const fetchSpySetRequestHeader = jest.spyOn(instrumentation, 'originalSetRequestHeader');
 
     const xhr = new XMLHttpRequest();
     xhr.open('GET', 'https://grafana.com');
@@ -39,14 +42,20 @@ describe('XHRInstrumentation', () => {
 
     xhr.send();
     expect(fetchSpySend).toHaveBeenCalledTimes(1);
+
+    // check if faro session was added to the request headers
+    expect(fetchSpySetRequestHeader).toHaveBeenCalledTimes(1);
+    expect(fetchSpySetRequestHeader).toHaveBeenCalledWith(faroRumHeader, makeFaroRumHeaderValue(sessionId));
   });
 
   it('initialize XHRInstrumentation and send XHR request to ignoredUrl', () => {
+    const sessionId = 'test-session-id';
     const transport = new MockTransport();
     const instrumentation = new XHRInstrumentation({ ignoredUrls: ['https://example.com'] });
 
+    const fetchSpySetRequestHeader = jest.spyOn(instrumentation, 'originalSetRequestHeader');
     const fetchSpySend = jest.spyOn(instrumentation, 'originalSend');
-    const faro = initializeFaro(mockConfig({ instrumentations: [instrumentation], transports: [transport] }));
+    const faro = initializeFaro(mockConfig({ instrumentations: [instrumentation], session: { id: sessionId }, transports: [transport] }));
     faro.pause();
 
     const xhr = new XMLHttpRequest();
@@ -55,5 +64,8 @@ describe('XHRInstrumentation', () => {
 
     expect(transport.items).toHaveLength(0);
     expect(fetchSpySend).toHaveBeenCalledTimes(1);
+
+    // if URL ignored, don't inject faro session header
+    expect(fetchSpySetRequestHeader).toHaveBeenCalledTimes(0);
   });
 });

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -65,10 +65,10 @@ export class XHRInstrumentation extends BaseInstrumentation {
 
         // add Faro RUM header to the request headers
         const sessionId = faro.api.getSession()?.id;
-        if (sessionId !== null) {
+        if (sessionId != null) {
           instrumentation.originalSetRequestHeader.apply(this, [
             faroRumHeader,
-            makeFaroRumHeaderValue(sessionId as string),
+            makeFaroRumHeaderValue(sessionId),
           ]);
         }
 

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -66,10 +66,7 @@ export class XHRInstrumentation extends BaseInstrumentation {
         // add Faro RUM header to the request headers
         const sessionId = faro.api.getSession()?.id;
         if (sessionId != null) {
-          instrumentation.originalSetRequestHeader.apply(this, [
-            faroRumHeader,
-            makeFaroRumHeaderValue(sessionId),
-          ]);
+          instrumentation.originalSetRequestHeader.apply(this, [faroRumHeader, makeFaroRumHeaderValue(sessionId)]);
         }
 
         this.addEventListener('load', loadEventListener.bind(this));

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -1,6 +1,6 @@
 import { BaseInstrumentation, faro, VERSION } from '@grafana/faro-core';
 
-import {faroRumHeader, makeFaroRumHeaderValue, XHREventType, XHRInstrumentationOptions} from './types';
+import { faroRumHeader, makeFaroRumHeaderValue, XHREventType, XHRInstrumentationOptions } from './types';
 import { parseXHREvent, parseXHRHeaders } from './utils';
 
 export class XHRInstrumentation extends BaseInstrumentation {
@@ -8,7 +8,7 @@ export class XHRInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
   readonly originalOpen: XMLHttpRequest['open'] = XMLHttpRequest.prototype.open;
   readonly originalSend: XMLHttpRequest['send'] = XMLHttpRequest.prototype.send;
-  readonly originalSetRequestHeader : XMLHttpRequest['setRequestHeader'] = XMLHttpRequest.prototype.setRequestHeader;
+  readonly originalSetRequestHeader: XMLHttpRequest['setRequestHeader'] = XMLHttpRequest.prototype.setRequestHeader;
   private ignoredUrls: XHRInstrumentationOptions['ignoredUrls'];
 
   constructor(private options?: XHRInstrumentationOptions) {
@@ -66,7 +66,10 @@ export class XHRInstrumentation extends BaseInstrumentation {
         // add Faro RUM header to the request headers
         const sessionId = faro.api.getSession()?.id;
         if (sessionId !== null) {
-          instrumentation.originalSetRequestHeader.apply(this, [faroRumHeader, makeFaroRumHeaderValue(sessionId as string)]);
+          instrumentation.originalSetRequestHeader.apply(this, [
+            faroRumHeader,
+            makeFaroRumHeaderValue(sessionId as string),
+          ]);
         }
 
         this.addEventListener('load', loadEventListener.bind(this));

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -39,9 +39,10 @@ export class XHRInstrumentation extends BaseInstrumentation {
         // @ts-expect-error - _url should be attached to "this"
         this._url = url;
 
-        // Add faro rum header to communicate client side session id to the server side
-        if (faro.api.getSession() !== undefined && faro.api.getSession()!.id !== undefined) {
-          this.setRequestHeader(faroRumHeader, makeFaroRumHeaderValue(faro.api.getSession()!.id as string));
+        // add Faro RUM header to the request headers
+        const sessionId = faro.api.getSession()?.id;
+        if (sessionId !== null) {
+          this.setRequestHeader(faroRumHeader, makeFaroRumHeaderValue(sessionId as string));
         }
 
         return instrumentation.originalOpen.apply(this, [

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -1,6 +1,6 @@
 import { BaseInstrumentation, faro, VERSION } from '@grafana/faro-core';
 
-import { XHREventType, XHRInstrumentationOptions } from './types';
+import {faroRumHeader, makeFaroRumHeaderValue, XHREventType, XHRInstrumentationOptions} from './types';
 import { parseXHREvent, parseXHRHeaders } from './utils';
 
 export class XHRInstrumentation extends BaseInstrumentation {
@@ -38,6 +38,11 @@ export class XHRInstrumentation extends BaseInstrumentation {
       ): void {
         // @ts-expect-error - _url should be attached to "this"
         this._url = url;
+
+        // Add faro rum header to communicate client side session id to the server side
+        if (faro.api.getSession() !== undefined && faro.api.getSession()!.id !== undefined) {
+          this.setRequestHeader(faroRumHeader, makeFaroRumHeaderValue(faro.api.getSession()!.id as string));
+        }
 
         return instrumentation.originalOpen.apply(this, [
           method,

--- a/experimental/instrumentation-xhr/src/types.ts
+++ b/experimental/instrumentation-xhr/src/types.ts
@@ -9,3 +9,10 @@ export enum XHREventType {
   ERROR = 'faro.xhr.error',
   TIMEOUT = 'faro.xhr.timeout',
 }
+
+export const serverTimingHeader = 'server-timing';
+export const faroRumHeader = 'x-faro-session';
+
+export const makeFaroRumHeaderValue = (sessionId: string): string => {
+  return `session_id=${sessionId}`;
+}

--- a/experimental/instrumentation-xhr/src/types.ts
+++ b/experimental/instrumentation-xhr/src/types.ts
@@ -15,4 +15,4 @@ export const faroRumHeader = 'x-faro-session';
 
 export const makeFaroRumHeaderValue = (sessionId: string): string => {
   return `session_id=${sessionId}`;
-}
+};


### PR DESCRIPTION
## Why

In order to propagate a client-side session id to the server side without needing a trace necessarily.

## What

Propagate an `x-faro-session` header to the server containing the session ID.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
