### PR TITLE
change: enable new session management by default, remove legacy session management

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -33,9 +33,6 @@ export function initializeFaro(): Faro {
         },
       }),
     ],
-    sessionTracking: {
-      enabled: true,
-    },
     batching: {
       // Batching is enabled by default and there is normally no reason to disable it.
       // We did it in the demo so users can inspect each single requests sent due to certain interactions.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -26,7 +26,6 @@ export interface Config<P = APIEvent> {
 
   beforeSend?: BeforeSendHook<P>;
   ignoreErrors?: Patterns;
-  session?: MetaSession;
   sessionTracking?: {
     enabled?: boolean;
     persistent?: boolean;

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -10,11 +10,7 @@ export function registerInitialMetas(faro: Faro): void {
     },
   };
 
-  let session = faro.config.session;
-  if (faro.config.sessionTracking?.enabled) {
-    session = faro.config.sessionTracking.session!;
-  }
-
+  const session = faro.config.sessionTracking?.session;
   if (session) {
     faro.api.setSession(session);
   }

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -11,7 +11,7 @@ import type { Config, MetaItem, Transport } from '@grafana/faro-core';
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultSessionTrackingConfig } from '../instrumentations/session';
-import { createSession, defaultMetas, defaultViewMeta } from '../metas';
+import { defaultMetas, defaultViewMeta } from '../metas';
 import { k6Meta } from '../metas/k6';
 import { FetchTransport } from '../transports';
 
@@ -83,16 +83,9 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
       ...browserConfig.sessionTracking,
     },
 
-    // TODO: deprecate/remove legacy session object at ga
-    session: browserConfig.session ?? createSession(),
-
     user: browserConfig.user,
     view: browserConfig.view ?? defaultViewMeta,
   };
-
-  if (config.sessionTracking?.enabled) {
-    delete config.session;
-  }
 
   return config;
 }

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -64,7 +64,9 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
-        session,
+        sessionTracking: {
+          session,
+        },
       })
     );
 
@@ -85,7 +87,6 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: false,
           session,
           samplingRate: 1, // default
@@ -122,7 +123,6 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           samplingRate: 1, // default
         },
       })
@@ -147,7 +147,6 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 1, // default
         },
@@ -188,7 +187,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           session: mockSessionMeta,
           samplingRate: 1, // default
         },
@@ -206,7 +204,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           samplingRate: 1, // default
         },
       })
@@ -233,7 +230,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 1, // default
         },
@@ -259,7 +255,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 1, // default
         },
@@ -286,7 +281,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 1, // default
         },
@@ -308,9 +302,7 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
-        sessionTracking: {
-          enabled: true,
-        },
+        sessionTracking: {},
       })
     );
 
@@ -343,7 +335,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 0,
         },
@@ -372,7 +363,6 @@ describe('SessionInstrumentation', () => {
       mockConfig({
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           persistent: true,
           samplingRate: 0,
         },
@@ -394,11 +384,9 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           samplingRate: 0,
         },
         batching: {
-          enabled: true,
           itemLimit: 5,
           sendTimeout: 1,
         },
@@ -426,11 +414,9 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           samplingRate: 1,
         },
         batching: {
-          enabled: true,
           itemLimit: 5,
           sendTimeout: 1,
         },
@@ -461,11 +447,9 @@ describe('SessionInstrumentation', () => {
         transports: [transport],
         instrumentations: [new SessionInstrumentation()],
         sessionTracking: {
-          enabled: true,
           session: { id: 'abc', attributes: { foo: 'bar' } },
         },
         batching: {
-          enabled: true,
           itemLimit: 5,
           sendTimeout: 1,
         },

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -105,6 +105,10 @@ export class SessionInstrumentation extends BaseInstrumentation {
         })
       );
 
+      if (this.notifiedSession != null) {
+        this.sendSessionStartEvent(initialSessionMeta as Meta);
+      }
+
       this.notifiedSession = initialSessionMeta;
       this.api.setSession(initialSessionMeta);
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -29,7 +29,6 @@ describe('Persistent Sessions Manager.', () => {
 
     const config = mockConfig({
       sessionTracking: {
-        enabled: true,
         persistent: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -29,7 +29,6 @@ describe('Volatile Sessions Manager.', () => {
 
     const config = mockConfig({
       sessionTracking: {
-        enabled: true,
         session: { id: mockInitialSessionId },
         onSessionChange: mockOnNewSessionCreated,
       },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.test.ts
@@ -13,7 +13,6 @@ describe('Sampling.', () => {
   it('Returns false if sampleRate is not of type number.', () => {
     const config = mockConfig({
       sessionTracking: {
-        enabled: true,
         samplingRate: 'hello' as any,
       },
     });
@@ -26,7 +25,6 @@ describe('Sampling.', () => {
   it('Returns proper sampling decision for configured samplingRate.', () => {
     let config = mockConfig({
       sessionTracking: {
-        enabled: true,
         samplingRate: 1,
       },
     });
@@ -42,7 +40,6 @@ describe('Sampling.', () => {
   it('Returns proper sampling decision for rate returned by sampler function.', () => {
     let config = mockConfig({
       sessionTracking: {
-        enabled: true,
         sampler: () => {
           return 1;
         },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
@@ -9,7 +9,7 @@ export const MAX_SESSION_PERSISTENCE_TIME_BUFFER = 1 * 60 * 1000;
 export const MAX_SESSION_PERSISTENCE_TIME = SESSION_INACTIVITY_TIME + MAX_SESSION_PERSISTENCE_TIME_BUFFER;
 
 export const defaultSessionTrackingConfig: Config['sessionTracking'] = {
-  enabled: false,
+  enabled: true,
   persistent: false,
   maxSessionPersistenceTime: MAX_SESSION_PERSISTENCE_TIME,
 } as const;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -161,8 +161,8 @@ describe('sessionManagerUtils', () => {
     const config = mockConfig({
       sessionTracking: {
         onSessionChange: mockOnSessionChange,
+        session: currentSessionMeta,
       },
-      session: currentSessionMeta,
     });
 
     const faro = initializeFaro(config);
@@ -209,7 +209,7 @@ describe('sessionManagerUtils', () => {
 
   it('Takes session object and adds meta data.', () => {
     const config = mockConfig({});
-    initializeFaro(config);
+    const { api } = initializeFaro(config);
 
     const newSession: FaroUserSession = {
       lastActivity: 1,
@@ -259,10 +259,7 @@ describe('sessionManagerUtils', () => {
       },
     };
 
-    const config2 = mockConfig({
-      session: sessionMeta,
-    });
-    initializeFaro(config2);
+    api.setSession(sessionMeta);
 
     const sessionWithMetadata3 = addSessionMetadataToNextSession(newSession, previousSession);
 


### PR DESCRIPTION
## Why
For several reasons we need the new session management enabled by default.


## What
* Remove legacy session object
* Enable volatile sessions manager by default


## Links

[Docs update](https://github.com/grafana/website/pull/16855)

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
