### PR TITLE
fix: cortex config for demo

### DIFF
--- a/infra/cortex/config/cortex.yaml
+++ b/infra/cortex/config/cortex.yaml
@@ -56,10 +56,11 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: false
-  storage:
-    type: 'local'
-    local:
-      directory: '/tmp/cortex/rules'
+
+ruler_storage:
+  backend: 'local'
+  local:
+    directory: '/tmp/cortex/rules'
 
 limits:
   ingestion_rate: 250000


### PR DESCRIPTION
## Why

I just cloned a fresh repo to my WSL ubuntu distro and was not able to run the `cortex` container

See:
![image](https://github.com/grafana/faro-web-sdk/assets/3078595/765e43b8-049d-48a3-95af-3f22333b1f76)

## What

Cortex config according to official docs: https://cortexmetrics.io/docs/configuration/configuration-file/
