### PR TITLE
change: always add x-faro-session-id HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Next
 
+## 1.2.8
+
+- Change: Custom x-faro-session-id header will now be added to legacy sessions as well (#384).
+
 ## 1.2.7
 
-- Hotfix: disable custom x-faro-session-id header for legacy sessions ()
+- Hotfix: disable custom x-faro-session-id header for legacy sessions (#383)
 
 ## 1.2.6
 

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -1,8 +1,5 @@
 import { getTransportBody, LogEvent, LogLevel, TransportItem, TransportItemType } from '@grafana/faro-core';
-import { mockConfig, mockInternalLogger } from '@grafana/faro-core/src/testUtils';
-
-import { initializeFaro } from '../../initialize';
-import { SessionInstrumentation } from '../../instrumentations';
+import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
 
 import { FetchTransport } from './transport';
 
@@ -64,7 +61,7 @@ describe('FetchTransport', () => {
       body: JSON.stringify(getTransportBody([item])),
       headers: {
         'Content-Type': 'application/json',
-        // 'x-faro-session-id': mockSessionId,
+        'x-faro-session-id': mockSessionId,
       },
       keepalive: true,
       method: 'POST',
@@ -208,41 +205,10 @@ describe('FetchTransport', () => {
       body: JSON.stringify(getTransportBody([largeItem])),
       headers: {
         'Content-Type': 'application/json',
-        // 'x-faro-session-id': mockSessionId,
+        'x-faro-session-id': mockSessionId,
       },
       keepalive: false,
       method: 'POST',
     });
-  });
-
-  it('adds x-faro-session-id header when the new session manager is used.', async () => {
-    const { transports } = initializeFaro(
-      mockConfig({
-        instrumentations: [new SessionInstrumentation()],
-        transports: [
-          new FetchTransport({
-            url: 'http://example.com/collect',
-          }),
-        ],
-        sessionTracking: {
-          enabled: true,
-          session: { id: '123' },
-        },
-      })
-    );
-
-    const transport = transports.transports[0] as FetchTransport;
-
-    transport.send([item]);
-
-    expect(fetch).toHaveBeenCalledWith(
-      'http://example.com/collect',
-      expect.objectContaining({
-        headers: {
-          'Content-Type': 'application/json',
-          'x-faro-session-id': '123',
-        },
-      })
-    );
   });
 });

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -55,7 +55,7 @@ export class FetchTransport extends BaseTransport {
             'Content-Type': 'application/json',
             ...(headers ?? {}),
             ...(apiKey ? { 'x-api-key': apiKey } : {}),
-            ...(this.config.sessionTracking?.enabled && sessionId ? { 'x-faro-session-id': sessionId } : {}),
+            ...(sessionId ? { 'x-faro-session-id': sessionId } : {}),
           },
           body,
           keepalive: body.length <= BEACON_BODY_SIZE_LIMIT,


### PR DESCRIPTION
## Why

Because of a backend issue—which got fixed—we needed to disable to always add the new x-faro-session-id header.

## What
* Always add x-faro-session-id header

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
