### PR TITLE
Add deployment.environment filled with MetaApp environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-web-tracing`): Add `deployment.environment` filled with the value of
+  the MetaApp environment variable (#453)
 - chore (`@grafana/faro-web-sdk`): change storage key prefix for faro session to use reverse domain
   notation (#432)
 - fix (`@grafana/faro-core`): fix the check for the presence of Event (#436)

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -39,6 +39,10 @@ export class TracingInstrumentation extends BaseInstrumentation {
       attributes[SemanticResourceAttributes.SERVICE_VERSION] = this.config.app.version;
     }
 
+    if (this.config.app.environment) {
+      attributes[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT] = this.config.app.environment;
+    }
+
     Object.assign(attributes, options.resourceAttributes);
 
     const resource = Resource.default().merge(new Resource(attributes));


### PR DESCRIPTION
Traces generated only contain `service.name` and `service.version` based on the MetaApp data.
https://github.com/grafana/faro-web-sdk/blob/a5f43a1f1bbe1f5a0c02546fe32c9d651f6a20db/packages/core/src/metas/types.ts#L28

MetaApp also has `environment`, but that is not propagated to the traces.

OpenTelemetry has the `deployment.environment` attribute as standard attribute for environment which can be filled.

It is possible to fill the attribute through initialisation, see 
https://ceesbos.nl/posts/20240108-grafana-faro-trace-with-deployment-environment/

But better is to make it part of the library itself and fill the standard attributes.