### PR TITLE
feat: capture view and route transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Deps: upgrade OTEL dependencies, remove outdated resolutions (#391).
 - Fix (Web Tracing): send otel timings, like timeUnixNano, as string instead in LongBits format (#391).
 - Feat: session based sampling (#385).
+- Change: Send view and route transition attributes (#397).
 
 ## 1.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 - Deps: upgrade OTEL dependencies, remove outdated resolutions (#391).
 - Fix (Web Tracing): send otel timings, like timeUnixNano, as string instead in LongBits format (#391).
 - Feat: session based sampling (#385).
-- Change: Send view and route transition attributes (#397).
+- Change: Send better attributes with the view and route transition events to contain information about
+  the previous route or view (`from*`) and the destination route or view (`to*`) (#397).
+- Breaking❗️: React Instrumentation, the route transition event is renamed from `routeChange` to
+  `route_change`. The `url` and `route` attributes sent with the event are renamed to `toRoute` and
+  `toUrl`.(#397).
 
 ## 1.2.8
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -87,7 +87,7 @@ All the actions will be performed assuming that the demo is freshly ran and the 
      [<img src="docs/assets/userJourney/homepageTraces.png" alt="Homepage traces" height="100" />][assets-journey-homepage-traces]
      [<img src="docs/assets/userJourney/homepageWebVitals.png" alt="Homepage Web Vitals" height="100" />][assets-journey-homepage-web-vitals]
 1. Navigate to the [Seed page][demo-seed-page]
-   - `routeChange` event is registered with the new URL and the React route associated to that specific URL
+   - `route_change` event is registered with the new URL and the React route associated to that specific URL
    - [<img src="docs/assets/userJourney/seed.png" alt="Seed page" height="100" />][assets-seed]
      [<img src="docs/assets/userJourney/seedEvents.png" alt="Seed page" height="100" />][assets-seed-events]
 1. Click on the `Seed` button to add some default data in the database
@@ -115,7 +115,7 @@ All the actions will be performed assuming that the demo is freshly ran and the 
      [<img src="docs/assets/userJourney/seedErrorEvents.png" alt="Events for Seed page with error run" height="100" />][assets-seed-error-events]
      [<img src="docs/assets/userJourney/seedErrorTraces.png" alt="Traces for Seed page with error run" height="100" />][assets-seed-error-traces]
 1. Navigate to the [Register page][demo-register-page]
-   - `routeChange` event is registered with the new URL and the React route associated to that specific URL
+   - `route_change` event is registered with the new URL and the React route associated to that specific URL
 1. Enter `john.doe@grafana.com` as email and the fill in the rest of the fields then click on the `Register` button
    - The following events are registered:
      - `registerAttempt`
@@ -125,9 +125,9 @@ All the actions will be performed assuming that the demo is freshly ran and the 
      [<img src="docs/assets/userJourney/registerErrorEvents.png" alt="Events for Register page with error" height="100" />][assets-register-error-events]
      [<img src="docs/assets/userJourney/registerErrorTraces.png" alt="Traces for Register page with error" height="100" />][assets-register-error-traces]
 1. Navigate to the [Login page][demo-login-page]
-   - `routeChange` event is registered with the new URL and the React route associated to that specific URL
+   - `route_change` event is registered with the new URL and the React route associated to that specific URL
 1. Login with the following credentials: `john.doe@grafana.com` as email and `test` as password
-   - `routeChange` event is registered with the new URL and the React route associated to that specific URL
+   - `route_change` event is registered with the new URL and the React route associated to that specific URL
    - The following events are registered:
      - `loginAttempt`
      - `loginSuccess` - The `registerAttempt` -> `registerFailed` -> `loginAttempt` -> `loginSuccess` sequence allows us
@@ -136,8 +136,8 @@ All the actions will be performed assuming that the demo is freshly ran and the 
    - All the data captured from this point until logout will be associated with the `John Doe` user. Associating the
      `John Doe` user and `session ID` will allow us to see what actions the user performed prior logging in.
 1. Click on the `First Article`
-   - `routeChange` event is registered with the new URL and the React route associated to that specific URL
-     - what's different from the other `routeChange` events is that the route for this event is not identical to the URL
+   - `route_change` event is registered with the new URL and the React route associated to that specific URL
+     - what's different from the other `route_change` events is that the route for this event is not identical to the URL
        but what React received as an input (`/articles/view/:id`)
 1. Input some text in the `Add Comment` section and click `Create Comment`
    - The following events are registered:

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -46,15 +46,21 @@ export function initializeMetaAPI(
   const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
   const setView: MetaAPI['setView'] = (view) => {
-    if (metaView) {
-      metas.remove(metaView);
+    if (metaView?.view?.name === view?.name) {
+      return;
     }
+
+    const previousView = metaView;
 
     metaView = {
       view,
     };
 
     metas.add(metaView);
+
+    if (previousView) {
+      metas.remove(previousView);
+    }
   };
 
   const getView: MetaAPI['getView'] = () => metas.value.view;

--- a/packages/core/src/semantic.ts
+++ b/packages/core/src/semantic.ts
@@ -19,3 +19,4 @@ export const EVENT_VIEW_CHANGED = 'view_changed';
 export const EVENT_SESSION_START = 'session_start';
 export const EVENT_SESSION_RESUME = 'session_resume';
 export const EVENT_SESSION_EXTEND = 'session_extend';
+export const EVENT_ROUTE_CHANGE = 'route_change';

--- a/packages/react/src/router/v4v5/activeEvent.ts
+++ b/packages/react/src/router/v4v5/activeEvent.ts
@@ -1,3 +1,5 @@
+import { EVENT_ROUTE_CHANGE } from '@grafana/faro-web-sdk';
+
 import { api } from '../../dependencies';
 
 import type { ReactRouterV4V5ActiveEvent } from './types';
@@ -20,7 +22,7 @@ export function setActiveEventRoute(route: string): void {
 }
 
 export function sendActiveEvent(): void {
-  api.pushEvent('routeChange', activeEvent, undefined, { skipDedupe: true });
+  api.pushEvent(EVENT_ROUTE_CHANGE, activeEvent, undefined, { skipDedupe: true });
 
   activeEvent = undefined;
 }

--- a/packages/react/src/router/v6/FaroRoutes.tsx
+++ b/packages/react/src/router/v6/FaroRoutes.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
-import { globalObject } from '@grafana/faro-web-sdk';
+import { EVENT_ROUTE_CHANGE, globalObject } from '@grafana/faro-web-sdk';
 
 import { api } from '../../dependencies';
 import { NavigationType } from '../types';
 
 import { createRoutesFromChildren, isInitialized, Routes, useLocation, useNavigationType } from './routerDependencies';
-import type { ReactRouterV6RoutesProps } from './types';
+import type { EventRouteTransitionAttributes, ReactRouterV6RoutesProps } from './types';
 import { getRouteFromLocation } from './utils';
 
 export function FaroRoutes(props: ReactRouterV6RoutesProps) {
@@ -15,12 +15,28 @@ export function FaroRoutes(props: ReactRouterV6RoutesProps) {
 
   const routes = useMemo(() => createRoutesFromChildren?.(props.children) ?? [], [props.children]);
 
+  const lastRouteRef = useRef<EventRouteTransitionAttributes>({});
+
   useEffect(() => {
     if (isInitialized && (navigationType === NavigationType.Push || navigationType === NavigationType.Pop)) {
-      api.pushEvent('routeChange', {
-        route: getRouteFromLocation(routes, location),
-        url: globalObject.location?.href,
+      const route = getRouteFromLocation(routes, location);
+      const url = globalObject.location?.href;
+      const { fromRoute, fromUrl } = lastRouteRef.current;
+
+      if (route === fromRoute && url === fromUrl) {
+        return;
+      }
+
+      api.pushEvent(EVENT_ROUTE_CHANGE, {
+        toRoute: route,
+        toUrl: globalObject.location?.href,
+        ...lastRouteRef.current,
       });
+
+      lastRouteRef.current = {
+        fromRoute: route,
+        fromUrl: url,
+      };
     }
   }, [location, navigationType, routes]);
 

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -63,3 +63,8 @@ export interface ReactRouterV6Dependencies {
   useLocation: ReactRouterV6UseLocation;
   useNavigationType: ReactRouterV6UseNavigationType;
 }
+
+export type EventRouteTransitionAttributes = {
+  fromRoute?: string;
+  fromUrl?: string;
+};

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -84,6 +84,13 @@ export {
   TransportItemType,
   transportItemTypeToBodyKey,
   VERSION,
+  EVENT_CLICK,
+  EVENT_NAVIGATION,
+  EVENT_ROUTE_CHANGE,
+  EVENT_SESSION_EXTEND,
+  EVENT_SESSION_RESUME,
+  EVENT_SESSION_START,
+  EVENT_VIEW_CHANGED,
 } from '@grafana/faro-core';
 
 export type {

--- a/packages/web-sdk/src/instrumentations/view/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/view/instrumentation.ts
@@ -12,10 +12,18 @@ export class ViewInstrumentation extends BaseInstrumentation {
   private sendViewChangedEvent(meta: Meta): void {
     const view = meta.view;
 
-    if (view && view !== this.notifiedView) {
-      this.notifiedView = view;
+    if (view && view.name !== this.notifiedView?.name) {
+      this.api.pushEvent(
+        EVENT_VIEW_CHANGED,
+        {
+          fromView: this.notifiedView?.name ?? '',
+          toView: view.name,
+        },
+        undefined,
+        { skipDedupe: true }
+      );
 
-      this.api.pushEvent(EVENT_VIEW_CHANGED, {}, undefined, { skipDedupe: true });
+      this.notifiedView = view;
     }
   }
 


### PR DESCRIPTION
## Why
To be able to properly visualize view and page transitions we need information about the previous route or view. 
We provide this information with the attributes object of the respective event. 

**Breaking change**
The event for route transitions got renamed from `routeChange` to `route_change`.
This is to be compliant with the structure of the other semantic events in Faro which are in the forma `{namespace}_{action}`

## What
* Rename the `routeChange` event to `route_change` to be compliant with the Faro event naming scheme.
* Add `{from|to}Route` and `{from|to}Url` attributes to the route transition event (`route_change`).
* De-noise route transition events by only sending a route transition to a different route then the current one.
* Update demo README to the new event name of the route change event.

* Add `{from|to}View` attributes to the view transition event (`view_changed`)
* De-noise view transitions events by only capturing real view changes


## Links

Resolves issue #390 

## Screenshots
### Route transitions

https://github.com/grafana/faro-web-sdk/assets/47627413/50e5f540-6477-4d6b-94ff-240d368ed696

<img width="1080" alt="Screenshot 2023-11-28 at 13 46 51" src="https://github.com/grafana/faro-web-sdk/assets/47627413/69047201-5d3b-4266-8082-3744f4766259">

### View transitions
https://github.com/grafana/faro-web-sdk/assets/47627413/a4ff6ef8-5fb3-47c2-b6f9-f0509cad5c8c

<img width="1080" alt="Screenshot 2023-11-28 at 13 46 51" src="https://github.com/grafana/faro-web-sdk/assets/47627413/f377b6d7-e782-4fd2-a98c-c2dd7f602c09">

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
