### PR TITLE
chore: add missing response time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-web-sdk`): add response time to performance timings (#465).
+
 ## 1.3.6
 
 - Feature preview (`@grafana/faro-web-sdk`): instrument navigation and resource timings. As long as

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -26,6 +26,7 @@ describe('performanceUtils', () => {
       tlsNegotiationTime: '33',
       redirectTime: '1',
       requestTime: '109',
+      responseTime: '0',
       fetchTime: '305',
       serviceWorkerTime: '237',
       decodedBodySize: '530675',

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -56,6 +56,7 @@ export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourc
     tlsNegotiationTime: toFaroPerformanceTimingString(requestStart - secureConnectionStart),
     redirectTime: toFaroPerformanceTimingString(redirectEnd - redirectStart),
     requestTime: toFaroPerformanceTimingString(responseStart - requestStart),
+    responseTime: toFaroPerformanceTimingString(responseEnd - responseStart),
     fetchTime: toFaroPerformanceTimingString(responseEnd - fetchStart),
     serviceWorkerTime: toFaroPerformanceTimingString(fetchStart - workerStart),
     decodedBodySize: toFaroPerformanceTimingString(decodedBodySize),

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -18,6 +18,7 @@ export type FaroResourceTiming = Readonly<{
   redirectTime: string;
   requestTime: string;
   fetchTime: string;
+  responseTime: string;
   serviceWorkerTime: string;
   decodedBodySize: string;
   encodedBodySize: string;


### PR DESCRIPTION
## Why

Response time was missing in resource timing.
Response time is part of the fetch time, but we need it for more granular insights.

## What

Add response time to Faro resource entries.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
