### PR TITLE
fix: guard against missing `isSampled` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Next
 
-- fix (`@grafana/faro-web-sdk`): guard against missing `isSampled` (#)
+- fix (`@grafana/faro-web-sdk`): guard against missing `isSampled` (#425)
 
 ## 1.3.4
 
-- fix (`@grafana/faro-web-sdk`): `generateSessionId()` was executed twice (#425)
+- fix (`@grafana/faro-web-sdk`): `generateSessionId()` was executed twice (#423)
 
 ## 1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Next
 
+- fix (`@grafana/faro-web-sdk`): guard against missing `isSampled` (#)
+
 ## 1.3.4
 
-- fix (`@grafana/faro-web-sdk`): `generateSessionId()` was executed twice (#423)
+- fix (`@grafana/faro-web-sdk`): `generateSessionId()` was executed twice (#425)
 
 ## 1.3.3
 

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -73,7 +73,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
       sessionAttributes = {
         ...sessionAttributes,
         ...userSession?.sessionMeta?.attributes,
-        isSampled: userSession!.isSampled.toString(),
+        isSampled: (userSession!.isSampled || false).toString(),
       };
 
       lifecycleType = EVENT_SESSION_RESUME;


### PR DESCRIPTION
## Why

I'm not sure why, but we sometimes get an error from Faro with `cannot read property 'toString' of undefined`. It doesn't happen with all users, only some

## What

Makes sure there's a valid value on which to call `toString`

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
