### PR TITLE
chore: use reverse domain name as web-storage item prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- chore (`@grafana/faro-web-sdk`): change storage key prefix for faro session to use reverse domain
+  notation (#432)
+
 ## 1.3.5
 
 - fix (`@grafana/faro-web-sdk`): Multiple session_extend events were emitted if multiple

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
@@ -1,6 +1,6 @@
 import type { Config } from '@grafana/faro-core';
 
-export const STORAGE_KEY = '__FARO_SESSION__';
+export const STORAGE_KEY = 'com.grafana.faro.session';
 export const SESSION_EXPIRATION_TIME = 4 * 60 * 60 * 1000; // hrs
 export const SESSION_INACTIVITY_TIME = 15 * 60 * 1000; // minutes
 export const STORAGE_UPDATE_DELAY = 1 * 1000; // seconds


### PR DESCRIPTION
## Why

to better align to common naming schemes as well as grafana naming for local web-strorage keys

## What

Change key to use reverese domain notation as pefix. `'com.grafana.faro.session'`

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
