### PR TITLE
Add user defined session attributes to the session meta and ensure that those attrinutes are not stored in web-storage. 

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -43,13 +43,6 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
-    sessionTracking: {
-      session: {
-        attributes: {
-          location: 'moon',
-        },
-      },
-    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -43,6 +43,13 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
+    sessionTracking: {
+      session: {
+        attributes: {
+          location: 'moon',
+        },
+      },
+    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -72,6 +72,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
       sessionId = userSession?.sessionId;
       sessionAttributes = {
         ...userSession?.sessionMeta?.attributes,
+        ...sessionAttributes,
         isSampled: userSession!.isSampled.toString(),
       };
       lifecycleType = EVENT_SESSION_RESUME;
@@ -113,10 +114,21 @@ export class SessionInstrumentation extends BaseInstrumentation {
         }
 
         const newAttributes = newItem.meta.session?.attributes;
+
+        if (newAttributes?.['location']) {
+          console.log('item :>> ', item);
+
+          console.log('newAttributes :>> ', { ...newAttributes });
+        }
+
         delete newAttributes?.['isSampled'];
 
         if (Object.keys(newAttributes ?? {}).length === 0) {
           delete newItem.meta.session?.attributes;
+        }
+
+        if (newAttributes?.['location']) {
+          console.log('newItem :>> ', { ...newItem });
         }
 
         return newItem;

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -115,20 +115,10 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
         const newAttributes = newItem.meta.session?.attributes;
 
-        if (newAttributes?.['location']) {
-          console.log('item :>> ', item);
-
-          console.log('newAttributes :>> ', { ...newAttributes });
-        }
-
         delete newAttributes?.['isSampled'];
 
         if (Object.keys(newAttributes ?? {}).length === 0) {
           delete newItem.meta.session?.attributes;
-        }
-
-        if (newAttributes?.['location']) {
-          console.log('newItem :>> ', { ...newItem });
         }
 
         return newItem;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.test.ts
@@ -111,7 +111,7 @@ describe('Persistent Sessions Manager.', () => {
     updateSession();
 
     // creates and stores new session
-    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+    const sessionFromStorage = JSON.parse(mockStorage[STORAGE_KEY]);
 
     const matchNewSessionMeta = {
       id: mockNewSessionId,
@@ -120,12 +120,15 @@ describe('Persistent Sessions Manager.', () => {
         isSampled: 'true',
       },
     };
-    expect(session).toStrictEqual({
+    expect(sessionFromStorage).toStrictEqual({
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
       isSampled: true,
-      sessionMeta: matchNewSessionMeta,
+      sessionMeta: {
+        id: matchNewSessionMeta.id,
+        attributes: { previousSession: mockInitialSessionId },
+      },
     });
 
     // Updates session meta
@@ -169,7 +172,7 @@ describe('Persistent Sessions Manager.', () => {
     updateSession();
 
     // creates and stores new session
-    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+    const sessionFromStorage = JSON.parse(mockStorage[STORAGE_KEY]);
 
     const matchNewSessionMeta = {
       id: mockNewSessionId,
@@ -178,12 +181,15 @@ describe('Persistent Sessions Manager.', () => {
         isSampled: 'true',
       },
     };
-    expect(session).toStrictEqual({
+    expect(sessionFromStorage).toStrictEqual({
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
       isSampled: true,
-      sessionMeta: matchNewSessionMeta,
+      sessionMeta: {
+        id: matchNewSessionMeta.id,
+        attributes: { previousSession: mockInitialSessionId },
+      },
     });
 
     // Updates session meta

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -6,7 +6,12 @@ import { getItem, removeItem, setItem, webStorageType } from '../../../utils/web
 
 import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
-import { addSessionMetadataToNextSession, createUserSessionObject, getUserSessionUpdater } from './sessionManagerUtils';
+import {
+  addSessionMetadataToNextSession,
+  cleanUpSessionMetaAttributes,
+  createUserSessionObject,
+  getUserSessionUpdater,
+} from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 
 export class PersistentSessionsManager {
@@ -27,7 +32,11 @@ export class PersistentSessionsManager {
   }
 
   static storeUserSession(session: FaroUserSession): void {
-    setItem(STORAGE_KEY, JSON.stringify(session), PersistentSessionsManager.storageTypeLocal);
+    setItem(
+      STORAGE_KEY,
+      JSON.stringify(cleanUpSessionMetaAttributes(session)),
+      PersistentSessionsManager.storageTypeLocal
+    );
   }
 
   static fetchUserSession(): FaroUserSession | null {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -6,7 +6,12 @@ import { getItem, removeItem, setItem, webStorageType } from '../../../utils/web
 
 import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
-import { addSessionMetadataToNextSession, createUserSessionObject, getUserSessionUpdater } from './sessionManagerUtils';
+import {
+  addSessionMetadataToNextSession,
+  cleanUpSessionMetaAttributes,
+  createUserSessionObject,
+  getUserSessionUpdater,
+} from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 
 export class VolatileSessionsManager {
@@ -27,7 +32,11 @@ export class VolatileSessionsManager {
   }
 
   static storeUserSession(session: FaroUserSession): void {
-    setItem(STORAGE_KEY, JSON.stringify(session), VolatileSessionsManager.storageTypeSession);
+    setItem(
+      STORAGE_KEY,
+      JSON.stringify(cleanUpSessionMetaAttributes(session)),
+      VolatileSessionsManager.storageTypeSession
+    );
   }
 
   static fetchUserSession(): FaroUserSession | null {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -104,7 +104,7 @@ describe('Volatile Sessions Manager.', () => {
     updateSession();
 
     // creates and stores new session
-    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+    const sessionFromStorage = JSON.parse(mockStorage[STORAGE_KEY]);
 
     const matchNewSessionMeta = {
       id: mockNewSessionId,
@@ -113,12 +113,15 @@ describe('Volatile Sessions Manager.', () => {
         isSampled: 'true',
       },
     };
-    expect(session).toStrictEqual({
+    expect(sessionFromStorage).toStrictEqual({
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
       isSampled: true,
-      sessionMeta: matchNewSessionMeta,
+      sessionMeta: {
+        id: matchNewSessionMeta.id,
+        attributes: { previousSession: mockInitialSessionId },
+      },
     });
 
     // Updates session meta
@@ -158,7 +161,7 @@ describe('Volatile Sessions Manager.', () => {
     updateSession();
 
     // creates and stores new session
-    const session = JSON.parse(mockStorage[STORAGE_KEY]);
+    const sessionFromStorage = JSON.parse(mockStorage[STORAGE_KEY]);
 
     const matchNewSessionMeta = {
       id: mockNewSessionId,
@@ -167,12 +170,15 @@ describe('Volatile Sessions Manager.', () => {
         isSampled: 'true',
       },
     };
-    expect(session).toStrictEqual({
+    expect(sessionFromStorage).toStrictEqual({
       sessionId: mockNewSessionId,
       lastActivity: maxActivityTimeReached,
       started: maxActivityTimeReached,
       isSampled: true,
-      sessionMeta: matchNewSessionMeta,
+      sessionMeta: {
+        id: matchNewSessionMeta.id,
+        attributes: { previousSession: mockInitialSessionId },
+      },
     });
 
     // Updates session meta

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -76,6 +76,7 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
       attributes: {
         ...(faro.metas.value.session?.attributes ?? {}),
         ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
+        ...faro.config.sessionTracking?.session?.attributes,
         isSampled: newSession.isSampled.toString(),
       },
     },


### PR DESCRIPTION
## Why

1. Ensure that user provided session attributes are also send if a session is resumed or extended.

2. Ensure that we do not store user defined attributes in web-storage. Otherwise Faro could easily leak sensitive information to the web-storage which is a privacy risk and may be an adoption blocker for customers.
 
## What
* Ensure that we send user defined attributes.
* Statically defined attributes (think of them as constants) during the init phase always win over dynamic attributes with the same name added by calling the `setSession()` function.

* Add a cleanup function which is called before storing session meta data in web storage 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
