### PR TITLE
hotfix: remove custom sessionId  header from legacy session.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+## 1.2.7
+
+- Hotfix: disable custom x-faro-session-id header for legacy sessions ()
+
+## 1.2.6
+
 - Feat: Add x-faro-session header to identify client session id to server
   for fetch and xhr instrumentations (#377)
 - Chore: Always send x-faro-session-id header, independent of the chosen session management (#381).

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -55,7 +55,7 @@ export class FetchTransport extends BaseTransport {
             'Content-Type': 'application/json',
             ...(headers ?? {}),
             ...(apiKey ? { 'x-api-key': apiKey } : {}),
-            ...(sessionId ? { 'x-faro-session-id': sessionId } : {}),
+            ...(this.config.sessionTracking?.enabled && sessionId ? { 'x-faro-session-id': sessionId } : {}),
           },
           body,
           keepalive: body.length <= BEACON_BODY_SIZE_LIMIT,


### PR DESCRIPTION
## Why

Adding the x-faro-session header for legacy sessions caused a problem with memcached which starts to stack up so we remove this for now. 

This change does affect an internal feature so no degredation of features for customers.

## What
* Don't add x-faro-session-id to beaon requests for  legcacy sessions.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
