### PR TITLE
prepare patch release 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.3.9
+
 - Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing (#490).
 - Fix (`@grafana/faro-web-sdk`): crash when navigator.userAgentData is undefined (#494).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## 1.3.9
 
-- Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing (#490).
+- Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing and
+  rename property `totalNavigationTime` to `duration` in a `faro.performance.navigation event` (#490).
 - Fix (`@grafana/faro-web-sdk`): crash when navigator.userAgentData is undefined (#494).
 
 ## 1.3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## 1.3.9
 
-- Enhancement (`@grafana/faro-web-sdk`): add `duration` property to a `faro.performance.resource` timing and
-  rename property `totalNavigationTime` to `duration` in a `faro.performance.navigation event` (#490).
+- Enhancement (`@grafana/faro-web-sdk`): add `duration` property in `faro.performance.resource` timings and
+  rename property `totalNavigationTime` to `duration` in `faro.performance.navigation` timings (#490).
 - Fix (`@grafana/faro-web-sdk`): crash when navigator.userAgentData is undefined (#494).
 
 ## 1.3.8


### PR DESCRIPTION
## Why / What

Patch release which fixes an issue happening because  `navigator.userAgentData` is initialized with `undefined` value in some browsers.

It also adds the missing `duration` prop to `faro.performance.resource` events (currently in preview).

 
## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
