### PR TITLE
Custom-session-id-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- feat (`@grafana/faro-web-sdk`): provide `sessionIdGenerator()` which Faro will use instead of the
+  internal sessionId generator if configured (#421).
+
 ## 1.3.2
 
 - fix (`@grafana/faro-web-sdk`): Fixed an issue where the session meta was missing in session

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -43,6 +43,17 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
+    sessionTracking: {
+      session: {
+        // id: 'initial-id',
+        attributes: {
+          location: 'moon',
+        },
+      },
+      sessionIdGenerator() {
+        return 'custom-id';
+      },
+    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -43,17 +43,6 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
-    sessionTracking: {
-      session: {
-        // id: 'initial-id',
-        attributes: {
-          location: 'moon',
-        },
-      },
-      sessionIdGenerator() {
-        return 'custom-id';
-      },
-    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -34,6 +34,7 @@ export interface Config<P = APIEvent> {
     onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
     samplingRate?: number;
     sampler?: (context: SamplingContext) => number;
+    sessionIdGenerator?: () => string;
   };
 
   user?: MetaUser;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -56,6 +56,30 @@ describe('sessionManagerUtils', () => {
     });
   });
 
+  it('creates new user session object and uses user defined sessionIdGenerator.', () => {
+    const customGeneratedSessionId = 'my-custom-id';
+
+    const config = mockConfig({
+      sessionTracking: {
+        enabled: true,
+        sessionIdGenerator() {
+          return customGeneratedSessionId;
+        },
+      },
+    });
+
+    initializeFaro(config);
+
+    const newSessionWithInitialSessionId = createUserSessionObject();
+
+    expect(newSessionWithInitialSessionId).toStrictEqual({
+      sessionId: customGeneratedSessionId,
+      lastActivity: fakeSystemTime,
+      started: fakeSystemTime,
+      isSampled: true,
+    });
+  });
+
   it('checks if user session is valid.', () => {
     jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockSessionId);
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -10,14 +10,10 @@ type CreateUserSessionObjectParams = {
 };
 
 export function createUserSessionObject({
-  sessionId = genShortID(),
+  sessionId = faro.config?.sessionTracking?.sessionIdGenerator?.() ?? genShortID(),
   isSampled = true,
 }: CreateUserSessionObjectParams = {}): FaroUserSession {
   const now = dateNow();
-
-  if (typeof faro.config.sessionTracking?.sessionIdGenerator === 'function') {
-    sessionId = faro.config.sessionTracking.sessionIdGenerator();
-  }
 
   return {
     sessionId,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -15,6 +15,10 @@ export function createUserSessionObject({
 }: CreateUserSessionObjectParams = {}): FaroUserSession {
   const now = dateNow();
 
+  if (typeof faro.config.sessionTracking?.sessionIdGenerator === 'function') {
+    sessionId = faro.config.sessionTracking.sessionIdGenerator();
+  }
+
   return {
     sessionId,
     lastActivity: now,


### PR DESCRIPTION
## Why

Add an option to provide a custom id generator function. 
This is for custoners who use their own session naming scheme.

## What
* Add optional `sessionIdGenerator` property to the session tracking object
* enhance `createUserSessionObject()` function to use the `sessionIdGenerator`. I sessionIdGenerator is not provided Faro uses the internal shortId genearot function.


## Links

[Documentation](https://github.com/grafana/website/pull/16964)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
