### PR TITLE
fix: crash when navigator.userAgentData is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing (#490).
+- Fix (`@grafana/faro-web-sdk`): crash when navigator.userAgentData is undefined (#494).
 
 ## 1.3.8
 

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -29,7 +29,7 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       return undefined;
     }
 
-    if ('userAgentData' in navigator) {
+    if ('userAgentData' in navigator && navigator.userAgentData) {
       // userAgentData in experimental (only Chrome supports it) thus TS does not ship the respective type declarations
       return (navigator as any).userAgentData.brands;
     }


### PR DESCRIPTION
## Why

We have gotten several Sentry reports about a crash `Cannot read properties of undefined (reading 'brands')` from this file. Apparently some browsers does have the field `userAgentData` defined, but its value is undefined.

## What
Adds an extra check that `userAgentData` is truthy before trying to read it.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
