### PR TITLE
fix: initial sampling decision was set tu true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+## 1.3.1
+
+- fix (`@grafana/faro-web-sdk`): Fixed an issue where the first calculated session was always part of the sample (#415).
+
 ## 1.3.0
 
 - Deps (`@grafana/faro-react`): add missing peer dependency on `react-dom` (#400).

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -374,7 +374,7 @@ describe('SessionInstrumentation', () => {
         sessionTracking: {
           enabled: true,
           persistent: true,
-          samplingRate: 0,
+          samplingRate: 0, // setting to zero so calculating sampling decision for new session will evaluate to false
         },
       })
     );
@@ -383,7 +383,7 @@ describe('SessionInstrumentation', () => {
     const sessionMeta = api.getSession();
 
     expect(sessionMeta?.attributes?.['isSampled']).toBe('false');
-    expect((JSON.parse(mockStorage[STORAGE_KEY]) as FaroUserSession).isSampled).toBe(initialIsSampled);
+    expect((JSON.parse(mockStorage[STORAGE_KEY]) as FaroUserSession).isSampled).toBe(false);
   });
 
   it('Will send 0% of the signals.', () => {

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -101,7 +101,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
       SessionManager.storeUserSession(
         createUserSessionObject({
           sessionId: initialSessionMeta.id,
-          isSampled: Boolean(initialSessionMeta.attributes!['isSampled']),
+          isSampled: initialSessionMeta.attributes?.['isSampled'] === 'true',
         })
       );
 


### PR DESCRIPTION
## Why

Storing the initial session in local storage always set teh samplng decsion to true which causes that we always send 100% of the signals.


## What

Faro attributes are always strings, so the following 
evaluation always evaluates to `true`.
```ts
isSampled: Boolean(initialSessionMeta.attributes!['isSampled']),
```

Chaged the evaluation so we evaluate if string attribute has value 'true' or not


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
