### PR TITLE
Session based sampling V0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+## 1.2.9
+
+- Feat: session based sampling (#385).
+
 ## 1.2.8
 
 - Change: Custom x-faro-session-id header will now be added to legacy sessions as well (#384).

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,7 +1,7 @@
 import type { APIEvent, StacktraceParser } from '../api';
 import type { Instrumentation } from '../instrumentations';
 import type { InternalLoggerLevel } from '../internalLogger';
-import type { MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '../metas';
+import type { Meta, MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '../metas';
 import type { BatchExecutorOptions, BeforeSendHook, Transport } from '../transports';
 import type { UnpatchedConsole } from '../unpatchedConsole';
 
@@ -29,6 +29,8 @@ export interface Config<P = APIEvent> {
     session?: MetaSession;
     maxSessionPersistenceTime?: number;
     onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
+    samplingRate?: number;
+    sampler?: (metas: Meta) => number;
   };
 
   user?: MetaUser;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -5,6 +5,10 @@ import type { Meta, MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '.
 import type { BatchExecutorOptions, BeforeSendHook, Transport } from '../transports';
 import type { UnpatchedConsole } from '../unpatchedConsole';
 
+type SamplingContext = {
+  metas: Meta;
+};
+
 export interface Config<P = APIEvent> {
   app: MetaApp;
   batching?: BatchExecutorOptions;
@@ -30,7 +34,7 @@ export interface Config<P = APIEvent> {
     maxSessionPersistenceTime?: number;
     onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
     samplingRate?: number;
-    sampler?: (metas: Meta) => number;
+    sampler?: (context: SamplingContext) => number;
   };
 
   user?: MetaUser;

--- a/packages/web-sdk/src/instrumentations/session/index.ts
+++ b/packages/web-sdk/src/instrumentations/session/index.ts
@@ -1,3 +1,16 @@
 export { SessionInstrumentation } from './instrumentation';
 
-export * from './sessionManager';
+export {
+  MAX_SESSION_PERSISTENCE_TIME,
+  MAX_SESSION_PERSISTENCE_TIME_BUFFER,
+  PersistentSessionsManager,
+  SESSION_EXPIRATION_TIME,
+  SESSION_INACTIVITY_TIME,
+  STORAGE_KEY,
+  STORAGE_UPDATE_DELAY,
+  VolatileSessionsManager,
+  defaultSessionTrackingConfig,
+  isSampled,
+} from './sessionManager';
+
+export type { FaroUserSession } from './sessionManager';

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -107,7 +107,7 @@ describe('SessionInstrumentation', () => {
     const transport = new MockTransport();
 
     const mockNewSessionId = '123';
-    mockStorage[STORAGE_KEY] = JSON.stringify(createUserSessionObject(mockNewSessionId));
+    mockStorage[STORAGE_KEY] = JSON.stringify(createUserSessionObject({ sessionId: mockNewSessionId }));
 
     initializeFaro(
       mockConfig({
@@ -130,7 +130,7 @@ describe('SessionInstrumentation', () => {
     const transport = new MockTransport();
 
     const mockNewSessionId = '123';
-    const mockUserSession = createUserSessionObject(mockNewSessionId);
+    const mockUserSession = createUserSessionObject({ sessionId: mockNewSessionId });
 
     mockStorage[STORAGE_KEY] = JSON.stringify(mockUserSession);
 
@@ -208,7 +208,7 @@ describe('SessionInstrumentation', () => {
   });
 
   it('creates session meta with id from persisted session for valid tracked session which is within maxSessionPersistenceTime.', () => {
-    const mockUserSession = createUserSessionObject('persisted-session');
+    const mockUserSession = createUserSessionObject({ sessionId: 'persisted-session' });
     mockUserSession.sessionMeta = {
       id: 'persisted-session',
       attributes: {
@@ -238,7 +238,7 @@ describe('SessionInstrumentation', () => {
   });
 
   it('creates new session meta with new sessionId for invalid tracked session which is within maxSessionPersistenceTime.', () => {
-    const mockUserSession = createUserSessionObject('persisted-session');
+    const mockUserSession = createUserSessionObject({ sessionId: 'persisted-session' });
     mockUserSession.sessionMeta = {
       id: 'persisted-session',
     };
@@ -265,7 +265,7 @@ describe('SessionInstrumentation', () => {
   });
 
   it('Deletes persisted session if maxSessionPersistenceTime is reached and creates new session meta.', () => {
-    const mockUserSession = createUserSessionObject('persisted-session');
+    const mockUserSession = createUserSessionObject({ sessionId: 'persisted-session' });
     mockUserSession.sessionMeta = {
       id: 'persisted-session',
     };

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -20,7 +20,7 @@ import {
   SESSION_INACTIVITY_TIME,
   STORAGE_KEY,
 } from './sessionManager';
-import * as samplingModule from './sessionManager/sampling';
+import * as samplingModuleMock from './sessionManager/sampling';
 import { createUserSessionObject } from './sessionManager/sessionManagerUtils';
 
 describe('SessionInstrumentation', () => {
@@ -45,7 +45,7 @@ describe('SessionInstrumentation', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    jest.spyOn(samplingModule, 'isSampled').mockRestore();
+    jest.spyOn(samplingModuleMock, 'isSampled').mockRestore();
     mockStorage = {};
   });
 
@@ -302,7 +302,7 @@ describe('SessionInstrumentation', () => {
   it('Removes items which are not part of the sample.', () => {
     const transport = new MockTransport();
 
-    jest.spyOn(samplingModule, 'isSampled').mockReturnValue(true);
+    jest.spyOn(samplingModuleMock, 'isSampled').mockReturnValue(true);
 
     const { api } = initializeFaro(
       mockConfig({
@@ -323,7 +323,7 @@ describe('SessionInstrumentation', () => {
 
     expect(transport.items).toHaveLength(3);
 
-    jest.spyOn(samplingModule, 'isSampled').mockReturnValueOnce(false);
+    jest.spyOn(samplingModuleMock, 'isSampled').mockReturnValueOnce(false);
     api.setSession({ id: 'second-session' });
     expect(transport.items).toHaveLength(4);
     expect(transport.items[3]?.meta.session?.attributes?.['isSampled']).toBeUndefined();

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -22,8 +22,6 @@ describe('SessionInstrumentation', () => {
   let getItemSpy: jest.SpyInstance<string | null, [key: string]>;
   let removeItemSpy: jest.SpyInstance<void, [key: string]>;
 
-  const originalGlobalMatch = global.Math;
-
   beforeAll(() => {
     jest.useFakeTimers();
     setItemSpy = jest.spyOn(global.Storage.prototype, 'setItem').mockImplementation((key, value) => {
@@ -40,7 +38,6 @@ describe('SessionInstrumentation', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    global.Math = originalGlobalMatch;
     mockStorage = {};
   });
 

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -114,11 +114,13 @@ export class SessionInstrumentation extends BaseInstrumentation {
         this.transports?.addBeforeSendHooks(...this.transports.getBeforeSendHooks(), (item) => {
           sessionManager?.updateSession();
 
-          if (item.meta.session?.attributes?.['isSampled']) {
-            return item;
-          }
+          // if (item.meta.session?.attributes?.['isSampled']) {
+          //   return item;
+          // }
 
-          return null;
+          // return null;
+
+          return item;
         });
       }
     } else {

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -62,7 +62,10 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
     if (isUserSessionValid(userSession)) {
       sessionId = userSession?.sessionId;
-      sessionAttributes = userSession?.sessionMeta?.attributes;
+      sessionAttributes = {
+        ...(userSession?.sessionMeta?.attributes ?? {}),
+        isSampled: userSession!.isSampled.toString(),
+      };
       this.api.pushEvent(EVENT_SESSION_RESUME, {}, undefined, { skipDedupe: true });
     } else {
       sessionId = sessionId ?? createSession().id;

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -95,7 +95,10 @@ export class SessionInstrumentation extends BaseInstrumentation {
       const initialSessionMeta = this.createInitialSessionMeta(sessionTracking);
 
       SessionManager.storeUserSession(
-        createUserSessionObject(initialSessionMeta.id, Boolean(initialSessionMeta.attributes!['isSampled']))
+        createUserSessionObject({
+          sessionId: initialSessionMeta.id,
+          isSampled: Boolean(initialSessionMeta.attributes!['isSampled']),
+        })
       );
 
       this.notifiedSession = initialSessionMeta;

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -63,7 +63,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
     if (isUserSessionValid(userSession)) {
       sessionId = userSession?.sessionId;
       sessionAttributes = {
-        ...(userSession?.sessionMeta?.attributes ?? {}),
+        ...userSession?.sessionMeta?.attributes,
         isSampled: userSession!.isSampled.toString(),
       };
       this.api.pushEvent(EVENT_SESSION_RESUME, {}, undefined, { skipDedupe: true });
@@ -78,7 +78,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
         isSampled: isSampled().toString(),
         // We do not want to recalculate the sampling decision on each init phase.
         // If session from web-storage has a isSampled attribute we will use that instead.
-        ...(sessionAttributes ?? {}),
+        ...sessionAttributes,
       },
     };
 
@@ -109,13 +109,13 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
       const { updateSession } = new SessionManager();
 
-      this.transports?.addBeforeSendHooks(...this.transports.getBeforeSendHooks(), (item) => {
+      this.transports?.addBeforeSendHooks((item) => {
         updateSession();
 
         const attributes = item.meta.session?.attributes;
 
-        if (Boolean(attributes?.['isSampled'])) {
-          const { isSampled: _, ...restAttributes } = attributes as any;
+        if (attributes && Boolean(attributes?.['isSampled'])) {
+          const { isSampled: _, ...restAttributes } = attributes;
 
           item.meta.session = {
             ...item.meta.session,

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -114,13 +114,11 @@ export class SessionInstrumentation extends BaseInstrumentation {
         this.transports?.addBeforeSendHooks(...this.transports.getBeforeSendHooks(), (item) => {
           sessionManager?.updateSession();
 
-          // if (item.meta.session?.attributes?.['isSampled']) {
-          //   return item;
-          // }
+          if (item.meta.session?.attributes?.['isSampled']) {
+            return item;
+          }
 
-          // return null;
-
-          return item;
+          return null;
         });
       }
     } else {

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -74,7 +74,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
       attributes: {
         isSampled: isSampled().toString(),
         // We do not want to recalculate the sampling decision on each init phase.
-        // If session from web-storage has a isSampled attribute we will overwrite the isSampled attribute in the previous line
+        // If session from web-storage has a isSampled attribute we will use that instead.
         ...(sessionAttributes ?? {}),
       },
     };

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -104,14 +104,21 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
     if (sessionTracking?.enabled) {
       const initialSessionMeta = this.createInitialSessionMeta(sessionTracking);
+
+      console.log('initialSessionMeta :>> ', initialSessionMeta);
       this.api.setSession(initialSessionMeta);
 
       const sessionManager = this.getSessionManagerInstanceByConfiguredStrategy(this.metas.value.session?.id);
 
       if (sessionManager != null) {
-        this.transports?.addBeforeSendHooks(...this.transports.getBeforeSendHooks(), (item: any) => {
+        this.transports?.addBeforeSendHooks(...this.transports.getBeforeSendHooks(), (item) => {
           sessionManager?.updateSession();
-          return item;
+
+          if (item.meta.session?.attributes?.['isSampled']) {
+            return item;
+          }
+
+          return null;
         });
       }
     } else {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -3,7 +3,9 @@ import { faro, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import { PersistentSessionsManager } from './PersistentSessionsManager';
+import * as samplingModule from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
+import type { FaroUserSession } from './types';
 
 const fakeSystemTime = new Date('2023-01-01').getTime();
 const mockInitialSessionId = '123';
@@ -50,6 +52,9 @@ describe('Persistent Sessions Manager.', () => {
   });
 
   it('Crates a persistent-session-manager instance and initializes it with a new session.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
     const manager = new PersistentSessionsManager(mockInitialSessionId);
 
     expect(typeof manager.updateSession).toBe('function');
@@ -63,9 +68,14 @@ describe('Persistent Sessions Manager.', () => {
         isSampled: false,
       })
     );
+
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
   });
 
   it('Updates last active timestamp for valid session.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
     const validSession = {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
@@ -76,6 +86,7 @@ describe('Persistent Sessions Manager.', () => {
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
 
     const { updateSession } = new PersistentSessionsManager(mockInitialSessionId);
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
     const nextActivityTimeAfterFiveSeconds = fakeSystemTime;
     jest.setSystemTime(nextActivityTimeAfterFiveSeconds);
@@ -91,9 +102,14 @@ describe('Persistent Sessions Manager.', () => {
         isSampled: false,
       })
     );
+
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
   });
 
-  it('Creates a new faro user session if (old) session max inactivity duration is reached.', () => {
+  it('Creates a new Faro user session if (old) session if max inactivity duration is reached.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
     const storedSession = {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
@@ -107,6 +123,7 @@ describe('Persistent Sessions Manager.', () => {
 
     const mockNewSessionId = 'abcde';
     jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
     const maxActivityTimeReached = fakeSystemTime + SESSION_INACTIVITY_TIME;
     jest.setSystemTime(maxActivityTimeReached);
@@ -136,9 +153,15 @@ describe('Persistent Sessions Manager.', () => {
     // Call session created hook
     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
     expect(mockOnNewSessionCreated).toHaveBeenCalledWith(null, matchNewSessionMeta);
+
+    // We calculate a new sampling decision in case we extend a session
+    expect(mockIsSampled).toHaveBeenCalledTimes(2);
   });
 
-  it('Creates a new faro user session if (old) session expiration time is reached.', () => {
+  it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
     const oldStoredMeta = {
       id: 'aaaa',
       attributes: {
@@ -163,6 +186,8 @@ describe('Persistent Sessions Manager.', () => {
 
     const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
     jest.setSystemTime(maxActivityTimeReached);
+
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
     updateSession();
 
@@ -189,5 +214,26 @@ describe('Persistent Sessions Manager.', () => {
     // Call session created hook
     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
     expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
+
+    // We calculate a new sampling decision in case we extend a session
+    expect(mockIsSampled).toHaveBeenCalledTimes(2);
+  });
+
+  it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
+    new PersistentSessionsManager(mockInitialSessionId);
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+    const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+    expect(initialSession.sessionId).toBe(mockInitialSessionId);
+
+    const manualSetSessionId = 'xyz';
+    faro.api.setSession({ id: manualSetSessionId });
+    expect(mockIsSampled).toHaveBeenCalledTimes(2);
+
+    const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+    expect(newSession.sessionId).toBe(manualSetSessionId);
   });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -65,7 +65,7 @@ describe('Persistent Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: fakeSystemTime,
         started: fakeSystemTime,
-        isSampled: false,
+        isSampled: true,
       })
     );
 
@@ -80,7 +80,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
@@ -99,7 +99,7 @@ describe('Persistent Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: nextActivityTimeAfterFiveSeconds,
         started: fakeSystemTime,
-        isSampled: false,
+        isSampled: true,
       })
     );
 
@@ -114,7 +114,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -143,7 +143,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -172,7 +172,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: oldStoredMeta,
     };
 
@@ -204,7 +204,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -112,6 +112,7 @@ describe('Persistent Sessions Manager.', () => {
       id: mockNewSessionId,
       attributes: {
         previousSession: mockInitialSessionId,
+        isSampled: 'true',
       },
     };
     expect(session).toStrictEqual({
@@ -138,6 +139,7 @@ describe('Persistent Sessions Manager.', () => {
       id: 'aaaa',
       attributes: {
         previousSession: 'bbbb',
+        isSampled: 'true',
       },
     };
     const storedSession = {
@@ -168,6 +170,7 @@ describe('Persistent Sessions Manager.', () => {
       id: mockNewSessionId,
       attributes: {
         previousSession: mockInitialSessionId,
+        isSampled: 'true',
       },
     };
     expect(session).toStrictEqual({

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -60,6 +60,7 @@ describe('Persistent Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: fakeSystemTime,
         started: fakeSystemTime,
+        isSampled: false,
       })
     );
   });
@@ -69,6 +70,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
@@ -86,6 +88,7 @@ describe('Persistent Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: nextActivityTimeAfterFiveSeconds,
         started: fakeSystemTime,
+        isSampled: false,
       })
     );
   });
@@ -95,6 +98,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -122,6 +126,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
+      isSampled: false,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -144,6 +149,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
       sessionMeta: oldStoredMeta,
     };
 
@@ -173,6 +179,7 @@ describe('Persistent Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
+      isSampled: false,
       sessionMeta: matchNewSessionMeta,
     });
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -29,6 +29,7 @@ describe('Persistent Sessions Manager.', () => {
 
     const config = mockConfig({
       sessionTracking: {
+        enabled: true,
         persistent: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -44,6 +44,10 @@ describe('Persistent Sessions Manager.', () => {
     mockStorage = {};
   });
 
+  afterEach(() => {
+    jest.spyOn(samplingModule, 'isSampled').mockRestore();
+  });
+
   afterAll(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -13,7 +13,7 @@ export class PersistentSessionsManager {
   private static storageTypeLocal = webStorageType.local;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
 
-  constructor(private initialSessionId?: string) {
+  constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: PersistentSessionsManager.fetchUserSession,
       storeUserSession: PersistentSessionsManager.storeUserSession,
@@ -43,16 +43,6 @@ export class PersistentSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
-    PersistentSessionsManager.storeUserSession(initialUserSession);
-    // faro.api.setSession({
-    //   ...faro.api.getSession(),
-    //   attributes: {
-    //     ...(faro.api.getSession()?.attributes ?? {}),
-    //     isSampled: initialUserSession.isSampled.toString(),
-    //   },
-    // });
-
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
         this.updateSession();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -45,13 +45,13 @@ export class PersistentSessionsManager {
   private init(): void {
     const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
     PersistentSessionsManager.storeUserSession(initialUserSession);
-    faro.api.setSession({
-      ...faro.api.getSession(),
-      attributes: {
-        ...(faro.api.getSession()?.attributes ?? {}),
-        isSampled: initialUserSession.isSampled.toString(),
-      },
-    });
+    // faro.api.setSession({
+    //   ...faro.api.getSession(),
+    //   attributes: {
+    //     ...(faro.api.getSession()?.attributes ?? {}),
+    //     isSampled: initialUserSession.isSampled.toString(),
+    //   },
+    // });
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -4,6 +4,7 @@ import type { Meta } from '@grafana/faro-core';
 import { throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
+import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
 import { addSessionMetadataToNextSession, createUserSessionObject, getUserSessionUpdater } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
@@ -42,7 +43,7 @@ export class PersistentSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    PersistentSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId));
+    PersistentSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId, isSampled()));
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -43,7 +43,15 @@ export class PersistentSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    PersistentSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId, isSampled()));
+    const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
+    PersistentSessionsManager.storeUserSession(initialUserSession);
+    faro.api.setSession({
+      ...faro.api.getSession(),
+      attributes: {
+        ...(faro.api.getSession()?.attributes ?? {}),
+        isSampled: initialUserSession.isSampled.toString(),
+      },
+    });
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -69,7 +69,7 @@ export class PersistentSessionsManager {
 
       if (session && session.id !== sessionFromLocalStorage?.sessionId) {
         const userSession = addSessionMetadataToNextSession(
-          createUserSessionObject(session.id, isSampled()),
+          createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
           sessionFromLocalStorage
         );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -71,7 +71,7 @@ export class PersistentSessionsManager {
 
       if (session && session.id !== sessionFromLocalStorage?.sessionId) {
         const userSession = addSessionMetadataToNextSession(
-          createUserSessionObject(session.id),
+          createUserSessionObject(session.id, isSampled()),
           sessionFromLocalStorage
         );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -58,7 +58,7 @@ export class VolatileSessionsManager {
 
       if (session && session.id !== sessionFromSessionStorage?.sessionId) {
         const userSession = addSessionMetadataToNextSession(
-          createUserSessionObject(session.id),
+          createUserSessionObject(session.id, isSampled()),
           sessionFromSessionStorage
         );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -13,7 +13,7 @@ export class VolatileSessionsManager {
   private static storageTypeSession = webStorageType.session;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
 
-  constructor(private initialSessionId?: string) {
+  constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: VolatileSessionsManager.fetchUserSession,
       storeUserSession: VolatileSessionsManager.storeUserSession,
@@ -43,9 +43,6 @@ export class VolatileSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
-    VolatileSessionsManager.storeUserSession(initialUserSession);
-
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
         this.updateSession();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -43,17 +43,8 @@ export class VolatileSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    // const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
     const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
     VolatileSessionsManager.storeUserSession(initialUserSession);
-
-    // faro.api.setSession({
-    //   ...faro.api.getSession(),
-    //   attributes: {
-    //     ...(faro.api.getSession()?.attributes ?? {}),
-    //     isSampled: initialUserSession.isSampled.toString(),
-    //   },
-    // });
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -43,7 +43,18 @@ export class VolatileSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    VolatileSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId, isSampled()));
+    const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
+    VolatileSessionsManager.storeUserSession(initialUserSession);
+
+    console.log('initialUserSession :>> ', initialUserSession);
+
+    faro.api.setSession({
+      ...faro.api.getSession(),
+      attributes: {
+        ...(faro.api.getSession()?.attributes ?? {}),
+        isSampled: initialUserSession.isSampled.toString(),
+      },
+    });
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -56,7 +56,7 @@ export class VolatileSessionsManager {
 
       if (session && session.id !== sessionFromSessionStorage?.sessionId) {
         const userSession = addSessionMetadataToNextSession(
-          createUserSessionObject(session.id, isSampled()),
+          createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
           sessionFromSessionStorage
         );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -43,18 +43,17 @@ export class VolatileSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
+    // const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
     const initialUserSession = createUserSessionObject(this.initialSessionId, isSampled());
     VolatileSessionsManager.storeUserSession(initialUserSession);
 
-    console.log('initialUserSession :>> ', initialUserSession);
-
-    faro.api.setSession({
-      ...faro.api.getSession(),
-      attributes: {
-        ...(faro.api.getSession()?.attributes ?? {}),
-        isSampled: initialUserSession.isSampled.toString(),
-      },
-    });
+    // faro.api.setSession({
+    //   ...faro.api.getSession(),
+    //   attributes: {
+    //     ...(faro.api.getSession()?.attributes ?? {}),
+    //     isSampled: initialUserSession.isSampled.toString(),
+    //   },
+    // });
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -4,6 +4,7 @@ import type { Meta } from '@grafana/faro-core';
 import { throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
+import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
 import { addSessionMetadataToNextSession, createUserSessionObject, getUserSessionUpdater } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
@@ -42,7 +43,7 @@ export class VolatileSessionsManager {
   updateSession = throttle(() => this.updateUserSession(), STORAGE_UPDATE_DELAY);
 
   private init(): void {
-    VolatileSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId));
+    VolatileSessionsManager.storeUserSession(createUserSessionObject(this.initialSessionId, isSampled()));
 
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -106,6 +106,7 @@ describe('Volatile Sessions Manager.', () => {
       id: mockNewSessionId,
       attributes: {
         previousSession: mockInitialSessionId,
+        isSampled: 'true',
       },
     };
     expect(session).toStrictEqual({
@@ -159,6 +160,7 @@ describe('Volatile Sessions Manager.', () => {
       id: mockNewSessionId,
       attributes: {
         previousSession: mockInitialSessionId,
+        isSampled: 'true',
       },
     };
     expect(session).toStrictEqual({

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -29,7 +29,7 @@ describe('Volatile Sessions Manager.', () => {
 
     const config = mockConfig({
       sessionTracking: {
-        persistent: true,
+        enabled: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,
       },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -65,7 +65,7 @@ describe('Volatile Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: fakeSystemTime,
         started: fakeSystemTime,
-        isSampled: false,
+        isSampled: true,
       })
     );
 
@@ -80,7 +80,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
@@ -99,7 +99,7 @@ describe('Volatile Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: nextActivityTimeAfterFiveSeconds,
         started: fakeSystemTime,
-        isSampled: false,
+        isSampled: true,
       })
     );
 
@@ -115,7 +115,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -144,7 +144,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -173,7 +173,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: oldStoredMeta,
     };
 
@@ -205,7 +205,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
-      isSampled: false,
+      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -3,8 +3,7 @@ import { faro, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import * as samplingModule from './sampling';
-import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
-import type { FaroUserSession } from './types';
+import { SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
 import { VolatileSessionsManager } from './VolatileSessionManager';
 
 const fakeSystemTime = new Date('2023-01-01').getTime();
@@ -51,26 +50,26 @@ describe('Volatile Sessions Manager.', () => {
     setItemSpy.mockRestore();
   });
 
-  it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
-    const mockIsSampled = jest.fn();
-    jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
+  // it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
+  //   const mockIsSampled = jest.fn();
+  //   jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
 
-    const manager = new VolatileSessionsManager(mockInitialSessionId);
+  //   const manager = new VolatileSessionsManager(mockInitialSessionId);
 
-    expect(typeof manager.updateSession).toBe('function');
+  //   expect(typeof manager.updateSession).toBe('function');
 
-    expect(setItemSpy).toHaveBeenCalledTimes(1);
-    expect(mockStorage[STORAGE_KEY]).toBe(
-      JSON.stringify({
-        sessionId: mockInitialSessionId,
-        lastActivity: fakeSystemTime,
-        started: fakeSystemTime,
-        isSampled: true,
-      })
-    );
+  //   expect(setItemSpy).toHaveBeenCalledTimes(1);
+  //   expect(mockStorage[STORAGE_KEY]).toBe(
+  //     JSON.stringify({
+  //       sessionId: mockInitialSessionId,
+  //       lastActivity: fakeSystemTime,
+  //       started: fakeSystemTime,
+  //       isSampled: true,
+  //     })
+  //   );
 
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
-  });
+  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
+  // });
 
   it('Updates last active timestamp for valid session.', () => {
     const mockIsSampled = jest.fn();
@@ -108,6 +107,8 @@ describe('Volatile Sessions Manager.', () => {
   });
 
   it('Creates a new Faro user session if (old) session max inactivity duration is reached.', () => {
+    setItemSpy.mockClear();
+
     const mockIsSampled = jest.fn();
     jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
 
@@ -159,82 +160,82 @@ describe('Volatile Sessions Manager.', () => {
     expect(mockIsSampled).toHaveBeenCalledTimes(2);
   });
 
-  it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
-    const mockIsSampled = jest.fn();
-    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+  // it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
+  //   const mockIsSampled = jest.fn();
+  //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
 
-    const oldStoredMeta = {
-      id: 'aaaa',
-      attributes: {
-        previousSession: 'bbbb',
-      },
-    };
-    const storedSession = {
-      sessionId: mockInitialSessionId,
-      lastActivity: fakeSystemTime,
-      started: fakeSystemTime,
-      isSampled: true,
-      sessionMeta: oldStoredMeta,
-    };
+  //   const oldStoredMeta = {
+  //     id: 'aaaa',
+  //     attributes: {
+  //       previousSession: 'bbbb',
+  //     },
+  //   };
+  //   const storedSession = {
+  //     sessionId: mockInitialSessionId,
+  //     lastActivity: fakeSystemTime,
+  //     started: fakeSystemTime,
+  //     isSampled: true,
+  //     sessionMeta: oldStoredMeta,
+  //   };
 
-    const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
+  //   const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
 
-    // overwrite auto created session
-    mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+  //   // overwrite auto created session
+  //   mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
 
-    const mockNewSessionId = 'abcde';
-    jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
+  //   const mockNewSessionId = 'abcde';
+  //   jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
 
-    const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
-    jest.setSystemTime(maxActivityTimeReached);
+  //   const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
+  //   jest.setSystemTime(maxActivityTimeReached);
 
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
+  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
-    updateSession();
+  //   updateSession();
 
-    // creates and stores new session
-    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+  //   // creates and stores new session
+  //   const session = JSON.parse(mockStorage[STORAGE_KEY]);
 
-    const matchNewSessionMeta = {
-      id: mockNewSessionId,
-      attributes: {
-        previousSession: mockInitialSessionId,
-      },
-    };
-    expect(session).toStrictEqual({
-      sessionId: mockNewSessionId,
-      lastActivity: maxActivityTimeReached,
-      started: maxActivityTimeReached,
-      isSampled: true,
-      sessionMeta: matchNewSessionMeta,
-    });
+  //   const matchNewSessionMeta = {
+  //     id: mockNewSessionId,
+  //     attributes: {
+  //       previousSession: mockInitialSessionId,
+  //     },
+  //   };
+  //   expect(session).toStrictEqual({
+  //     sessionId: mockNewSessionId,
+  //     lastActivity: maxActivityTimeReached,
+  //     started: maxActivityTimeReached,
+  //     isSampled: true,
+  //     sessionMeta: matchNewSessionMeta,
+  //   });
 
-    // Updates session meta
-    expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
+  //   // Updates session meta
+  //   expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
 
-    // Call session created hook
-    expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
-    expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
+  //   // Call session created hook
+  //   expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
+  //   expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
 
-    // We calculate a new sampling decision in case we extend a session
-    expect(mockIsSampled).toHaveBeenCalledTimes(2);
-  });
+  //   // We calculate a new sampling decision in case we extend a session
+  //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
+  // });
 
-  it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
-    const mockIsSampled = jest.fn();
-    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+  // it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
+  //   const mockIsSampled = jest.fn();
+  //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
 
-    new VolatileSessionsManager(mockInitialSessionId);
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
+  //   new VolatileSessionsManager(mockInitialSessionId);
+  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
-    const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-    expect(initialSession.sessionId).toBe(mockInitialSessionId);
+  //   const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+  //   expect(initialSession.sessionId).toBe(mockInitialSessionId);
 
-    const manualSetSessionId = 'xyz';
-    faro.api.setSession({ id: manualSetSessionId });
-    expect(mockIsSampled).toHaveBeenCalledTimes(2);
+  //   const manualSetSessionId = 'xyz';
+  //   faro.api.setSession({ id: manualSetSessionId });
+  //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
 
-    const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-    expect(newSession.sessionId).toBe(manualSetSessionId);
-  });
+  //   const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+  //   expect(newSession.sessionId).toBe(manualSetSessionId);
+  // });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -60,6 +60,7 @@ describe('Volatile Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: fakeSystemTime,
         started: fakeSystemTime,
+        isSampled: false,
       })
     );
   });
@@ -69,6 +70,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
@@ -86,6 +88,7 @@ describe('Volatile Sessions Manager.', () => {
         sessionId: mockInitialSessionId,
         lastActivity: nextActivityTimeAfterFiveSeconds,
         started: fakeSystemTime,
+        isSampled: false,
       })
     );
   });
@@ -95,6 +98,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -122,6 +126,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
+      isSampled: false,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -144,6 +149,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
       sessionMeta: oldStoredMeta,
     };
 
@@ -173,6 +179,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
+      isSampled: false,
       sessionMeta: matchNewSessionMeta,
     });
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -2,7 +2,9 @@ import * as faroCore from '@grafana/faro-core';
 import { faro, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
+import * as samplingModule from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
+import type { FaroUserSession } from './types';
 import { VolatileSessionsManager } from './VolatileSessionManager';
 
 const fakeSystemTime = new Date('2023-01-01').getTime();
@@ -70,13 +72,14 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
 
     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
 
-    const nextActivityTimeAfterFiveSeconds = fakeSystemTime + 5000;
+    const nextActivityTimeAfterFiveSeconds = fakeSystemTime;
     jest.setSystemTime(nextActivityTimeAfterFiveSeconds);
 
     updateSession();
@@ -97,6 +100,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -120,8 +124,6 @@ describe('Volatile Sessions Manager.', () => {
         previousSession: mockInitialSessionId,
       },
     };
-    console.log('session :>> ', session);
-
     expect(session).toStrictEqual({
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
@@ -150,6 +152,7 @@ describe('Volatile Sessions Manager.', () => {
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
       sessionMeta: oldStoredMeta,
+      isSampled: true,
     };
 
     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
@@ -178,6 +181,7 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
+      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -188,246 +192,22 @@ describe('Volatile Sessions Manager.', () => {
     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
     expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
   });
+
+  it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
+    const mockIsSampled = jest.fn();
+    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
+    new VolatileSessionsManager(mockInitialSessionId);
+    expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+    const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+    expect(initialSession.sessionId).toBe(mockInitialSessionId);
+
+    const manualSetSessionId = 'xyz';
+    faro.api.setSession({ id: manualSetSessionId });
+    expect(mockIsSampled).toHaveBeenCalledTimes(2);
+
+    const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+    expect(newSession.sessionId).toBe(manualSetSessionId);
+  });
 });
-
-// import * as faroCore from '@grafana/faro-core';
-// import { faro, initializeFaro } from '@grafana/faro-core';
-// import { mockConfig } from '@grafana/faro-core/src/testUtils';
-
-// import * as samplingModule from './sampling';
-// import { SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
-// import { VolatileSessionsManager } from './VolatileSessionManager';
-
-// const fakeSystemTime = new Date('2023-01-01').getTime();
-// const mockInitialSessionId = '123';
-
-// describe('Volatile Sessions Manager.', () => {
-//   let mockStorage: Record<string, string> = {};
-//   let setItemSpy: jest.SpyInstance<void, [key: string, value: string]>;
-//   let getItemSpy: jest.SpyInstance<string | null, [key: string]>;
-
-//   let mockOnNewSessionCreated = jest.fn();
-
-//   beforeAll(() => {
-//     jest.useFakeTimers();
-//     jest.setSystemTime(fakeSystemTime);
-
-//     setItemSpy = jest.spyOn(global.Storage.prototype, 'setItem').mockImplementation((key, value) => {
-//       mockStorage[key] = value;
-//     });
-
-//     getItemSpy = jest.spyOn(global.Storage.prototype, 'getItem').mockImplementation((key) => mockStorage[key] ?? null);
-
-//     const config = mockConfig({
-//       sessionTracking: {
-//         persistent: true,
-//         session: { id: mockInitialSessionId },
-//         onSessionChange: mockOnNewSessionCreated,
-//       },
-//     });
-
-//     initializeFaro(config);
-//   });
-
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//     mockStorage = {};
-//   });
-
-//   afterAll(() => {
-//     jest.useRealTimers();
-//     jest.restoreAllMocks();
-
-//     getItemSpy.mockRestore();
-//     setItemSpy.mockRestore();
-//   });
-
-//   // it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
-//   //   const mockIsSampled = jest.fn();
-//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
-
-//   //   const manager = new VolatileSessionsManager(mockInitialSessionId);
-
-//   //   expect(typeof manager.updateSession).toBe('function');
-
-//   //   expect(setItemSpy).toHaveBeenCalledTimes(1);
-//   //   expect(mockStorage[STORAGE_KEY]).toBe(
-//   //     JSON.stringify({
-//   //       sessionId: mockInitialSessionId,
-//   //       lastActivity: fakeSystemTime,
-//   //       started: fakeSystemTime,
-//   //       isSampled: true,
-//   //     })
-//   //   );
-
-//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-//   // });
-
-//   it('Updates last active timestamp for valid session.', () => {
-//     const mockIsSampled = jest.fn();
-//     jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
-
-//     const validSession = {
-//       sessionId: mockInitialSessionId,
-//       lastActivity: fakeSystemTime,
-//       started: fakeSystemTime,
-//       isSampled: true,
-//     };
-
-//     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
-
-//     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
-//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-//     const nextActivityTimeAfterFiveSeconds = fakeSystemTime;
-//     jest.setSystemTime(nextActivityTimeAfterFiveSeconds);
-
-//     updateSession();
-
-//     expect(setItemSpy).toBeCalledTimes(2); // called on time in the init function and the in the onActivity func
-//     expect(mockStorage[STORAGE_KEY]).toBe(
-//       JSON.stringify({
-//         sessionId: mockInitialSessionId,
-//         lastActivity: nextActivityTimeAfterFiveSeconds,
-//         started: fakeSystemTime,
-//         isSampled: true,
-//       })
-//     );
-
-//     // we do not recalculate if we only update a session
-//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
-//   });
-
-//   it('Creates a new Faro user session if (old) session max inactivity duration is reached.', () => {
-//     setItemSpy.mockClear();
-
-//     const mockIsSampled = jest.fn();
-//     jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
-//     const storedSession = {
-//       sessionId: mockInitialSessionId,
-//       lastActivity: fakeSystemTime,
-//       started: fakeSystemTime,
-//       isSampled: true,
-//     };
-
-//     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
-
-//     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
-
-//     const mockNewSessionId = 'abcde';
-//     jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
-
-//     const maxActivityTimeReached = fakeSystemTime + SESSION_INACTIVITY_TIME;
-//     jest.setSystemTime(maxActivityTimeReached);
-//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-//     updateSession();
-
-//     // creates and stores new session
-//     const session = JSON.parse(mockStorage[STORAGE_KEY]);
-
-//     const matchNewSessionMeta = {
-//       id: mockNewSessionId,
-//       attributes: {
-//         previousSession: mockInitialSessionId,
-//       },
-//     };
-//     expect(session).toStrictEqual({
-//       sessionId: mockNewSessionId,
-//       lastActivity: maxActivityTimeReached,
-//       started: maxActivityTimeReached,
-//       isSampled: true,
-//       sessionMeta: matchNewSessionMeta,
-//     });
-
-//     // Updates session meta
-//     expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
-
-//     // Call session created hook
-//     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
-//     expect(mockOnNewSessionCreated).toHaveBeenCalledWith(null, matchNewSessionMeta);
-
-//     // We calculate a new sampling decision in case we extend a session
-//     expect(mockIsSampled).toHaveBeenCalledTimes(2);
-//   });
-
-//   // it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
-//   //   const mockIsSampled = jest.fn();
-//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
-//   //   const oldStoredMeta = {
-//   //     id: 'aaaa',
-//   //     attributes: {
-//   //       previousSession: 'bbbb',
-//   //     },
-//   //   };
-//   //   const storedSession = {
-//   //     sessionId: mockInitialSessionId,
-//   //     lastActivity: fakeSystemTime,
-//   //     started: fakeSystemTime,
-//   //     isSampled: true,
-//   //     sessionMeta: oldStoredMeta,
-//   //   };
-
-//   //   const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
-
-//   //   // overwrite auto created session
-//   //   mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
-
-//   //   const mockNewSessionId = 'abcde';
-//   //   jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
-
-//   //   const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
-//   //   jest.setSystemTime(maxActivityTimeReached);
-
-//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-//   //   updateSession();
-
-//   //   // creates and stores new session
-//   //   const session = JSON.parse(mockStorage[STORAGE_KEY]);
-
-//   //   const matchNewSessionMeta = {
-//   //     id: mockNewSessionId,
-//   //     attributes: {
-//   //       previousSession: mockInitialSessionId,
-//   //     },
-//   //   };
-//   //   expect(session).toStrictEqual({
-//   //     sessionId: mockNewSessionId,
-//   //     lastActivity: maxActivityTimeReached,
-//   //     started: maxActivityTimeReached,
-//   //     isSampled: true,
-//   //     sessionMeta: matchNewSessionMeta,
-//   //   });
-
-//   //   // Updates session meta
-//   //   expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
-
-//   //   // Call session created hook
-//   //   expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
-//   //   expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
-
-//   //   // We calculate a new sampling decision in case we extend a session
-//   //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
-//   // });
-
-//   // it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
-//   //   const mockIsSampled = jest.fn();
-//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
-//   //   new VolatileSessionsManager(mockInitialSessionId);
-//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-//   //   const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-//   //   expect(initialSession.sessionId).toBe(mockInitialSessionId);
-
-//   //   const manualSetSessionId = 'xyz';
-//   //   faro.api.setSession({ id: manualSetSessionId });
-//   //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
-
-//   //   const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-//   //   expect(newSession.sessionId).toBe(manualSetSessionId);
-//   // });
-// });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -43,6 +43,10 @@ describe('Volatile Sessions Manager.', () => {
     mockStorage = {};
   });
 
+  afterEach(() => {
+    jest.spyOn(samplingModule, 'isSampled').mockRestore();
+  });
+
   afterAll(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -2,8 +2,7 @@ import * as faroCore from '@grafana/faro-core';
 import { faro, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
-import * as samplingModule from './sampling';
-import { SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
+import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
 import { VolatileSessionsManager } from './VolatileSessionManager';
 
 const fakeSystemTime = new Date('2023-01-01').getTime();
@@ -50,44 +49,34 @@ describe('Volatile Sessions Manager.', () => {
     setItemSpy.mockRestore();
   });
 
-  // it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
-  //   const mockIsSampled = jest.fn();
-  //   jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
+  it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
+    const manager = new VolatileSessionsManager(mockInitialSessionId);
 
-  //   const manager = new VolatileSessionsManager(mockInitialSessionId);
+    expect(typeof manager.updateSession).toBe('function');
 
-  //   expect(typeof manager.updateSession).toBe('function');
-
-  //   expect(setItemSpy).toHaveBeenCalledTimes(1);
-  //   expect(mockStorage[STORAGE_KEY]).toBe(
-  //     JSON.stringify({
-  //       sessionId: mockInitialSessionId,
-  //       lastActivity: fakeSystemTime,
-  //       started: fakeSystemTime,
-  //       isSampled: true,
-  //     })
-  //   );
-
-  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-  // });
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(mockStorage[STORAGE_KEY]).toBe(
+      JSON.stringify({
+        sessionId: mockInitialSessionId,
+        lastActivity: fakeSystemTime,
+        started: fakeSystemTime,
+        isSampled: true,
+      })
+    );
+  });
 
   it('Updates last active timestamp for valid session.', () => {
-    const mockIsSampled = jest.fn();
-    jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
-
     const validSession = {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
 
     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
 
-    const nextActivityTimeAfterFiveSeconds = fakeSystemTime;
+    const nextActivityTimeAfterFiveSeconds = fakeSystemTime + 5000;
     jest.setSystemTime(nextActivityTimeAfterFiveSeconds);
 
     updateSession();
@@ -101,22 +90,13 @@ describe('Volatile Sessions Manager.', () => {
         isSampled: true,
       })
     );
-
-    // we do not recalculate if we only update a session
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
   });
 
-  it('Creates a new Faro user session if (old) session max inactivity duration is reached.', () => {
-    setItemSpy.mockClear();
-
-    const mockIsSampled = jest.fn();
-    jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
+  it('Creates a new faro user session if (old) session max inactivity duration is reached.', () => {
     const storedSession = {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: true,
     };
 
     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
@@ -128,7 +108,60 @@ describe('Volatile Sessions Manager.', () => {
 
     const maxActivityTimeReached = fakeSystemTime + SESSION_INACTIVITY_TIME;
     jest.setSystemTime(maxActivityTimeReached);
-    expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+    updateSession();
+
+    // creates and stores new session
+    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+
+    const matchNewSessionMeta = {
+      id: mockNewSessionId,
+      attributes: {
+        previousSession: mockInitialSessionId,
+      },
+    };
+    console.log('session :>> ', session);
+
+    expect(session).toStrictEqual({
+      sessionId: mockNewSessionId,
+      lastActivity: maxActivityTimeReached,
+      started: maxActivityTimeReached,
+      isSampled: true,
+      sessionMeta: matchNewSessionMeta,
+    });
+
+    // Updates session meta
+    expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
+
+    // Call session created hook
+    expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
+    expect(mockOnNewSessionCreated).toHaveBeenCalledWith(null, matchNewSessionMeta);
+  });
+
+  it('Creates a new faro user session if (old) session expiration time is reached.', () => {
+    const oldStoredMeta = {
+      id: 'aaaa',
+      attributes: {
+        previousSession: 'bbbb',
+      },
+    };
+    const storedSession = {
+      sessionId: mockInitialSessionId,
+      lastActivity: fakeSystemTime,
+      started: fakeSystemTime,
+      sessionMeta: oldStoredMeta,
+    };
+
+    const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
+
+    // overwrite auto created session
+    mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+
+    const mockNewSessionId = 'abcde';
+    jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
+
+    const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
+    jest.setSystemTime(maxActivityTimeReached);
 
     updateSession();
 
@@ -145,7 +178,6 @@ describe('Volatile Sessions Manager.', () => {
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
-      isSampled: true,
       sessionMeta: matchNewSessionMeta,
     });
 
@@ -154,88 +186,248 @@ describe('Volatile Sessions Manager.', () => {
 
     // Call session created hook
     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
-    expect(mockOnNewSessionCreated).toHaveBeenCalledWith(null, matchNewSessionMeta);
-
-    // We calculate a new sampling decision in case we extend a session
-    expect(mockIsSampled).toHaveBeenCalledTimes(2);
+    expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
   });
-
-  // it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
-  //   const mockIsSampled = jest.fn();
-  //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
-  //   const oldStoredMeta = {
-  //     id: 'aaaa',
-  //     attributes: {
-  //       previousSession: 'bbbb',
-  //     },
-  //   };
-  //   const storedSession = {
-  //     sessionId: mockInitialSessionId,
-  //     lastActivity: fakeSystemTime,
-  //     started: fakeSystemTime,
-  //     isSampled: true,
-  //     sessionMeta: oldStoredMeta,
-  //   };
-
-  //   const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
-
-  //   // overwrite auto created session
-  //   mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
-
-  //   const mockNewSessionId = 'abcde';
-  //   jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
-
-  //   const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
-  //   jest.setSystemTime(maxActivityTimeReached);
-
-  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-  //   updateSession();
-
-  //   // creates and stores new session
-  //   const session = JSON.parse(mockStorage[STORAGE_KEY]);
-
-  //   const matchNewSessionMeta = {
-  //     id: mockNewSessionId,
-  //     attributes: {
-  //       previousSession: mockInitialSessionId,
-  //     },
-  //   };
-  //   expect(session).toStrictEqual({
-  //     sessionId: mockNewSessionId,
-  //     lastActivity: maxActivityTimeReached,
-  //     started: maxActivityTimeReached,
-  //     isSampled: true,
-  //     sessionMeta: matchNewSessionMeta,
-  //   });
-
-  //   // Updates session meta
-  //   expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
-
-  //   // Call session created hook
-  //   expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
-  //   expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
-
-  //   // We calculate a new sampling decision in case we extend a session
-  //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
-  // });
-
-  // it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
-  //   const mockIsSampled = jest.fn();
-  //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
-
-  //   new VolatileSessionsManager(mockInitialSessionId);
-  //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
-
-  //   const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-  //   expect(initialSession.sessionId).toBe(mockInitialSessionId);
-
-  //   const manualSetSessionId = 'xyz';
-  //   faro.api.setSession({ id: manualSetSessionId });
-  //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
-
-  //   const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
-  //   expect(newSession.sessionId).toBe(manualSetSessionId);
-  // });
 });
+
+// import * as faroCore from '@grafana/faro-core';
+// import { faro, initializeFaro } from '@grafana/faro-core';
+// import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+// import * as samplingModule from './sampling';
+// import { SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionConstants';
+// import { VolatileSessionsManager } from './VolatileSessionManager';
+
+// const fakeSystemTime = new Date('2023-01-01').getTime();
+// const mockInitialSessionId = '123';
+
+// describe('Volatile Sessions Manager.', () => {
+//   let mockStorage: Record<string, string> = {};
+//   let setItemSpy: jest.SpyInstance<void, [key: string, value: string]>;
+//   let getItemSpy: jest.SpyInstance<string | null, [key: string]>;
+
+//   let mockOnNewSessionCreated = jest.fn();
+
+//   beforeAll(() => {
+//     jest.useFakeTimers();
+//     jest.setSystemTime(fakeSystemTime);
+
+//     setItemSpy = jest.spyOn(global.Storage.prototype, 'setItem').mockImplementation((key, value) => {
+//       mockStorage[key] = value;
+//     });
+
+//     getItemSpy = jest.spyOn(global.Storage.prototype, 'getItem').mockImplementation((key) => mockStorage[key] ?? null);
+
+//     const config = mockConfig({
+//       sessionTracking: {
+//         persistent: true,
+//         session: { id: mockInitialSessionId },
+//         onSessionChange: mockOnNewSessionCreated,
+//       },
+//     });
+
+//     initializeFaro(config);
+//   });
+
+//   beforeEach(() => {
+//     jest.clearAllMocks();
+//     mockStorage = {};
+//   });
+
+//   afterAll(() => {
+//     jest.useRealTimers();
+//     jest.restoreAllMocks();
+
+//     getItemSpy.mockRestore();
+//     setItemSpy.mockRestore();
+//   });
+
+//   // it('Crates a volatile-session-manager instance and initializes it with a new session.', () => {
+//   //   const mockIsSampled = jest.fn();
+//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
+
+//   //   const manager = new VolatileSessionsManager(mockInitialSessionId);
+
+//   //   expect(typeof manager.updateSession).toBe('function');
+
+//   //   expect(setItemSpy).toHaveBeenCalledTimes(1);
+//   //   expect(mockStorage[STORAGE_KEY]).toBe(
+//   //     JSON.stringify({
+//   //       sessionId: mockInitialSessionId,
+//   //       lastActivity: fakeSystemTime,
+//   //       started: fakeSystemTime,
+//   //       isSampled: true,
+//   //     })
+//   //   );
+
+//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
+//   // });
+
+//   it('Updates last active timestamp for valid session.', () => {
+//     const mockIsSampled = jest.fn();
+//     jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
+
+//     const validSession = {
+//       sessionId: mockInitialSessionId,
+//       lastActivity: fakeSystemTime,
+//       started: fakeSystemTime,
+//       isSampled: true,
+//     };
+
+//     mockStorage[STORAGE_KEY] = JSON.stringify(validSession);
+
+//     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
+//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+//     const nextActivityTimeAfterFiveSeconds = fakeSystemTime;
+//     jest.setSystemTime(nextActivityTimeAfterFiveSeconds);
+
+//     updateSession();
+
+//     expect(setItemSpy).toBeCalledTimes(2); // called on time in the init function and the in the onActivity func
+//     expect(mockStorage[STORAGE_KEY]).toBe(
+//       JSON.stringify({
+//         sessionId: mockInitialSessionId,
+//         lastActivity: nextActivityTimeAfterFiveSeconds,
+//         started: fakeSystemTime,
+//         isSampled: true,
+//       })
+//     );
+
+//     // we do not recalculate if we only update a session
+//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
+//   });
+
+//   it('Creates a new Faro user session if (old) session max inactivity duration is reached.', () => {
+//     setItemSpy.mockClear();
+
+//     const mockIsSampled = jest.fn();
+//     jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
+//     const storedSession = {
+//       sessionId: mockInitialSessionId,
+//       lastActivity: fakeSystemTime,
+//       started: fakeSystemTime,
+//       isSampled: true,
+//     };
+
+//     mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+
+//     const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
+
+//     const mockNewSessionId = 'abcde';
+//     jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
+
+//     const maxActivityTimeReached = fakeSystemTime + SESSION_INACTIVITY_TIME;
+//     jest.setSystemTime(maxActivityTimeReached);
+//     expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+//     updateSession();
+
+//     // creates and stores new session
+//     const session = JSON.parse(mockStorage[STORAGE_KEY]);
+
+//     const matchNewSessionMeta = {
+//       id: mockNewSessionId,
+//       attributes: {
+//         previousSession: mockInitialSessionId,
+//       },
+//     };
+//     expect(session).toStrictEqual({
+//       sessionId: mockNewSessionId,
+//       lastActivity: maxActivityTimeReached,
+//       started: maxActivityTimeReached,
+//       isSampled: true,
+//       sessionMeta: matchNewSessionMeta,
+//     });
+
+//     // Updates session meta
+//     expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
+
+//     // Call session created hook
+//     expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
+//     expect(mockOnNewSessionCreated).toHaveBeenCalledWith(null, matchNewSessionMeta);
+
+//     // We calculate a new sampling decision in case we extend a session
+//     expect(mockIsSampled).toHaveBeenCalledTimes(2);
+//   });
+
+//   // it('Creates a new Faro user session if (old) session expiration time is reached.', () => {
+//   //   const mockIsSampled = jest.fn();
+//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
+//   //   const oldStoredMeta = {
+//   //     id: 'aaaa',
+//   //     attributes: {
+//   //       previousSession: 'bbbb',
+//   //     },
+//   //   };
+//   //   const storedSession = {
+//   //     sessionId: mockInitialSessionId,
+//   //     lastActivity: fakeSystemTime,
+//   //     started: fakeSystemTime,
+//   //     isSampled: true,
+//   //     sessionMeta: oldStoredMeta,
+//   //   };
+
+//   //   const { updateSession } = new VolatileSessionsManager(mockInitialSessionId);
+
+//   //   // overwrite auto created session
+//   //   mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+
+//   //   const mockNewSessionId = 'abcde';
+//   //   jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockNewSessionId);
+
+//   //   const maxActivityTimeReached = fakeSystemTime + SESSION_EXPIRATION_TIME;
+//   //   jest.setSystemTime(maxActivityTimeReached);
+
+//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+//   //   updateSession();
+
+//   //   // creates and stores new session
+//   //   const session = JSON.parse(mockStorage[STORAGE_KEY]);
+
+//   //   const matchNewSessionMeta = {
+//   //     id: mockNewSessionId,
+//   //     attributes: {
+//   //       previousSession: mockInitialSessionId,
+//   //     },
+//   //   };
+//   //   expect(session).toStrictEqual({
+//   //     sessionId: mockNewSessionId,
+//   //     lastActivity: maxActivityTimeReached,
+//   //     started: maxActivityTimeReached,
+//   //     isSampled: true,
+//   //     sessionMeta: matchNewSessionMeta,
+//   //   });
+
+//   //   // Updates session meta
+//   //   expect(faro.metas.value.session).toStrictEqual(matchNewSessionMeta);
+
+//   //   // Call session created hook
+//   //   expect(mockOnNewSessionCreated).toHaveBeenCalledTimes(1);
+//   //   expect(mockOnNewSessionCreated).toHaveBeenCalledWith(oldStoredMeta, matchNewSessionMeta);
+
+//   //   // We calculate a new sampling decision in case we extend a session
+//   //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
+//   // });
+
+//   // it('Creates a new Faro user session if a new session is created with the setSession function.', () => {
+//   //   const mockIsSampled = jest.fn();
+//   //   jest.spyOn(samplingModule, 'isSampled').mockImplementation(mockIsSampled);
+
+//   //   new VolatileSessionsManager(mockInitialSessionId);
+//   //   expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+//   //   const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+//   //   expect(initialSession.sessionId).toBe(mockInitialSessionId);
+
+//   //   const manualSetSessionId = 'xyz';
+//   //   faro.api.setSession({ id: manualSetSessionId });
+//   //   expect(mockIsSampled).toHaveBeenCalledTimes(2);
+
+//   //   const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+//   //   expect(newSession.sessionId).toBe(manualSetSessionId);
+//   // });
+// });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
@@ -1,7 +1,16 @@
 export { PersistentSessionsManager } from './PersistentSessionsManager';
 export { VolatileSessionsManager } from './VolatileSessionManager';
 
-export * from './sessionConstants';
-export * from './sampling';
+export {
+  MAX_SESSION_PERSISTENCE_TIME,
+  MAX_SESSION_PERSISTENCE_TIME_BUFFER,
+  SESSION_EXPIRATION_TIME,
+  SESSION_INACTIVITY_TIME,
+  STORAGE_KEY,
+  STORAGE_UPDATE_DELAY,
+  defaultSessionTrackingConfig,
+} from './sessionConstants';
+
+export { isSampled } from './sampling';
 
 export type { FaroUserSession } from './types';

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
@@ -1,4 +1,7 @@
 export { PersistentSessionsManager } from './PersistentSessionsManager';
 export { VolatileSessionsManager } from './VolatileSessionManager';
+
 export * from './sessionConstants';
+export * from './sampling';
+
 export type { FaroUserSession } from './types';

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.test.ts
@@ -1,0 +1,73 @@
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { createSession } from '../../../metas';
+
+import { isSampled } from './sampling';
+
+describe('Sampling.', () => {
+  afterEach(() => {
+    jest.spyOn(global.Math, 'random').mockRestore();
+  });
+
+  it('Returns false if sampleRate is not of type number.', () => {
+    const config = mockConfig({
+      sessionTracking: {
+        enabled: true,
+        samplingRate: 'hello' as any,
+      },
+    });
+
+    initializeFaro(config);
+
+    expect(isSampled()).toBe(false);
+  });
+
+  it('Returns proper sampling decision for configured samplingRate.', () => {
+    let config = mockConfig({
+      sessionTracking: {
+        enabled: true,
+        samplingRate: 1,
+      },
+    });
+
+    initializeFaro(config);
+    expect(isSampled()).toBe(true);
+
+    config.sessionTracking!.samplingRate = 0;
+    initializeFaro(config);
+    expect(isSampled()).toBe(false);
+  });
+
+  it('Returns proper sampling decision for rate returned by sampler function.', () => {
+    let config = mockConfig({
+      sessionTracking: {
+        enabled: true,
+        sampler: () => {
+          return 1;
+        },
+      },
+    });
+
+    initializeFaro(config);
+    expect(isSampled()).toBe(true);
+
+    config.sessionTracking!.sampler = () => 0;
+    initializeFaro(config);
+    expect(isSampled()).toBe(false);
+
+    config.sessionTracking!.session = createSession({ location: 'moon' });
+    config.sessionTracking!.sampler = ({ metas }) => {
+      if (metas.session?.attributes?.['location'] === 'moon') {
+        return 0;
+      }
+      return 1;
+    };
+    initializeFaro(config);
+    expect(isSampled()).toBe(false);
+
+    config.sessionTracking!.session = createSession({ location: 'mars' });
+    initializeFaro(config);
+    expect(isSampled()).toBe(true);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,11 +1,20 @@
 import { faro } from '@grafana/faro-core';
 
 export function isSampled() {
+  const sendAllSignals = 1;
   const sessionTracking = faro.config.sessionTracking;
-  const samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate;
+  let samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate ?? sendAllSignals;
 
-  if (typeof samplingRate !== 'number' || samplingRate > 1 || samplingRate < 0) {
+  if (typeof samplingRate !== 'number') {
     return false;
+  }
+
+  if (samplingRate > 1) {
+    samplingRate = 1;
+  }
+
+  if (samplingRate < 0) {
+    samplingRate = 0;
   }
 
   return Math.random() < samplingRate;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -7,7 +7,8 @@ export function isSampled() {
     sessionTracking?.sampler?.({ metas: faro.metas.value }) ?? sessionTracking?.samplingRate ?? sendAllSignals;
 
   if (typeof samplingRate !== 'number') {
-    return false;
+    const sendNoSignals = 0;
+    samplingRate = sendNoSignals;
   }
 
   return Math.random() < samplingRate;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,6 +1,6 @@
 import { faro } from '@grafana/faro-core';
 
-export function isSampled() {
+export function isSampled(): boolean {
   const sendAllSignals = 1;
   const sessionTracking = faro.config.sessionTracking;
   let samplingRate =

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,9 +1,8 @@
 import { faro } from '@grafana/faro-core';
 
 export function isSampled() {
-  const samplingOff = 0;
   const sessionTracking = faro.config.sessionTracking;
-  const samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate ?? samplingOff;
+  const samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate;
 
   if (typeof samplingRate !== 'number') {
     return false;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -4,7 +4,7 @@ export function isSampled() {
   const sessionTracking = faro.config.sessionTracking;
   const samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate;
 
-  if (typeof samplingRate !== 'number') {
+  if (typeof samplingRate !== 'number' || samplingRate > 1 || samplingRate < 0) {
     return false;
   }
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -3,27 +3,12 @@ import { faro } from '@grafana/faro-core';
 export function isSampled() {
   const sendAllSignals = 1;
   const sessionTracking = faro.config.sessionTracking;
-  let samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate ?? sendAllSignals;
+  let samplingRate =
+    sessionTracking?.sampler?.({ metas: faro.metas.value }) ?? sessionTracking?.samplingRate ?? sendAllSignals;
 
   if (typeof samplingRate !== 'number') {
     return false;
   }
 
-  if (samplingRate > 1) {
-    samplingRate = 1;
-  }
-
-  if (samplingRate < 0) {
-    samplingRate = 0;
-  }
-
-  const random = Math.random();
-
-  if (samplingRate === 0.5) {
-    console.log('samplingRate :>> ', samplingRate);
-    console.log('random :>> ', random);
-    console.log('random < samplingRate :>> ', random < samplingRate);
-  }
-
-  return random < samplingRate;
+  return Math.random() < samplingRate;
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -17,5 +17,13 @@ export function isSampled() {
     samplingRate = 0;
   }
 
-  return Math.random() < samplingRate;
+  const random = Math.random();
+
+  if (samplingRate === 0.5) {
+    console.log('samplingRate :>> ', samplingRate);
+    console.log('random :>> ', random);
+    console.log('random < samplingRate :>> ', random < samplingRate);
+  }
+
+  return random < samplingRate;
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,5 +1,11 @@
-export function isSampled(samplingRate: number) {
-  if (Number.isNaN(samplingRate)) {
+import { faro } from '@grafana/faro-core';
+
+export function isSampled() {
+  const samplingOff = 0;
+  const sessionTracking = faro.config.sessionTracking;
+  const samplingRate = sessionTracking?.sampler?.(faro.metas.value) ?? sessionTracking?.samplingRate ?? samplingOff;
+
+  if (typeof samplingRate !== 'number') {
     return false;
   }
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,0 +1,7 @@
+export function isSampled(samplingRate: number) {
+  if (Number.isNaN(samplingRate)) {
+    return false;
+  }
+
+  return Math.random() < samplingRate;
+}

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
@@ -1,3 +1,5 @@
+import type { Config } from '@grafana/faro-core';
+
 export const STORAGE_KEY = '__FARO_SESSION__';
 export const SESSION_EXPIRATION_TIME = 4 * 60 * 60 * 1000; // hrs
 export const SESSION_INACTIVITY_TIME = 15 * 60 * 1000; // minutes
@@ -6,7 +8,7 @@ export const STORAGE_UPDATE_DELAY = 1 * 1000; // seconds
 export const MAX_SESSION_PERSISTENCE_TIME_BUFFER = 5 * 60 * 1000;
 export const MAX_SESSION_PERSISTENCE_TIME = SESSION_EXPIRATION_TIME + MAX_SESSION_PERSISTENCE_TIME_BUFFER;
 
-export const defaultSessionTrackingConfig = {
+export const defaultSessionTrackingConfig: Config['sessionTracking'] = {
   enabled: false,
   persistent: false,
   maxSessionPersistenceTime: MAX_SESSION_PERSISTENCE_TIME,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -41,7 +41,7 @@ describe('sessionManagerUtils', () => {
       sessionId: mockSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     });
 
     // create with given sessionId
@@ -52,7 +52,7 @@ describe('sessionManagerUtils', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
-      isSampled: false,
+      isSampled: true,
     });
   });
 
@@ -207,7 +207,7 @@ describe('sessionManagerUtils', () => {
       lastActivity: 1,
       started: 2,
       sessionId: 'new-session-id',
-      isSampled: false,
+      isSampled: true,
     };
 
     const sessionWithMetadata1 = addSessionMetadataToNextSession(newSession, null);
@@ -223,7 +223,7 @@ describe('sessionManagerUtils', () => {
       lastActivity: 8,
       started: 9,
       sessionId: 'previous-session-id',
-      isSampled: false,
+      isSampled: true,
     };
 
     const sessionWithMetadata2 = addSessionMetadataToNextSession(newSession, previousSession);

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -137,16 +137,23 @@ describe('sessionManagerUtils', () => {
       id: mockSessionId,
       attributes: {
         previousSession: 'abc',
+        isSampled: 'true',
       },
     });
 
-    expect(mockOnSessionChange).toHaveBeenCalledWith(null, { attributes: { previousSession: 'abc' }, id: '123' });
+    expect(mockOnSessionChange).toHaveBeenCalledWith(null, {
+      attributes: { previousSession: 'abc', isSampled: 'true' },
+      id: '123',
+    });
   });
 
   it('configures userSessionUpdater and expands the current user session as well as the current sessionMeta for a session which already got expanded.', () => {
     const currentSessionMeta = {
       id: 'currentSession',
-      attributes: { previousSession: 'previous' },
+      attributes: {
+        previousSession: 'previous',
+        isSampled: 'true',
+      },
     };
 
     const mockOnSessionChange = jest.fn();
@@ -191,6 +198,7 @@ describe('sessionManagerUtils', () => {
       id: nextSessionId,
       attributes: {
         previousSession: currentSessionMeta.id,
+        isSampled: 'true',
       },
     };
 
@@ -216,6 +224,9 @@ describe('sessionManagerUtils', () => {
       ...newSession,
       sessionMeta: {
         id: newSession.sessionId,
+        attributes: {
+          isSampled: 'true',
+        },
       },
     });
 
@@ -234,6 +245,7 @@ describe('sessionManagerUtils', () => {
         id: newSession.sessionId,
         attributes: {
           previousSession: previousSession.sessionId,
+          isSampled: 'true',
         },
       },
     });
@@ -260,6 +272,7 @@ describe('sessionManagerUtils', () => {
         id: newSession.sessionId,
         attributes: {
           ...sessionMeta.attributes,
+          isSampled: 'true',
           previousSession: previousSession.sessionId,
         },
       },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -46,7 +46,7 @@ describe('sessionManagerUtils', () => {
 
     // create with given sessionId
     const mockInitialSessionId = 'abcde';
-    const newSessionWithInitialSessionId = createUserSessionObject(mockInitialSessionId);
+    const newSessionWithInitialSessionId = createUserSessionObject({ sessionId: mockInitialSessionId });
 
     expect(newSessionWithInitialSessionId).toStrictEqual({
       sessionId: mockInitialSessionId,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -41,6 +41,7 @@ describe('sessionManagerUtils', () => {
       sessionId: mockSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     });
 
     // create with given sessionId
@@ -51,6 +52,7 @@ describe('sessionManagerUtils', () => {
       sessionId: mockInitialSessionId,
       lastActivity: fakeSystemTime,
       started: fakeSystemTime,
+      isSampled: false,
     });
   });
 
@@ -205,6 +207,7 @@ describe('sessionManagerUtils', () => {
       lastActivity: 1,
       started: 2,
       sessionId: 'new-session-id',
+      isSampled: false,
     };
 
     const sessionWithMetadata1 = addSessionMetadataToNextSession(newSession, null);
@@ -220,6 +223,7 @@ describe('sessionManagerUtils', () => {
       lastActivity: 8,
       started: 9,
       sessionId: 'previous-session-id',
+      isSampled: false,
     };
 
     const sessionWithMetadata2 = addSessionMetadataToNextSession(newSession, previousSession);

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -55,7 +55,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
 
       storeUserSession(newSession);
 
-      // faro.api?.setSession(newSession.sessionMeta);
+      faro.api?.setSession(newSession.sessionMeta);
       faro.config.sessionTracking?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
     }
   };

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -3,13 +3,14 @@ import { dateNow, faro, genShortID } from '@grafana/faro-core';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import type { FaroUserSession } from './types';
 
-export function createUserSessionObject(sessionId?: string): FaroUserSession {
+export function createUserSessionObject(sessionId: string = genShortID(), isSampled = false): FaroUserSession {
   const now = dateNow();
 
   return {
-    sessionId: sessionId ?? genShortID(),
+    sessionId,
     lastActivity: now,
     started: now,
+    isSampled: isSampled,
   };
 }
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -5,7 +5,7 @@ import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConst
 import type { FaroUserSession } from './types';
 
 // TODO: use params object
-export function createUserSessionObject(sessionId: string = genShortID(), isSampled = false): FaroUserSession {
+export function createUserSessionObject(sessionId: string = genShortID(), isSampled = true): FaroUserSession {
   const now = dateNow();
 
   return {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -4,8 +4,15 @@ import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import type { FaroUserSession } from './types';
 
-// TODO: use params object
-export function createUserSessionObject(sessionId: string = genShortID(), isSampled = true): FaroUserSession {
+type CreateUserSessionObjectParams = {
+  sessionId?: string;
+  isSampled?: boolean;
+};
+
+export function createUserSessionObject({
+  sessionId = genShortID(),
+  isSampled = true,
+}: CreateUserSessionObjectParams = {}): FaroUserSession {
   const now = dateNow();
 
   return {
@@ -49,7 +56,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
     } else {
       let newSession = addSessionMetadataToNextSession(
-        createUserSessionObject(undefined, isSampled()),
+        createUserSessionObject({ isSampled: isSampled() }),
         sessionFromStorage
       );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -66,16 +66,13 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
     ...newSession,
     sessionMeta: {
       id: newSession.sessionId,
+      attributes: {
+        ...(faro.metas.value.session?.attributes ?? {}),
+        ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
+        isSampled: newSession.isSampled.toString(),
+      },
     },
   };
-
-  const metaAttributes = faro.metas.value.session?.attributes;
-  if (metaAttributes || previousSession != null) {
-    sessionWithMeta.sessionMeta.attributes = {
-      ...(metaAttributes ?? {}),
-      ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
-    };
-  }
 
   return sessionWithMeta;
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -55,7 +55,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
 
       storeUserSession(newSession);
 
-      faro.api?.setSession(newSession.sessionMeta);
+      // faro.api?.setSession(newSession.sessionMeta);
       faro.config.sessionTracking?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
     }
   };

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,8 +1,10 @@
 import { dateNow, faro, genShortID } from '@grafana/faro-core';
 
+import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import type { FaroUserSession } from './types';
 
+// TODO: use params object
 export function createUserSessionObject(sessionId: string = genShortID(), isSampled = false): FaroUserSession {
   const now = dateNow();
 
@@ -46,7 +48,10 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
     if (isUserSessionValid(sessionFromStorage)) {
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
     } else {
-      let newSession = addSessionMetadataToNextSession(createUserSessionObject(), sessionFromStorage);
+      let newSession = addSessionMetadataToNextSession(
+        createUserSessionObject(undefined, isSampled()),
+        sessionFromStorage
+      );
 
       storeUserSession(newSession);
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/types.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/types.ts
@@ -4,5 +4,6 @@ export interface FaroUserSession {
   sessionId: string;
   lastActivity: number;
   started: number;
+  isSampled: boolean;
   sessionMeta?: MetaSession;
 }

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -1,2 +1,11 @@
-export * from './webStorage';
-export * from './throttle';
+export {
+  isLocalStorageAvailable,
+  isSessionStorageAvailable,
+  webStorageType,
+  getItem,
+  isWebStorageAvailable,
+  removeItem,
+  setItem,
+} from './webStorage';
+
+export { throttle } from './throttle';


### PR DESCRIPTION
## Why

With this PR we introduce a first version of session based sampling.
We use a head based sampling strategy based on sessions.
This means, if a session is not part of the sample we drop all events related to this session.

We calculate a sampling decision on the following points in time:
- On initialize, if either no session is persisted in web-storage or if the persisted session is invalid
- When we extend a session
- When the setSession() method is called outside of Faros' default session logic (if users "manually" call the function)
 
Settings:
- Users can either config a sample rate or use a sampler function to define a sample based on a custom calculation
  -  Faro inject a `context` parameter which current;y only contains the metas. 
  - The function returns a number
- If sampleRate or the result of the sampler function is not a number Faro sets the sample rate to 0 means we do not send any signals. This is to prevent costs rising up but will lead to data loss. _We may change this!_
- By default the sample rate is set to 1 (100%) means we always sent all events.


## What
* Provide first impl. of session based sampling

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
