### PR TITLE
Add resource load duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing (#490).
+
 ## 1.3.8
 
 - Deps (`@grafana/faro-web-tracing`, `@grafana/faro-core`): Update OpenTelemetry dependencies (#475).

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -4,7 +4,7 @@ import type { EventsAPI } from '@grafana/faro-core';
 import { getItem, setItem, webStorageType } from '../../utils';
 
 import { NAVIGATION_ENTRY, NAVIGATION_ID_STORAGE_KEY } from './performanceConstants';
-import { calculateFaroNavigationTiming, calculateFaroResourceTiming, entryUrlIsIgnored } from './performanceUtils';
+import { calculateFaroNavigationTiming, entryUrlIsIgnored } from './performanceUtils';
 import type { FaroNavigationItem } from './types';
 
 export function getNavigationTimings(
@@ -26,7 +26,6 @@ export function getNavigationTimings(
     const faroPreviousNavigationId = getItem(NAVIGATION_ID_STORAGE_KEY, webStorageType.session) ?? 'unknown';
 
     const faroNavigationEntry: FaroNavigationItem = {
-      ...calculateFaroResourceTiming(navigationEntryRaw.toJSON()),
       ...calculateFaroNavigationTiming(navigationEntryRaw.toJSON()),
       faroNavigationId: genShortID(),
       faroPreviousNavigationId,

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -1,25 +1,20 @@
 import { calculateFaroNavigationTiming, calculateFaroResourceTiming } from './performanceUtils';
-import { performanceNavigationEntry } from './performanceUtilsTestData';
+import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 import type { FaroNavigationTiming, FaroResourceTiming } from './types';
 
 describe('performanceUtils', () => {
-  it(`calculates navigation timings`, () => {
+  it(`calculates navigation timing`, () => {
     const faroNavigationTiming = calculateFaroNavigationTiming(performanceNavigationEntry);
     expect(faroNavigationTiming).toStrictEqual({
       visibilityState: 'visible',
-      totalNavigationTime: '2700',
+      duration: '2700',
       pageLoadTime: '2441',
       domProcessingTime: '1431',
       onLoadTime: '22',
       domContentLoadHandlerTime: '3',
       ttfb: '542',
       type: 'navigate',
-    } as FaroNavigationTiming);
-  });
 
-  it(`calculates resource timings`, () => {
-    const faroResourceTiming = calculateFaroResourceTiming(performanceNavigationEntry);
-    expect(faroResourceTiming).toStrictEqual({
       name: 'http://example.com',
       tcpHandshakeTime: '53',
       dnsLookupTime: '139',
@@ -35,6 +30,28 @@ describe('performanceUtils', () => {
       renderBlockingStatus: 'unknown',
       protocol: 'h2',
       initiatorType: 'navigation',
+    } as FaroNavigationTiming);
+  });
+
+  it(`calculates resource timings`, () => {
+    const faroResourceTiming = calculateFaroResourceTiming(performanceResourceEntry);
+    expect(faroResourceTiming).toStrictEqual({
+      name: 'http://example.com/awesome-image',
+      duration: '370',
+      tcpHandshakeTime: '0',
+      dnsLookupTime: '0',
+      tlsNegotiationTime: '11',
+      redirectTime: '0',
+      requestTime: '359',
+      responseTime: '0',
+      fetchTime: '370',
+      serviceWorkerTime: '778',
+      decodedBodySize: '10526',
+      encodedBodySize: '10526',
+      cacheHitStatus: 'fullLoad',
+      renderBlockingStatus: 'unknown',
+      protocol: 'h2',
+      initiatorType: 'img',
     } as FaroResourceTiming);
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -52,7 +52,7 @@ export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourc
 
   return {
     name: name,
-    resourceLoadDuration: toFaroPerformanceTimingString(duration),
+    duration: toFaroPerformanceTimingString(duration),
     tcpHandshakeTime: toFaroPerformanceTimingString(connectEnd - connectStart),
     dnsLookupTime: toFaroPerformanceTimingString(domainLookupEnd - domainLookupStart),
     tlsNegotiationTime: toFaroPerformanceTimingString(requestStart - secureConnectionStart),
@@ -98,7 +98,6 @@ export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNav
     domContentLoadedEventEnd,
     domContentLoadedEventStart,
     domInteractive,
-    duration,
     fetchStart,
     loadEventEnd,
     loadEventStart,
@@ -108,7 +107,6 @@ export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNav
 
   return {
     visibilityState: document.visibilityState,
-    navigationDuration: toFaroPerformanceTimingString(duration),
     pageLoadTime: toFaroPerformanceTimingString(domComplete - fetchStart),
     domProcessingTime: toFaroPerformanceTimingString(domComplete - domInteractive),
     domContentLoadHandlerTime: toFaroPerformanceTimingString(domContentLoadedEventEnd - domContentLoadedEventStart),
@@ -119,6 +117,8 @@ export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNav
     ttfb: toFaroPerformanceTimingString(Math.max(responseStart - (activationStart ?? 0), 0)),
 
     type: type,
+
+    ...calculateFaroResourceTiming(navigationEntryRaw),
   };
 }
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -30,6 +30,7 @@ export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourc
     decodedBodySize,
     domainLookupEnd,
     domainLookupStart,
+    duration,
     encodedBodySize,
     fetchStart,
     initiatorType,
@@ -51,6 +52,7 @@ export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourc
 
   return {
     name: name,
+    resourceLoadDuration: toFaroPerformanceTimingString(duration),
     tcpHandshakeTime: toFaroPerformanceTimingString(connectEnd - connectStart),
     dnsLookupTime: toFaroPerformanceTimingString(domainLookupEnd - domainLookupStart),
     tlsNegotiationTime: toFaroPerformanceTimingString(requestStart - secureConnectionStart),
@@ -106,7 +108,7 @@ export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNav
 
   return {
     visibilityState: document.visibilityState,
-    totalNavigationTime: toFaroPerformanceTimingString(duration),
+    navigationDuration: toFaroPerformanceTimingString(duration),
     pageLoadTime: toFaroPerformanceTimingString(domComplete - fetchStart),
     domProcessingTime: toFaroPerformanceTimingString(domComplete - domInteractive),
     domContentLoadHandlerTime: toFaroPerformanceTimingString(domContentLoadedEventEnd - domContentLoadedEventStart),

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -1,5 +1,5 @@
 export type FaroNavigationTiming = Readonly<{
-  totalNavigationTime: string;
+  navigationDuration: string;
   visibilityState: DocumentVisibilityState;
   domProcessingTime: string;
   pageLoadTime: string;
@@ -11,6 +11,7 @@ export type FaroNavigationTiming = Readonly<{
 
 export type FaroResourceTiming = Readonly<{
   name: string;
+  resourceLoadDuration: string;
   protocol: string;
   tcpHandshakeTime: string;
   dnsLookupTime: string;

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -1,17 +1,19 @@
-export type FaroNavigationTiming = Readonly<{
-  navigationDuration: string;
-  visibilityState: DocumentVisibilityState;
-  domProcessingTime: string;
-  pageLoadTime: string;
-  domContentLoadHandlerTime: string;
-  onLoadTime: string;
-  ttfb: string;
-  type: NavigationTimingType;
-}>;
+export type FaroNavigationTiming = Readonly<
+  {
+    duration: string;
+    visibilityState: DocumentVisibilityState;
+    domProcessingTime: string;
+    pageLoadTime: string;
+    domContentLoadHandlerTime: string;
+    onLoadTime: string;
+    ttfb: string;
+    type: NavigationTimingType;
+  } & FaroResourceTiming
+>;
 
 export type FaroResourceTiming = Readonly<{
   name: string;
-  resourceLoadDuration: string;
+  duration: string;
   protocol: string;
   tcpHandshakeTime: string;
   dnsLookupTime: string;


### PR DESCRIPTION
## Why

Duration of a resource load was missing

## What
* Add resource load `duration` property
* Rename `totalNavigationTime` property to duration
* Make calculation of `faro.performance.navigation` entries explicit.
  - `calculateFaroNavigationTiming()` now calls `calculateFaroResourceTiming()`. Before both methods were called separately, e. g. by the `navigation` instrumentation, to calculate a nav timing.
  - The `navigation` instrumentation now needs only to call `calculateFaroNavigationTiming()` to calculate a `faro.performance.navigation` entry.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Screenshots
<img width="292" alt="Screenshot 2024-02-20 at 15 06 52" src="https://github.com/grafana/faro-web-sdk/assets/47627413/817d8496-a8ef-40db-9799-2851f997de38">

<img width="311" alt="Screenshot 2024-02-20 at 15 06 38" src="https://github.com/grafana/faro-web-sdk/assets/47627413/1d1f8aeb-53b0-4677-a4e6-80a923fa6111">


## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
