### PR TITLE
FetchTransport: make sessionId retrieval more stable

### DIFF
--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -47,7 +47,11 @@ export class FetchTransport extends BaseTransport {
 
         const { headers, ...restOfRequestOptions } = requestOptions ?? {};
 
-        const sessionId = this.metas.value.session?.id;
+        let sessionId;
+        const sessionMeta = this.metas.value.session;
+        if (sessionMeta != null) {
+          sessionId = sessionMeta.id;
+        }
 
         return fetch(url, {
           method: 'POST',


### PR DESCRIPTION
## Why

It can happen that the transpiled JS code of the FetchTransport to get the sessionId from the sessionMeta will cause an error if the session meta is absent. 
Since the exception is handled, Faro will not send the respective item.

It caused by translating a property retrieval where we use optional chaining.

## What
Instead of optional chaining use explicit code to check if session meta is available.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Screenshots

### Error
<img width="809" alt="Screenshot 2023-12-22 at 09 49 12" src="https://github.com/grafana/faro-web-sdk/assets/47627413/b19fb389-2219-4e77-950f-3220e340985b">


### Transpiled code before
<img width="972" alt="Screenshot 2023-12-22 at 10 10 05" src="https://github.com/grafana/faro-web-sdk/assets/47627413/7688b869-c400-4b90-b7a8-a852eb0a8e4b">

### Transpiled code after
<img width="393" alt="Screenshot 2023-12-22 at 10 13 42" src="https://github.com/grafana/faro-web-sdk/assets/47627413/807a1a37-c384-4741-9eb0-f06adc02c568">

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
