### PR TITLE
409 xhr and fetch instrumentation should inject x faro session header only into requests sent to the same origin as the current window

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -1,5 +1,6 @@
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
 
+import { XHRInstrumentation } from '@grafana/faro-instrumentation-xhr';
 import {
   initializeFaro as coreInit,
   getWebInstrumentations,
@@ -32,6 +33,7 @@ export function initializeFaro(): Faro {
           },
         },
       }),
+      new XHRInstrumentation(),
     ],
     batching: {
       // Batching is enabled by default and there is normally no reason to disable it.
@@ -46,6 +48,20 @@ export function initializeFaro(): Faro {
   });
 
   faro.api.pushLog(['Faro was initialized']);
+
+  setTimeout(() => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', 'www.google.com', true);
+
+    xhr.onload = () => {
+      // Request finished. Do processing here.
+      if (xhr.status === 200) {
+        console.log(xhr.responseText);
+      }
+    };
+
+    xhr.send();
+  }, 5000);
 
   return faro;
 }

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -49,19 +49,5 @@ export function initializeFaro(): Faro {
 
   faro.api.pushLog(['Faro was initialized']);
 
-  setTimeout(() => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', 'www.google.com', true);
-
-    xhr.onload = () => {
-      // Request finished. Do processing here.
-      if (xhr.status === 200) {
-        console.log(xhr.responseText);
-      }
-    };
-
-    xhr.send();
-  }, 5000);
-
   return faro;
 }

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -166,15 +166,7 @@ export function shouldPropagateRumHeaders(
   url: string,
   propagateRumHeaderCorsUrls: FetchInstrumentationOptions['propagateRumHeaderCorsUrls'] = []
 ): boolean {
-  if (url.startsWith('https://example2.com')) {
-    console.log('url :>> ', url);
-  }
   return propagateRumHeaderCorsUrls.some((pattern) => {
-    if (url.startsWith('https://example2.com')) {
-      console.log('pattern :>> ', pattern);
-      console.log('return :>> ', isString(pattern) ? url.includes(pattern) : Boolean(url.match(pattern)));
-    }
-
     return isString(pattern) ? url.includes(pattern) : Boolean(url.match(pattern));
   });
 }

--- a/experimental/instrumentation-fetch/src/types.ts
+++ b/experimental/instrumentation-fetch/src/types.ts
@@ -1,3 +1,5 @@
+import type { Patterns } from '@grafana/faro-core';
+
 /**
  * Interface used to provide information to finish span on fetch error
  */
@@ -11,4 +13,10 @@ export interface FetchInstrumentationOptions {
   ignoredUrls?: Array<string | RegExp>;
   // For testing purposes - if true, fetch will be writable - necessary for jest tests
   testing?: boolean;
+
+  /**
+   * RUM headers are only added to URLs which have the same origin as the document.
+   * Ad other URLs which should have RUM headers added to this list.
+   */
+  propagateRumHeaderCorsUrls?: Patterns;
 }

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -26,8 +26,6 @@ export class XHRInstrumentation extends BaseInstrumentation {
     instrumentXMLHttpRequestOpen();
     instrumentXMLHttpRequestSend();
 
-    console.log('XHRInstrumentation');
-
     /**
      * XMLHttpRequest.prototype.open becomes instrumented and the parameter defaults are properly passed to the original function
      */

--- a/experimental/instrumentation-xhr/src/types.ts
+++ b/experimental/instrumentation-xhr/src/types.ts
@@ -1,6 +1,9 @@
+import type { Patterns } from '@grafana/faro-core';
+
 export interface XHRInstrumentationOptions {
   // For these URLs no events will be tracked
   ignoredUrls?: Array<string | RegExp>;
+  propagateRumHeaderCorsUrls?: Patterns;
 }
 
 export enum XHREventType {

--- a/experimental/instrumentation-xhr/src/utils.ts
+++ b/experimental/instrumentation-xhr/src/utils.ts
@@ -1,3 +1,7 @@
+import { isString } from '@grafana/faro-core';
+
+import type { XHRInstrumentationOptions } from './types';
+
 // This code parses the headers from an XMLHttpRequest and returns them as an object.
 export const parseXHRHeaders = (context: XMLHttpRequest): Record<string, any> => {
   const headers = context.getAllResponseHeaders().split('\r\n');
@@ -26,3 +30,12 @@ export const parseXHREvent = (context: XMLHttpRequest, event: ProgressEvent<Even
     status: status?.toString() ?? '',
   };
 };
+
+export function shouldPropagateRumHeaders(
+  url: string,
+  propagateRumHeaderCorsUrls: XHRInstrumentationOptions['propagateRumHeaderCorsUrls'] = []
+): boolean {
+  return propagateRumHeaderCorsUrls.some((pattern) => {
+    return isString(pattern) ? url.includes(pattern) : Boolean(url.match(pattern));
+  });
+}


### PR DESCRIPTION
## Why

Fetch and XHR instrumentations caused to CORS issues when sending requests to other origins.
This is because it adds the custom `x-faro-session-id` header to each request.

## What
* By default, the instruments only add the custom header to requests sent to the same origin.
* The user can configure external URLs which shall have custom headers added with the `propagateRumHeaderCorsUrls` option.


## Links
Fixes: https://github.com/grafana/faro-web-sdk/issues/409

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
