### PR TITLE
480 create opentelemetry trace sampler taking faro sampling decisions into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Feat (`@grafana/faro-web-sdk`): Enable Faro Navigation and Resource timings instrumentation by default (#482).
+- Update (`@grafana/faro-web-tracing`): Send a dedicated Faro event for traces of kind=client (#499).
+
 ## 1.3.9
 
 - Enhancement (`@grafana/faro-web-sdk`): add `duration` property in `faro.performance.resource` timings and
@@ -11,7 +14,6 @@
 ## 1.3.8
 
 - Deps (`@grafana/faro-web-tracing`, `@grafana/faro-core`): Update OpenTelemetry dependencies (#475).
-- Feat (`@grafana/faro-web-sdk`): Enable Faro Navigation and Resource timings instrumentation by default (#482).
 
 ## 1.3.7
 

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -38,6 +38,9 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
+    sessionTracking: {
+      samplingRate: 1,
+    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -38,9 +38,6 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
-    sessionTracking: {
-      samplingRate: 1,
-    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/packages/web-tracing/jest.config.js
+++ b/packages/web-tracing/jest.config.js
@@ -1,0 +1,7 @@
+const { jestBaseConfig } = require('../../jest.config.base.js');
+
+module.exports = {
+  ...jestBaseConfig,
+  roots: ['packages/web-tracing/src'],
+  testEnvironment: 'jsdom',
+};

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -43,7 +43,7 @@
     "watch:compile": "yarn build:compile:cjs -w",
     "clean": "rimraf dist/ yarn-error.log",
     "quality": "run-s quality:*",
-    "quality:test": "exit 0",
+    "quality:test": "jest",
     "quality:format": "prettier --cache --cache-location=../../.cache/prettier/webTracing --ignore-path ../../.prettierignore -w \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\"",
     "quality:lint": "run-s quality:lint:*",
     "quality:lint:eslint": "eslint --cache --cache-location ../../.cache/eslint/webTracing --ignore-path ../../.eslintignore \"./**/*.{js,jsx,ts,tsx}\"",

--- a/packages/web-tracing/src/faroTraceExporter.ts
+++ b/packages/web-tracing/src/faroTraceExporter.ts
@@ -3,6 +3,7 @@ import type { ExportResult } from '@opentelemetry/core';
 import { createExportTraceServiceRequest } from '@opentelemetry/otlp-transformer';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 
+import { sendFaroEvents } from './faroTraceExporter.utils';
 import type { FaroTraceExporterConfig } from './types';
 
 export class FaroTraceExporter implements SpanExporter {
@@ -12,6 +13,7 @@ export class FaroTraceExporter implements SpanExporter {
     const traceEvent = createExportTraceServiceRequest(spans, { useHex: true, useLongBits: false });
 
     this.config.api.pushTraces(traceEvent);
+    sendFaroEvents(traceEvent.resourceSpans);
 
     resultCallback({ code: ExportResultCode.SUCCESS });
   }

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -1,0 +1,311 @@
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { sendFaroEvents } from './faroTraceExporter.utils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Emits no faro events if no client spans are contained ', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // remove scopeSpan which contains client span
+    const data = {
+      ...testData[0],
+      scopeSpans: testData[0]?.scopeSpans.map((s) => ({ ...s })),
+    };
+
+    data.scopeSpans!.pop();
+
+    sendFaroEvents([data as any]);
+
+    expect(mockPushEvent).toBeCalledTimes(0);
+  });
+
+  it('Creates a Faro event for client spans only', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    sendFaroEvents(testData);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent).toHaveBeenCalledWith('faro.trace.fetch', {
+      component: 'fetch',
+      session_id: 'my-session-id',
+      'http.host': 'my-host',
+      'http.method': 'GET',
+      'http.response_content_length': '127',
+      'http.scheme': 'http',
+      'http.status_code': '401',
+      'http.status_text': 'Unauthorized',
+      'http.url': 'http://foo/bar',
+      'http.user_agent': 'my-user-agent',
+    });
+  });
+
+  it('Uses whole instrumentation name if no "-" is part of the name', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const data = {
+      ...testData[0],
+      scopeSpans: testData[0]?.scopeSpans.map((s) => ({ ...s })),
+    };
+    data.scopeSpans!.at(-1)!.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data as any]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.trace.coolName');
+  });
+});
+
+// some unnecessary parts are removed to shorten the object a bit.
+const testData = [
+  {
+    resource: {
+      attributes: [],
+      droppedAttributesCount: 0,
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-document-load',
+          version: '0.35.0',
+        },
+        spans: [
+          {
+            traceId: 'b3eb030d2a6a3ea28fd81a2c3c865d32',
+            spanId: '146cbe6578eedc77',
+            parentSpanId: '411fbeb357bad860',
+            name: 'resourceFetch',
+            kind: 1,
+            startTimeUnixNano: '1709051097380000000',
+            endTimeUnixNano: '1709051097419000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue:
+                    'http://localhost:5173/@fs/Users/marcoschaefer/Code/Repos/Grafana/faro-web-sdk/packages/core/dist/esm/api/traces/index.js',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 652,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097380000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@grafana/faro-react',
+          version: '1.3.9',
+        },
+        spans: [
+          {
+            traceId: 'e2e8ca244a7f149ca0f8e820df2d2ec1',
+            spanId: 'f4e18e624b397865',
+            name: 'componentMount',
+            kind: 1,
+            startTimeUnixNano: '1709051097617000000',
+            endTimeUnixNano: '1709051097617000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'react.component.name',
+                value: {
+                  stringValue: 'CounterComponent',
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-fetch',
+          version: '0.45.1',
+        },
+        spans: [
+          {
+            // this is the only span which is of kind=3 (client)
+            traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+            spanId: '4c47d5f85e4b2aec',
+            parentSpanId: 'da5a27b83e0f2871',
+            name: 'HTTP GET',
+            kind: 3,
+            startTimeUnixNano: '1709051097594000000',
+            endTimeUnixNano: '1709051097609000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: 'my-session-id',
+                },
+              },
+              {
+                key: 'component',
+                value: {
+                  stringValue: 'fetch',
+                },
+              },
+              {
+                key: 'http.method',
+                value: {
+                  stringValue: 'GET',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue: 'http://foo/bar',
+                },
+              },
+              {
+                key: 'http.status_code',
+                value: {
+                  intValue: 401,
+                },
+              },
+              {
+                key: 'http.status_text',
+                value: {
+                  stringValue: 'Unauthorized',
+                },
+              },
+              {
+                key: 'http.host',
+                value: {
+                  stringValue: 'my-host',
+                },
+              },
+              {
+                key: 'http.scheme',
+                value: {
+                  stringValue: 'http',
+                },
+              },
+              {
+                key: 'http.user_agent',
+                value: {
+                  stringValue: 'my-user-agent',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 127,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'requestStart',
+                timeUnixNano: '1709051097596000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseStart',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseEnd',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -36,7 +36,8 @@ describe('faroTraceExporter.utils', () => {
     sendFaroEvents(testData);
 
     expect(mockPushEvent).toBeCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenCalledWith('faro.trace.fetch', {
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.fetch');
+    expect(mockPushEvent.mock.lastCall[1]).toStrictEqual({
       component: 'fetch',
       session_id: 'my-session-id',
       'http.host': 'my-host',
@@ -66,7 +67,7 @@ describe('faroTraceExporter.utils', () => {
     sendFaroEvents([data as any]);
 
     expect(mockPushEvent).toBeCalledTimes(1);
-    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.trace.coolName');
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.coolName');
   });
 });
 

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -1,0 +1,41 @@
+import { ESpanKind, IResourceSpans } from '@opentelemetry/otlp-transformer';
+
+import { faro } from '@grafana/faro-core';
+import type { EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
+
+export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
+  for (const resourceSpan of resourceSpans) {
+    const { scopeSpans } = resourceSpan;
+
+    for (const scopeSpan of scopeSpans) {
+      const { scope, spans = [] } = scopeSpan;
+
+      for (const span of spans) {
+        if (span.kind !== ESpanKind.SPAN_KIND_CLIENT) {
+          continue;
+        }
+
+        const faroEventAttributes: FaroEventAttributes = {};
+
+        for (const attribute of span.attributes) {
+          faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);
+        }
+
+        const index = (scope?.name ?? '').indexOf('-');
+        let eventName = 'unknown';
+
+        if (scope?.name) {
+          if (index === -1) {
+            eventName = scope.name.split('/')[1] ?? scope.name;
+          }
+
+          if (index > -1) {
+            eventName = scope?.name.substring(index + 1);
+          }
+        }
+
+        faro.api.pushEvent(`faro.trace.${eventName}`, faroEventAttributes);
+      }
+    }
+  }
+}

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -34,7 +34,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           }
         }
 
-        faro.api.pushEvent(`faro.trace.otel.${eventName}`, faroEventAttributes, undefined, { skipDedupe: true });
+        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, { skipDedupe: true });
       }
     }
   }

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -34,7 +34,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           }
         }
 
-        faro.api.pushEvent(`faro.trace.${eventName}`, faroEventAttributes);
+        faro.api.pushEvent(`faro.trace.otel.${eventName}`, faroEventAttributes, undefined, { skipDedupe: true });
       }
     }
   }

--- a/packages/web-tracing/src/index.ts
+++ b/packages/web-tracing/src/index.ts
@@ -6,6 +6,6 @@ export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations
 
 export { TracingInstrumentation } from './instrumentation';
 
-export { getSessionBasedSamplingDecision } from './sampler';
+export { getSamplingDecision } from './sampler';
 
 export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';

--- a/packages/web-tracing/src/index.ts
+++ b/packages/web-tracing/src/index.ts
@@ -6,4 +6,6 @@ export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations
 
 export { TracingInstrumentation } from './instrumentation';
 
+export { getSessionBasedSamplingDecision } from './sampler';
+
 export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -10,6 +10,7 @@ import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+import { getSessionBasedSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
 
@@ -47,7 +48,16 @@ export class TracingInstrumentation extends BaseInstrumentation {
 
     const resource = Resource.default().merge(new Resource(attributes));
 
-    const provider = new WebTracerProvider({ resource });
+    const provider = new WebTracerProvider({
+      resource,
+      sampler: {
+        shouldSample: () => {
+          return {
+            decision: getSessionBasedSamplingDecision(this.api.getSession()),
+          };
+        },
+      },
+    });
 
     provider.addSpanProcessor(
       options.spanProcessor ??

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -10,7 +10,7 @@ import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
-import { getSessionBasedSamplingDecision } from './sampler';
+import { getSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
 
@@ -53,7 +53,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
       sampler: {
         shouldSample: () => {
           return {
-            decision: getSessionBasedSamplingDecision(this.api.getSession()),
+            decision: getSamplingDecision(this.api.getSession()),
           };
         },
       },

--- a/packages/web-tracing/src/sampler.test.ts
+++ b/packages/web-tracing/src/sampler.test.ts
@@ -1,6 +1,6 @@
 import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
 
-import { getSessionBasedSamplingDecision } from './sampler';
+import { getSamplingDecision } from './sampler';
 
 describe('Sampler', () => {
   afterEach(() => {
@@ -8,7 +8,7 @@ describe('Sampler', () => {
   });
 
   it('Set SamplingDecision to NOT_RECORD (0) if session is not part of the sample', () => {
-    const samplingDecision = getSessionBasedSamplingDecision({
+    const samplingDecision = getSamplingDecision({
       attributes: {
         isSampled: 'false',
       },
@@ -18,7 +18,7 @@ describe('Sampler', () => {
   });
 
   it('Set SamplingDecision to RECORD_AND_SAMPLED (2) if session is part of the sample', () => {
-    const samplingDecision = getSessionBasedSamplingDecision({
+    const samplingDecision = getSamplingDecision({
       attributes: {
         isSampled: 'true',
       },

--- a/packages/web-tracing/src/sampler.test.ts
+++ b/packages/web-tracing/src/sampler.test.ts
@@ -1,0 +1,29 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import { getSessionBasedSamplingDecision } from './sampler';
+
+describe('Sampler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Set SamplingDecision to NOT_RECORD (0) if session is not part of the sample', () => {
+    const samplingDecision = getSessionBasedSamplingDecision({
+      attributes: {
+        isSampled: 'false',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.NOT_RECORD);
+  });
+
+  it('Set SamplingDecision to RECORD_AND_SAMPLED (2) if session is part of the sample', () => {
+    const samplingDecision = getSessionBasedSamplingDecision({
+      attributes: {
+        isSampled: 'true',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+});

--- a/packages/web-tracing/src/sampler.ts
+++ b/packages/web-tracing/src/sampler.ts
@@ -1,0 +1,10 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import type { MetaSession } from '@grafana/faro-web-sdk';
+
+export function getSessionBasedSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
+  const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';
+  const samplingDecision = isSessionSampled ? SamplingDecision.RECORD_AND_SAMPLED : SamplingDecision.NOT_RECORD;
+
+  return samplingDecision;
+}

--- a/packages/web-tracing/src/sampler.ts
+++ b/packages/web-tracing/src/sampler.ts
@@ -2,7 +2,7 @@ import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
 
 import type { MetaSession } from '@grafana/faro-web-sdk';
 
-export function getSessionBasedSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
+export function getSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
   const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';
   const samplingDecision = isSessionSampled ? SamplingDecision.RECORD_AND_SAMPLED : SamplingDecision.NOT_RECORD;
 


### PR DESCRIPTION
## Why

**1. Sampling**
Faro has a probabilistic sampler, but when tracing is enabled, the sampling decision is not promoted to the OpenTelemetry-JS tracer which lead to problems if backend traces are sampled as well. 

> The implication is that when the SDK has chosen not to sample, the Otel tracer will still propagate the desire to sample downstream, creating undesired side-effects for `parentbased_always_off` scenarios.

**2. Sending a Faro event for client spans** 

Open tasks:
- [ ] update documentation

## What

* Add sampler which reads the `isSampled` flag from the session meta and sets the otel sampling decision based on that flag.
* Send a Faro event for spans of `kind=client`


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
