### PR TITLE
chore(tracing): Dedupe extra fFaro trace events

### DIFF
--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -34,7 +34,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           }
         }
 
-        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, { skipDedupe: true });
+        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes);
       }
     }
   }


### PR DESCRIPTION
## Why

Deduplicate the new Faro extra trace events.

## What

* remove `skipDedupe`

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
