### PR TITLE
430 add body field for measurement logs for otlp transport

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -8,6 +8,7 @@ import {
   ReactRouterVersion,
 } from '@grafana/faro-react';
 import type { Faro } from '@grafana/faro-react';
+import { OtlpHttpTransport } from '@grafana/faro-transport-otlp-http';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { env } from '../utils';

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -8,7 +8,6 @@ import {
   ReactRouterVersion,
 } from '@grafana/faro-react';
 import type { Faro } from '@grafana/faro-react';
-import { OtlpHttpTransport } from '@grafana/faro-transport-otlp-http';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { env } from '../utils';

--- a/experimental/transport-otlp-http/README.md
+++ b/experimental/transport-otlp-http/README.md
@@ -75,7 +75,8 @@ initializeFaro({
       otlpTransform: {
         // create custom body string for measurement logs
         createMeasurementLogBody(item) {
-          // Note: It's not advisable to built big strings which contain redundant data because it ads unnecessary bytes to the requests and your storage solution
+          // Note: It's not advisable to built big strings which contain redundant data because
+          // it ads unnecessary bytes to the requests and your storage solution
           // This example is to show how we can use the transport-item to built a custom string
           const { payload } = item;
           const [measurementName, measurementValue] = Object.entries(payload.values).flat();
@@ -84,7 +85,8 @@ initializeFaro({
         },
         // create custom body string for error logs
         createErrorLogBody(item) {
-          // Note: It's not advisable to built big strings which contain redundant data because it ads unnecessary bytes to the requests and your storage solution
+          // Note: It's not advisable to built big strings which contain redundant data because
+          // it ads unnecessary bytes to the requests and your storage solution
           // This example is to show how we can use the transport-item to built a custom string
           const { payload } = item;
           const body = `faro.signal.error: type=${payload.type} message=${payload.value}`;
@@ -109,5 +111,7 @@ initializeFaro({
 - `tracesURL?: string`: Endpoint to send Traces to.
 - `logsURL?: string`: Endpoint to send Logs to.
 - `otlpTransform?:`: Customize parts of logs transformation.
-- `otlpTransform.createErrorLogBody?: (item: TransportItem<ExceptionEvent>) => string`: create custom body for error logs.
-  `otlpTransform.createMeasurementLogBody?: (item: TransportItem<MeasurementEvent>) => string;`: create custom body for measurement logs.
+- `otlpTransform.createErrorLogBody?: (item: TransportItem<ExceptionEvent>) => string`:
+  create custom body for error logs.
+  `otlpTransform.createMeasurementLogBody?: (item: TransportItem<MeasurementEvent>) => string;`:
+  create custom body for measurement logs.

--- a/experimental/transport-otlp-http/README.md
+++ b/experimental/transport-otlp-http/README.md
@@ -41,6 +41,61 @@ initializeFaro({
 The Faro OtlpHttpTransport converts the Faro model to the Otlp schema, so you can send Faro data to
 compatible Otel Receivers.
 
+### Optional `body` property in Logs of type `Measurement` and `Exception`
+
+The `body` field is optional as defined by the Otel Log spec.
+Because of this we only add the body property only to signals which have a body value.
+This is all signals besides of `Measurement` and `Exception`
+
+This can cause issues with some Otel Collector components.
+
+Faro provides the `createErrorLogBody` and `createMeasurementLogBody` functions which you can use
+to create a body string for these logs.
+Both properties are part of the `otlpTransform` object in `OtlpHttpTransportOptions`.
+
+As a parameter each function gets the transport item of the log which is currently in transformation.
+You can use values from this object to built a custom string.
+
+#### Example
+
+```ts
+initializeFaro({
+  // ...
+  instrumentations: [
+    // Load the default Web instrumentations
+    ...getWebInstrumentations(),
+  ],
+  transports: [
+    new OtlpHttpTransport({
+      apiKey: env.faro.apiKey,
+      logsURL: 'https://example.com/v1/logs',
+      tracesURL: 'https://example.com/v1/traces',
+
+      // customize logs transformation
+      otlpTransform: {
+        // create custom body string for measurement logs
+        createMeasurementLogBody(item) {
+          // Note: It's not advisable to built big strings which contain redundant data because it ads unnecessary bytes to the requests and your storage solution
+          // This example is to show how we can use the transport-item to built a custom string
+          const { payload } = item;
+          const [measurementName, measurementValue] = Object.entries(payload.values).flat();
+          const body = `faro.signal.measurement: type=${payload.type} name=${measurementName} value=${measurementValue}`;
+          return body;
+        },
+        // create custom body string for error logs
+        createErrorLogBody(item) {
+          // Note: It's not advisable to built big strings which contain redundant data because it ads unnecessary bytes to the requests and your storage solution
+          // This example is to show how we can use the transport-item to built a custom string
+          const { payload } = item;
+          const body = `faro.signal.error: type=${payload.type} message=${payload.value}`;
+          return body;
+        },
+      },
+    }),
+  ],
+});
+```
+
 ### Config Options
 
 - `apiKey?: string`: Will be added as `x-api-key` header.
@@ -53,3 +108,6 @@ compatible Otel Receivers.
   sending the data.
 - `tracesURL?: string`: Endpoint to send Traces to.
 - `logsURL?: string`: Endpoint to send Logs to.
+- `otlpTransform?:`: Customize parts of logs transformation.
+- `otlpTransform.createErrorLogBody?: (item: TransportItem<ExceptionEvent>) => string`: create custom body for error logs.
+  `otlpTransform.createMeasurementLogBody?: (item: TransportItem<MeasurementEvent>) => string;`: create custom body for measurement logs.

--- a/experimental/transport-otlp-http/src/payload/OtelPayload.test.ts
+++ b/experimental/transport-otlp-http/src/payload/OtelPayload.test.ts
@@ -139,14 +139,14 @@ describe('OtelPayload', () => {
   };
 
   it('Creates an instance with empty OtelPayload', () => {
-    const otelPayload = new OtelPayload(mockInternalLogger);
+    const otelPayload = new OtelPayload({ internalLogger: mockInternalLogger });
     const payload = otelPayload.getPayload();
 
     expect(payload.resourceLogs).toHaveLength(0);
   });
 
   it('Creates an instance containing the correct resourceLog for the given TransportItem', () => {
-    const otelPayload = new OtelPayload(mockInternalLogger, logTransportItem);
+    const otelPayload = new OtelPayload({ internalLogger: mockInternalLogger, transportItem: logTransportItem });
     const payload = otelPayload.getPayload();
 
     expect(payload.resourceLogs).toHaveLength(1);
@@ -162,7 +162,7 @@ describe('OtelPayload', () => {
       meta: { browser: { name: 'Firefox' } },
     };
 
-    const otelPayload = new OtelPayload(mockInternalLogger, transportItem);
+    const otelPayload = new OtelPayload({ internalLogger: mockInternalLogger, transportItem });
 
     otelPayload.addResourceItem({
       ...transportItem,
@@ -186,7 +186,7 @@ describe('OtelPayload', () => {
   });
 
   it('Adds a new ResourceSpan', () => {
-    const otelPayload = new OtelPayload(mockInternalLogger, traceTransportItem);
+    const otelPayload = new OtelPayload({ internalLogger: mockInternalLogger, transportItem: traceTransportItem });
     const payload = otelPayload.getPayload();
 
     expect(payload.resourceLogs).toHaveLength(0);

--- a/experimental/transport-otlp-http/src/payload/OtelPayload.ts
+++ b/experimental/transport-otlp-http/src/payload/OtelPayload.ts
@@ -1,8 +1,16 @@
 import { InternalLogger, TraceEvent, TransportItem, TransportItemType } from '@grafana/faro-core';
 
+import type { OtlpHttpTransportOptions } from '../types';
+
 import { getLogTransforms, getTraceTransforms, LogsTransform, TraceTransform } from './transform';
 import type { ResourceLogs, ResourceSpans } from './transform/types';
 import type { OtelTransportPayload } from './types';
+
+type OtelPayloadParams = {
+  internalLogger: InternalLogger;
+  transportItem?: TransportItem;
+  customOtlpTransform?: OtlpHttpTransportOptions['otlpTransform'];
+};
 
 export class OtelPayload {
   private resourceLogs: ResourceLogs;
@@ -11,14 +19,13 @@ export class OtelPayload {
   private getLogTransforms: LogsTransform;
   private getTraceTransforms: TraceTransform;
 
-  constructor(
-    private internalLogger: InternalLogger,
-    transportItem?: TransportItem
-  ) {
+  private internalLogger: InternalLogger;
+
+  constructor({ internalLogger, customOtlpTransform, transportItem }: OtelPayloadParams) {
     this.internalLogger = internalLogger;
     this.resourceLogs = [];
 
-    this.getLogTransforms = getLogTransforms(this.internalLogger);
+    this.getLogTransforms = getLogTransforms(this.internalLogger, customOtlpTransform);
     this.getTraceTransforms = getTraceTransforms(this.internalLogger);
 
     if (transportItem) {

--- a/experimental/transport-otlp-http/src/payload/transform/index.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/index.ts
@@ -11,4 +11,5 @@ export type {
   Scope,
   ScopeLog,
   TraceTransform,
+  StringValueNonNullable,
 } from './types';

--- a/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toErrorLogRecord.test.ts
@@ -67,6 +67,10 @@ const item: TransportItem<ExceptionEvent> = {
 const matchErrorLogRecord = {
   timeUnixNano: 1674813181035000000,
 
+  body: {
+    stringValue: 'signal.error',
+  },
+
   attributes: [
     {
       key: 'view.name',

--- a/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
@@ -167,6 +167,9 @@ const matchMeasurementLogRecord = {
 describe('toMeasurementLogRecord', () => {
   it('Builds resource payload object for given transport item.', () => {
     const measurementLogRecord = getLogTransforms(mockInternalLogger).toScopeLog(item).logRecords[0];
+
+    console.log('measurementLogRecord :>> ', measurementLogRecord);
+
     expect(measurementLogRecord).toMatchObject(matchMeasurementLogRecord);
   });
 });

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -141,9 +141,11 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
   function toErrorLogRecord(transportItem: TransportItem<ExceptionEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
+    const body = toAttributeValue(`signal.error`) as StringValueNonNullable;
 
     return {
       timeUnixNano,
+      body,
       attributes: [
         ...getCommonLogAttributes(meta),
         toAttribute(SemanticAttributes.EXCEPTION_TYPE, payload.type),
@@ -162,9 +164,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
     const [measurementName, measurementValue] = Object.entries(payload.values).flat();
 
-    const body = toAttributeValue(
-      `Measurement: ${payload.type}.${measurementName}=${measurementValue}`
-    ) as StringValueNonNullable;
+    const body = toAttributeValue(`signal.measurement`) as StringValueNonNullable;
 
     return {
       timeUnixNano,

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -141,7 +141,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
   function toErrorLogRecord(transportItem: TransportItem<ExceptionEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
-    const body = toAttributeValue(`signal.error`) as StringValueNonNullable;
+    const body = toAttributeValue('signal.error') as StringValueNonNullable;
 
     return {
       timeUnixNano,
@@ -163,8 +163,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
     const [measurementName, measurementValue] = Object.entries(payload.values).flat();
-
-    const body = toAttributeValue(`signal.measurement`) as StringValueNonNullable;
+    const body = toAttributeValue('signal.measurement') as StringValueNonNullable;
 
     return {
       timeUnixNano,

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -29,6 +29,7 @@ import type {
   ResourceMeta,
   ResourceSpan,
   ScopeLog,
+  StringValueNonNullable,
   TraceTransform,
 } from './types';
 
@@ -87,9 +88,9 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
   function toLogLogRecord(transportItem: TransportItem<LogEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
-    const body = toAttributeValue(payload.message) as { stringValue: string; key: string };
+    const body = toAttributeValue(payload.message) as StringValueNonNullable;
 
-    function getSeverityProperties(logLevel: LogLevel): { severityNumber: number; severityText: string } {
+    function getSeverityProperties(logLevel: LogLevel) {
       switch (logLevel) {
         case LogLevel.TRACE:
           return { severityNumber: 1, severityText: 'TRACE' };
@@ -121,7 +122,7 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
   function toEventLogRecord(transportItem: TransportItem<EventEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
-    const body = toAttributeValue(payload.name) as { stringValue: string; key: string };
+    const body = toAttributeValue(payload.name) as StringValueNonNullable;
 
     return {
       timeUnixNano,
@@ -161,8 +162,13 @@ export function getLogTransforms(internalLogger: InternalLogger): LogsTransform 
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
     const [measurementName, measurementValue] = Object.entries(payload.values).flat();
 
+    const body = toAttributeValue(
+      `Measurement: ${payload.type}.${measurementName}=${measurementValue}`
+    ) as StringValueNonNullable;
+
     return {
       timeUnixNano,
+      body,
       attributes: [
         ...getCommonLogAttributes(meta),
         toAttribute('measurement.type', payload.type),

--- a/experimental/transport-otlp-http/src/payload/transform/types.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/types.ts
@@ -58,3 +58,5 @@ export type TraceTransform = {
 };
 
 export type ResourceMeta = Pick<Meta, 'app' | 'browser' | 'sdk'>;
+
+export type StringValueNonNullable = { stringValue: string };

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -40,7 +40,10 @@ export class OtlpHttpTransport extends BaseTransport {
   }
 
   send(items: TransportItem[]): void {
-    const otelPayload = new OtelPayload(this.internalLogger);
+    const otelPayload = new OtelPayload({
+      internalLogger: this.internalLogger,
+      customOtlpTransform: this.options.otlpTransform,
+    });
 
     items.forEach((item) => otelPayload.addResourceItem(item));
     this.sendPayload(otelPayload.getPayload());

--- a/experimental/transport-otlp-http/src/types.ts
+++ b/experimental/transport-otlp-http/src/types.ts
@@ -1,3 +1,5 @@
+import type { ExceptionEvent, MeasurementEvent, TransportItem } from '@grafana/faro-core';
+
 export interface OtlpTransportRequestOptions extends Omit<RequestInit, 'body' | 'headers'> {
   headers?: Record<string, string>;
 }
@@ -23,4 +25,13 @@ export interface OtlpHttpTransportOptions {
   // The Otel spec defines separate endpoints per signal
   readonly tracesURL?: string;
   readonly logsURL?: string;
+
+  // customize aspects about logs transformation
+  otlpTransform?: {
+    // Body field is optional in Otel Log spec, but can cause issues with Otel Collector components.
+    // By default Faro does not send a body for logs of type error and measurement.
+    // Users can define a body string by using the following functions.
+    createErrorLogBody?: (item: TransportItem<ExceptionEvent>) => string;
+    createMeasurementLogBody?: (item: TransportItem<MeasurementEvent>) => string;
+  };
 }


### PR DESCRIPTION
## Why

Enhancement request from the community

> Faro web vitals measurements are sent without a body field in the OTLP transport. The body field is optional in the [Otel Log spec](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body) but can cause issues with Otel Collector components (e.g. Splunk HEC Exporter).

## What

* Keep the current behavior but provide options to the user to configure a custom string which will be attached as a body property.
* Provide this functionality also to logs of type `Exception`
* Do a small refactoring to reduce the number of parameter in `OtelPayload.ts`
* Update docs

## Links

Resolves: #430

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
