### PR TITLE
fix: patch demo for arm64

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   cortex:
     env_file:
       - './.env'
-    image: 'cortexproject/cortex:v1.13.0'
+    image: 'cortexproject/cortex:v1.14.1'
     volumes:
       - '${CORTEX_CONFIG_PATH_LOCAL}:${CORTEX_CONFIG_PATH}'
     entrypoint:


### PR DESCRIPTION
## Why
Running the DEMO on Mac hardware like an Mx will fail without support for ARM. `v1.14.1` looks to be the first to support `arm64`. 

```
 ✔ Container faro-web-sdk-cortex-1                                                                                                                       Recreated0.1s 
 ! cortex The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s 
 ⠋ Container faro-web-sdk-agent-1                                                                                                                        Creating0.0s 
```

## What

Bumped the version of `cortex` to one that supports ARM.

## Links

[Cortext Dockerhub](https://hub.docker.com/r/cortexproject/cortex/tags)

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
