### PR TITLE
fix: add missing `react-dom` peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Deps (`@grafana/faro-react`): add missing peer dependency on `react-dom` (#400).
+
 ## 1.2.9
 
 - Deps: upgrade OTEL dependencies, remove outdated resolutions (#391).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,10 +60,12 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^18.0.26",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Why

Fixes the following warning when running `yarn install` in this repository

```warning "workspace-aggregator-08102a81-82fa-4a72-b370-86363f217eff > @grafana/faro-react > react-router-dom@6.16.0" has unmet peer dependency "react-dom@>=16.8".```

## What

Added a missing peer dep (and added it as a dev dep)

## Links

N/A

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
