### PR TITLE
chore: cleanup sampled items before send

### DIFF
--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -10,6 +10,7 @@ import {
 } from '@grafana/faro-core';
 import type { Config } from '@grafana/faro-core';
 
+import type { TransportItem } from '../..';
 import { createSession } from '../../metas';
 
 import { type FaroUserSession, isSampled } from './sessionManager';
@@ -115,7 +116,19 @@ export class SessionInstrumentation extends BaseInstrumentation {
         const attributes = item.meta.session?.attributes;
 
         if (attributes && attributes?.['isSampled'] === 'true') {
-          return item;
+          let newItem: TransportItem;
+
+          // Structured clone is supported in all major browsers
+          // but for old browsers we need a fallback
+          if ('structuredClone' in window) {
+            newItem = structuredClone(item);
+          } else {
+            newItem = JSON.parse(JSON.stringify(item));
+          }
+
+          delete newItem.meta.session?.attributes?.['isSampled'];
+
+          return newItem;
         }
 
         return null;


### PR DESCRIPTION
## Why

Remove the isSampled attribute before sending items.

For now I decided to clone items before removing them so it won't cause problems if beforeSend hooks are called multiple times. 
Otherwise this would cause an error in bacthed mode were items woudl not be sent.


Cloning items comes with a performance overhead but I think it's mostly negligible.
But if attributes object grow big or once we enabled structured object for attributes this may change.


From a timing perspective it would make more sense to do thies even later in the trasports immediately before sending the items  because this would not cause any side effect if we mutate the items.
This approach has the tinty downside that users which implement thier own custom transports will need to adapt their implementation to remove the isSampled attribute.


So for now I decided for cloning, even if it causes us deep-cloning objects but would like to open up for discussions on the two approaches.




## What

* Deep clone transport items in the before send hook of the session instrumentation
* Remove the isSampled object from the session attributes


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
