### PR TITLE
fix: remove storage sync between browser contexts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- fix (`@grafana/faro-web-sdk`): only create a single session_extend event across browsing contexts(#428)
 - fix (`@grafana/faro-web-sdk`): guard against missing `isSampled` (#425)
 - fix (`@grafana/faro-instrumentation-fetch`): only add custom headers to requests sent to the same
   origin as the document (#427)

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -49,19 +49,6 @@ export class PersistentSessionsManager {
       }
     });
 
-    window.addEventListener('storage', (event: StorageEvent) => {
-      if (event.key !== STORAGE_KEY) {
-        return;
-      }
-
-      const newSession: FaroUserSession = JSON.parse(event.newValue ?? '');
-      const previousSession: FaroUserSession = JSON.parse(event.oldValue ?? '');
-
-      if (newSession.sessionId !== previousSession.sessionId) {
-        faro.api?.setSession(newSession.sessionMeta);
-      }
-    });
-
     // Users can call the setSession() method, so we need to sync this with the local storage session
     faro.metas.addListener(function syncSessionIfChangedExternally(meta: Meta) {
       const session = meta.session;


### PR DESCRIPTION
## Why

The PersistetSessionManager registered a listener to the storage event and updated the session if a storage event was emitted from another browsing context.

This syncronisarions could lead to a case were multiple session_extend events are send.

The synchronisation is superflous and should be removed.

## What

Remove session sync on storage event

## Screenshots
### Before




https://github.com/grafana/faro-web-sdk/assets/47627413/4bfcbbaf-5884-481d-a8c5-2aa5ab8705b3




### After



https://github.com/grafana/faro-web-sdk/assets/47627413/f231c73e-fa55-4aea-96c1-c0b2a0d53fed



## Links



## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
