### PR TITLE
feat: enable performance timeline by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## 1.3.8
 
 - Deps (`@grafana/faro-web-tracing`, `@grafana/faro-core`): Update OpenTelemetry dependencies (#475).
+- Feat (`@grafana/faro-web-sdk`): Enable Faro Navigation and Resource timings instrumentation by default (#482).
 
 ## 1.3.7
 

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -19,8 +19,8 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
     new ViewInstrumentation(),
   ];
 
-  if (options.enablePerformanceInstrumentation === true) {
-    // ensure that it gets initialized as early as possible
+  if (options.enablePerformanceInstrumentation !== false) {
+    // unshift to ensure that initialization starts before the other instrumentations
     instrumentations.unshift(new PerformanceInstrumentation());
   }
 

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -8,9 +8,5 @@ export interface BrowserConfig extends Partial<Omit<Config, 'app' | 'parseStackt
 export interface GetWebInstrumentationsOptions {
   captureConsole?: boolean;
   captureConsoleDisabledLevels?: LogLevel[];
-  /**
-   * The performance instrumentation is currently in preview phase so it has to be enabled manually.
-   * Once preview phase is over, it is enabled by default.
-   */
   enablePerformanceInstrumentation?: boolean;
 }


### PR DESCRIPTION
## Why
Enable performance timeline instrumentation to deliver value for performance insights early.



## What
* Enable instrumentation by default
* Write docs: 
  -  issue: #481 

## Links

Docs PR (privaet repo): https://github.com/grafana/faro/issues/11

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
