### PR TITLE
fix: remove unused OTel `api-metrics` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Deps: remove unused `@opentelemetry/api-metrics` dependency (#401).
+- Deps (Web Tracing): remove unused `@opentelemetry/api-metrics` dependency (#401).
 
 ## 1.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- Deps (Web Tracing): remove unused `@opentelemetry/api-metrics` dependency (#401).
+- Deps (Faro Core): remove unused `@opentelemetry/api-metrics` dependency (#401).
+- Deps (Web Tracing): remove unused `@opentelemetry/sdk-trace-base` dependency (#401).
 
 ## 1.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Deps: remove unused `@opentelemetry/api-metrics` dependency (#401).
+
 ## 1.2.9
 
 - Deps: upgrade OTEL dependencies, remove outdated resolutions (#391).

--- a/demo/package.json
+++ b/demo/package.json
@@ -50,7 +50,6 @@
     "@opentelemetry/instrumentation-winston": "^0.33.0",
     "@opentelemetry/resources": "^1.18.1",
     "@opentelemetry/sdk-node": "^0.45.1",
-    "@opentelemetry/sdk-trace-base": "^1.18.1",
     "@opentelemetry/sdk-trace-node": "^1.18.1",
     "@opentelemetry/semantic-conventions": "^1.18.1",
     "@reduxjs/toolkit": "^1.9.1",

--- a/demo/src/server/otel/initialize.ts
+++ b/demo/src/server/otel/initialize.ts
@@ -6,8 +6,7 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { WinstonInstrumentation } from '@opentelemetry/instrumentation-winston';
 import { Resource } from '@opentelemetry/resources';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 import { env } from '../utils';

--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -236,8 +236,7 @@ import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-docu
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { Resource } from '@opentelemetry/resources';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { initializeFaro } from '@grafana/faro-web-sdk';
 import { FaroSessionSpanProcessor, FaroTraceExporter } from '@grafana/faro-web-tracing';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-metrics": "^0.33.0",
     "@opentelemetry/otlp-transformer": "^0.45.1",
     "murmurhash-js": "^1.0.0"
   },

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -63,7 +63,6 @@
     "@opentelemetry/instrumentation-xml-http-request": "^0.45.1",
     "@opentelemetry/otlp-transformer": "^0.45.1",
     "@opentelemetry/resources": "^1.18.1",
-    "@opentelemetry/sdk-trace-base": "^1.18.1",
     "@opentelemetry/sdk-trace-web": "^1.18.1",
     "@opentelemetry/semantic-conventions": "^1.18.1"
   },

--- a/packages/web-tracing/src/faroTraceExporter.ts
+++ b/packages/web-tracing/src/faroTraceExporter.ts
@@ -1,7 +1,7 @@
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ExportResult } from '@opentelemetry/core';
 import { createExportTraceServiceRequest } from '@opentelemetry/otlp-transformer';
-import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 
 import type { FaroTraceExporterConfig } from './types';
 

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -3,8 +3,7 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource, ResourceAttributes } from '@opentelemetry/resources';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';

--- a/packages/web-tracing/src/sessionSpanProcessor.ts
+++ b/packages/web-tracing/src/sessionSpanProcessor.ts
@@ -1,5 +1,5 @@
 import type { Context } from '@opentelemetry/api';
-import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
 import type { Metas } from '@grafana/faro-web-sdk';
 

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -1,7 +1,7 @@
 import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
 import type { InstrumentationOption } from '@opentelemetry/instrumentation';
 import type { ResourceAttributes } from '@opentelemetry/resources';
-import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
 import type { API } from '@grafana/faro-web-sdk';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,13 +1286,6 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api-metrics@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz#753d355289b7811ad254d6e5b0193bd1b9f23ab0"
-  integrity sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==
-  dependencies:
-    "@opentelemetry/api" "^1.0.0"
-
 "@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.4.0", "@opentelemetry/api@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.7.0.tgz#b139c81999c23e3c8d3c0a7234480e945920fc40"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,7 +1538,7 @@
     "@opentelemetry/sdk-trace-node" "1.18.1"
     "@opentelemetry/semantic-conventions" "1.18.1"
 
-"@opentelemetry/sdk-trace-base@1.18.1", "@opentelemetry/sdk-trace-base@^1.0.0", "@opentelemetry/sdk-trace-base@^1.18.1":
+"@opentelemetry/sdk-trace-base@1.18.1", "@opentelemetry/sdk-trace-base@^1.0.0":
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz#256605d90b202002d5672305c66dbcf377132379"
   integrity sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==


### PR DESCRIPTION
## Why

`@opentelemetry/api-metrics` is unused, and it is also deprecated: https://www.npmjs.com/package/@opentelemetry/api-metrics

<img width="487" alt="image" src="https://github.com/grafana/faro-web-sdk/assets/1404810/c7091e04-00bf-4b12-ac96-7fca3706535e">


## What

I removed the unused `@opentelemetry/api-metrics` dependency declaration.

In addition, I noticed that `@opentelemetry/sdk-trace-base` is used - this is not necessary. `sdk-trace-web` and `sdk-trace-node` both re-export the entirety of the `base` package, so there's no need for an explicit dependency.

## Links

N/A

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
