### PR TITLE
User defined attributes are missing in the session meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ picked up (#420)
 
 - fix (`@grafana/faro-web-sdk`): user defined session attributes added during initialize were not
   picked up (#420)
-- feat (`@grafana/faro-web-sdk`): provide `sessionIdGenerator()` which Faro will use instead of the
-  internal sessionId generator if configured (#421).
+- feat (`@grafana/faro-web-sdk`): provide custom `generateSessionId()` function which Faro will use
+  instead of the internal sessionId generator if configured (#421).
 
 ## 1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+fix (`@grafana/faro-web-sdk`): user defined session attributes added during initialize were not
+picked up (#420)
+
+- fix (`@grafana/faro-web-sdk`): user defined session attributes added during initialize were not
+  picked up (#420)
 - feat (`@grafana/faro-web-sdk`): provide `sessionIdGenerator()` which Faro will use instead of the
   internal sessionId generator if configured (#421).
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -34,7 +34,7 @@ export interface Config<P = APIEvent> {
     onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
     samplingRate?: number;
     sampler?: (context: SamplingContext) => number;
-    sessionIdGenerator?: () => string;
+    generateSessionId?: () => string;
   };
 
   user?: MetaUser;

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -142,12 +142,13 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
       const { sessionMeta: initialSessionMeta, lifecycleType } = this.createInitialSessionMeta(sessionTracking);
 
-      SessionManager.storeUserSession(
-        createUserSessionObject({
+      SessionManager.storeUserSession({
+        ...createUserSessionObject({
           sessionId: initialSessionMeta.id,
           isSampled: initialSessionMeta.attributes?.['isSampled'] === 'true',
-        })
-      );
+        }),
+        sessionMeta: initialSessionMeta,
+      });
 
       this.notifiedSession = initialSessionMeta;
       this.api.setSession(initialSessionMeta);

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -71,9 +71,11 @@ export class SessionInstrumentation extends BaseInstrumentation {
     if (isUserSessionValid(userSession)) {
       sessionId = userSession?.sessionId;
       sessionAttributes = {
+        ...sessionAttributes,
         ...userSession?.sessionMeta?.attributes,
         isSampled: userSession!.isSampled.toString(),
       };
+
       lifecycleType = EVENT_SESSION_RESUME;
     } else {
       sessionId = sessionId ?? createSession().id;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -56,13 +56,13 @@ describe('sessionManagerUtils', () => {
     });
   });
 
-  it('creates new user session object and uses user defined sessionIdGenerator.', () => {
+  it('creates new user session object and uses user defined generateSessionId.', () => {
     const customGeneratedSessionId = 'my-custom-id';
 
     const config = mockConfig({
       sessionTracking: {
         enabled: true,
-        sessionIdGenerator() {
+        generateSessionId() {
           return customGeneratedSessionId;
         },
       },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -10,7 +10,7 @@ type CreateUserSessionObjectParams = {
 };
 
 export function createUserSessionObject({
-  sessionId = faro.config?.sessionTracking?.sessionIdGenerator?.() ?? genShortID(),
+  sessionId = faro.config?.sessionTracking?.generateSessionId?.() ?? genShortID(),
   isSampled = true,
 }: CreateUserSessionObjectParams = {}): FaroUserSession {
   const now = dateNow();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -74,10 +74,8 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
     sessionMeta: {
       id: newSession.sessionId,
       attributes: {
-        ...(faro.metas.value.session?.attributes ?? {}),
-        // order matters, new session meta created with setSession() shall not overwrite attributes with the same name which were manually configured on initialize.
         ...faro.config.sessionTracking?.session?.attributes,
-        // order matters, previousSession and isSampled overwrites attributes from config with the same.
+        ...(faro.metas.value.session?.attributes ?? {}),
         ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
         isSampled: newSession.isSampled.toString(),
       },

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -75,6 +75,9 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
       id: newSession.sessionId,
       attributes: {
         ...(faro.metas.value.session?.attributes ?? {}),
+        // order matters, new session meta created with setSession() shall not overwrite attributes with the same name which were manually configured on initialize.
+        ...faro.config.sessionTracking?.session?.attributes,
+        // order matters, previousSession and isSampled overwrites attributes from config with the same.
         ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
         isSampled: newSession.isSampled.toString(),
       },


### PR DESCRIPTION
## Why

User defined session attributes were missing in the session meta.

The current flow is:
* User defined attributes—either added during the init phase  or later via setSession()—are added to the meta we sent to the backend
* The are also stored with the FaroUserSession in local storage.
* Session attributes will be picked up from local storage when resuming sessions, also across page loads

## What
* Fix bug were initial session attributes were not send
* Store session attributes in web-storage to make them outlive page loads

## Screenshots


https://github.com/grafana/faro-web-sdk/assets/47627413/93102918-244b-45d0-ba7b-559a259f042d



<img width="642" alt="Screenshot 2023-12-08 at 16 32 07" src="https://github.com/grafana/faro-web-sdk/assets/47627413/7bb74212-7772-4e99-8580-294cbdc6de46">

I forgot to show in the video that attributes are also picked up om session_resume


## Links

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
