### PR TITLE
fix: fix the check for presence of Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - chore (`@grafana/faro-web-sdk`): change storage key prefix for faro session to use reverse domain
   notation (#432)
+- fix(`@grafana/faro-core`): fix the check for the presence of Event
 
 ## 1.3.5
 

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -45,7 +45,7 @@ export const isPrimitive = ((value) => !isObject(value) && !isFunction(value)) a
   string | number | bigint | boolean | symbol
 >;
 
-export const isEventDefined = !isUndefined(Event);
+export const isEventDefined = typeof Event !== 'undefined';
 
 export const isEvent = ((value) => isEventDefined && isInstanceOf(value, Event)) as IsFnHelper<Event>;
 


### PR DESCRIPTION
## Why

The check for `undefined` by using a function will fail on React Native, as `Event` will be needed to be accessed to pass it as an argument, and it's not defined.

Such check will fail in the browser as well:

<img width="468" alt="Screenshot 2023-12-20 at 6 47 15 AM" src="https://github.com/grafana/faro-web-sdk/assets/16039/689147b1-a28d-48b3-932a-63f5ef1c0082">

## What

Use the "classic" check instead

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
