### PR TITLE
Revert "v1.2.6"

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-demo",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Demo of Faro",
   "license": "Apache-2.0",
   "author": "Grafana Labs",
@@ -35,10 +35,10 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^1.2.6",
-    "@grafana/faro-react": "^1.2.6",
-    "@grafana/faro-web-sdk": "^1.2.6",
-    "@grafana/faro-web-tracing": "^1.2.6",
+    "@grafana/faro-core": "^1.2.5",
+    "@grafana/faro-react": "^1.2.5",
+    "@grafana/faro-web-sdk": "^1.2.5",
+    "@grafana/faro-web-tracing": "^1.2.5",
     "@grpc/grpc-js": "^1.9.0",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/core": "^1.15.2",

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-instrumentation-fetch",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro fetch auto-instrumentation package",
   "keywords": [
     "observability",
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/grafana/faro-web-sdk",
   "dependencies": {
-    "@grafana/faro-core": "^1.2.6"
+    "@grafana/faro-core": "^1.2.5"
   },
   "devDependencies": {
     "@remix-run/web-fetch": "^4.3.4"

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-instrumentation-performance-timeline",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro instrumentation to capture Browser Performance Timeline data.",
   "keywords": [
     "observability",
@@ -50,7 +50,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "devDependencies": {
-    "@grafana/faro-core": "^1.2.6"
+    "@grafana/faro-core": "^1.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/experimental/instrumentation-xhr/package.json
+++ b/experimental/instrumentation-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-instrumentation-xhr",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro XHR auto-instrumentation package",
   "keywords": [
     "observability",
@@ -38,7 +38,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^1.2.6"
+    "@grafana/faro-core": "^1.2.5"
   },
   "devDependencies": {
     "@remix-run/web-fetch": "^4.3.4"

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-transport-otlp-http",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
   "keywords": [
     "observability",
@@ -50,7 +50,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "devDependencies": {
-    "@grafana/faro-core": "^1.2.6"
+    "@grafana/faro-core": "^1.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
     "experimental/*",
     "demo"
   ],
-  "version": "1.2.6",
+  "version": "1.2.5",
   "npmClient": "yarn"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-core",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Core package of Faro.",
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-react",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro package that enables easier integration in projects built with React.",
   "keywords": [
     "observability",
@@ -52,8 +52,8 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^1.2.6",
-    "@grafana/faro-web-tracing": "^1.2.6",
+    "@grafana/faro-web-sdk": "^1.2.5",
+    "@grafana/faro-web-tracing": "^1.2.5",
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-sdk",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro instrumentations, metas, transports for web.",
   "keywords": [
     "observability",
@@ -52,7 +52,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^1.2.6",
+    "@grafana/faro-core": "^1.2.5",
     "ua-parser-js": "^1.0.32",
     "web-vitals": "^3.1.1"
   },

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-tracing",
-  "version": "1.2.6",
+  "version": "1.2.5",
   "description": "Faro web tracing implementation.",
   "keywords": [
     "observability",
@@ -52,7 +52,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^1.2.6",
+    "@grafana/faro-web-sdk": "^1.2.5",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/context-zone": "^1.15.2",
     "@opentelemetry/core": "^1.15.2",


### PR DESCRIPTION
This reverts commit 9eb32b34a9b1a3153c9686337c7b5d0963389c54.

## Why

On v1.2.6, we are seeing increased timeouts from memcached, resulting in about 5% of the requests timing out. Reverting to the last good known version until the actual source of the problem is resolved.

## What

Changed the package definition to point to the last known good version.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
