### PR TITLE
feat: disable `keepalive` if body size is >= 60 kb

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Next
 
-#431
-
-- enhancement (`@grafana/faro-transport-otlp-http`): Turn of beaconing if request body exceeds a
+- enhancement (`@grafana/faro-transport-otlp-http`): Turn off beaconing if request body exceeds a
   certain size limit (#431).
 
 ## 1.3.0 – 1.3.5

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+#431
+
+- enhancement (`@grafana/faro-transport-otlp-http`): Turn of beaconing if request body exceeds a
+  certain size limit (#431).
+
 ## 1.3.0 – 1.3.5
 
 - fix (`@grafana/faro-instrumentation-fetch`): only add custom headers to requests sent to the same

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -1,12 +1,4 @@
-import {
-  getTransportBody,
-  LogEvent,
-  LogLevel,
-  TraceEvent,
-  TransportItem,
-  TransportItemType,
-  VERSION,
-} from '@grafana/faro-core';
+import { LogEvent, LogLevel, TraceEvent, TransportItem, TransportItemType, VERSION } from '@grafana/faro-core';
 import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
 
 import type { LogRecord, Logs } from './payload';
@@ -29,7 +21,7 @@ const largeItem: TransportItem<LogEvent> = {
     context: {},
     level: LogLevel.INFO,
     message: Buffer.alloc(60_000, 'I').toString('utf-8'),
-    timestamp: new Date().toISOString(),
+    timestamp: '2023-01-27T09:53:01.035Z',
   },
   meta: {},
 };
@@ -325,6 +317,26 @@ describe('OtlpHttpTransport', () => {
     });
   });
 
+  // it('will turn off keepalive if the payload length is over 60_000', async () => {
+  //   const transport = new OtlpHttpTransport({
+  //     logsURL: 'www.example.com/v1/logs',
+  //   });
+
+  //   transport.internalLogger = mockInternalLogger;
+
+  //   transport.send([largeItem]);
+
+  //   expect(fetch).toHaveBeenCalledTimes(1);
+  //   expect(fetch).toHaveBeenCalledWith('www.example.com/v1/logs', {
+  //     body: JSON.stringify(getTransportBody([largeItem])),
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     keepalive: false,
+  //     method: 'POST',
+  //   });
+  // });
+
   it('will turn off keepalive if the payload length is over 60_000', async () => {
     const transport = new OtlpHttpTransport({
       logsURL: 'www.example.com/v1/logs',
@@ -336,7 +348,77 @@ describe('OtlpHttpTransport', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith('www.example.com/v1/logs', {
-      body: JSON.stringify(getTransportBody([largeItem])),
+      // body: JSON.stringify({
+      //   resourceLogs: [
+      //     {
+      //       resource: {
+      //         attributes: [],
+      //       },
+      //       scopeLogs: [
+      //         {
+      //           scope: {
+      //             name: '@grafana/faro-web-sdk',
+      //             version: VERSION,
+      //           },
+      //           logRecords: [
+      //             {
+      //               timeUnixNano: 1702986676380000000,
+      //               severityNumber: 9,
+      //               severityText: 'INFO',
+      //               body: {
+      //                 stringValue: largeItem.payload.message,
+      //               },
+      //               attributes: [
+      //                 {
+      //                   key: 'faro.log.context',
+      //                   value: {
+      //                     kvlistValue: { values: [] },
+      //                   },
+      //                 },
+      //               ],
+      //             } as LogRecord,
+      //           ],
+      //         },
+      //       ],
+      //     },
+      //   ],
+      // }),
+      // body: 'a',
+      body: JSON.stringify({
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [],
+            },
+            scopeLogs: [
+              {
+                scope: {
+                  name: '@grafana/faro-web-sdk',
+                  version: VERSION,
+                },
+                logRecords: [
+                  {
+                    timeUnixNano: 1674813181035000000,
+                    severityNumber: 9,
+                    severityText: 'INFO',
+                    body: {
+                      stringValue: largeItem.payload.message,
+                    },
+                    attributes: [
+                      {
+                        key: 'faro.log.context',
+                        value: {
+                          kvlistValue: { values: [] },
+                        },
+                      },
+                    ],
+                  } as LogRecord,
+                ],
+              },
+            ],
+          },
+        ],
+      }),
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Why

Browsers put size restrictions on the body size of requests sent with the beacon API.
This can lead to data loss for large payloads.

## What
* Disable `keepalive` if body size exceeds 60kb

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
