### PR TITLE
Add span context when sending faro events which belong to specific spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Next
 
 - Fix (`@grafana/faro-web-sdk`): Session started timestamp was reset on page-loads (#513).
+- Fix (`@grafana/faro-web-tracing`): `faro.trace.*` attached spanContext from active span instead of
+  the respective child span (#510).
+- Feat (`@grafana/faro-web-sdk`): Faro APIs no support to add a custom traceId (#510).
 
 ## 1.4.1
 

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -98,7 +98,7 @@ describe('api.events', () => {
         expect(transport.items).toHaveLength(2);
       });
 
-      it('Uses traceId and spanId from custom context', () => {
+      it('uses traceId and spanId from custom context', () => {
         const spanContext: PushEventOptions['spanContext'] = {
           traceId: 'my-trace-id',
           spanId: 'my-span-id',

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -18,7 +18,7 @@ export function initializeEventsAPI(
 ): EventsAPI {
   let lastPayload: Pick<EventEvent, 'name' | 'domain' | 'attributes'> | null = null;
 
-  const pushEvent: EventsAPI['pushEvent'] = (name, attributes, domain, { skipDedupe } = {}) => {
+  const pushEvent: EventsAPI['pushEvent'] = (name, attributes, domain, { skipDedupe, spanContext } = {}) => {
     try {
       const item: TransportItem<EventEvent> = {
         meta: metas.value,
@@ -27,7 +27,12 @@ export function initializeEventsAPI(
           domain: domain ?? config.eventDomain,
           attributes,
           timestamp: getCurrentTimestamp(),
-          trace: tracesApi.getTraceContext(),
+          trace: spanContext
+            ? {
+                trace_id: spanContext.traceId,
+                span_id: spanContext.spanId,
+              }
+            : tracesApi.getTraceContext(),
         },
         type: TransportItemType.EVENT,
       };

--- a/packages/core/src/api/events/types.ts
+++ b/packages/core/src/api/events/types.ts
@@ -1,3 +1,5 @@
+import type { SpanContext } from '@opentelemetry/api';
+
 import type { TraceContext } from '../traces';
 
 export type EventAttributes = Record<string, string>;
@@ -13,6 +15,7 @@ export interface EventEvent {
 
 export interface PushEventOptions {
   skipDedupe?: boolean;
+  spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
 }
 
 export interface EventsAPI {

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -34,7 +34,10 @@ export function initializeExceptionsAPI(
 
   const getStacktraceParser: ExceptionsAPI['getStacktraceParser'] = () => stacktraceParser;
 
-  const pushError: ExceptionsAPI['pushError'] = (error, { skipDedupe, stackFrames, type, context } = {}) => {
+  const pushError: ExceptionsAPI['pushError'] = (
+    error,
+    { skipDedupe, stackFrames, type, context, spanContext } = {}
+  ) => {
     type = type || error.name || defaultExceptionType;
 
     const item: TransportItem<ExceptionEvent> = {
@@ -43,7 +46,12 @@ export function initializeExceptionsAPI(
         type,
         value: error.message,
         timestamp: getCurrentTimestamp(),
-        trace: tracesApi.getTraceContext(),
+        trace: spanContext
+          ? {
+              trace_id: spanContext.traceId,
+              span_id: spanContext.spanId,
+            }
+          : tracesApi.getTraceContext(),
         context: context ?? {},
       },
       type: TransportItemType.EXCEPTION,

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -1,3 +1,5 @@
+import type { SpanContext } from '@opentelemetry/api';
+
 import type { TraceContext } from '../traces';
 
 export type StacktraceParser = (err: ExtendedError) => Stacktrace;
@@ -36,6 +38,7 @@ export interface PushErrorOptions {
   stackFrames?: ExceptionStackFrame[];
   type?: string;
   context?: ExceptionContext;
+  spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
 }
 
 export interface ExceptionsAPI {

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -3,6 +3,8 @@ import { mockConfig, MockTransport } from '../../testUtils';
 import { LogLevel } from '../../utils';
 import type { API } from '../types';
 
+import type { LogEvent, PushLogOptions } from './types';
+
 describe('api.logs', () => {
   function createAPI({ dedupe }: { dedupe: boolean } = { dedupe: true }): [API, MockTransport] {
     const transport = new MockTransport();
@@ -92,6 +94,21 @@ describe('api.logs', () => {
 
         api.pushLog(['test'], { skipDedupe: true });
         expect(transport.items).toHaveLength(2);
+      });
+
+      it('uses traceId and spanId from custom context', () => {
+        const spanContext: PushLogOptions['spanContext'] = {
+          traceId: 'my-trace-id',
+          spanId: 'my-span-id',
+        };
+
+        api.pushLog(['test'], { spanContext });
+        expect(transport.items).toHaveLength(1);
+
+        expect((transport.items[0]?.payload as LogEvent).trace).toStrictEqual({
+          trace_id: 'my-trace-id',
+          span_id: 'my-span-id',
+        });
       });
     });
   });

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -21,7 +21,7 @@ export function initializeLogsAPI(
 
   let lastPayload: Pick<LogEvent, 'message' | 'level' | 'context'> | null = null;
 
-  const pushLog: LogsAPI['pushLog'] = (args, { context, level, skipDedupe } = {}) => {
+  const pushLog: LogsAPI['pushLog'] = (args, { context, level, skipDedupe, spanContext } = {}) => {
     try {
       const item: TransportItem<LogEvent> = {
         type: TransportItemType.LOG,
@@ -38,7 +38,12 @@ export function initializeLogsAPI(
           level: level ?? defaultLogLevel,
           context: context ?? {},
           timestamp: getCurrentTimestamp(),
-          trace: tracesApi.getTraceContext(),
+          trace: spanContext
+            ? {
+                trace_id: spanContext.traceId,
+                span_id: spanContext.spanId,
+              }
+            : tracesApi.getTraceContext(),
         },
         meta: metas.value,
       };

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -1,3 +1,5 @@
+import type { SpanContext } from '@opentelemetry/api';
+
 import type { LogLevel } from '../../utils';
 import type { TraceContext } from '../traces';
 
@@ -16,6 +18,7 @@ export interface PushLogOptions {
   context?: LogContext;
   level?: LogLevel;
   skipDedupe?: boolean;
+  spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
 }
 
 export interface LogsAPI {

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -1,3 +1,4 @@
+import type { MeasurementEvent, PushMeasurementOptions } from '../..';
 import { initializeFaro } from '../../initialize';
 import { mockConfig, MockTransport } from '../../testUtils';
 import type { API } from '../types';
@@ -167,6 +168,28 @@ describe('api.measurements', () => {
 
         api.pushMeasurement(measurement, { skipDedupe: true });
         expect(transport.items).toHaveLength(2);
+      });
+
+      it('uses traceId and spanId from custom context', () => {
+        const spanContext: PushMeasurementOptions['spanContext'] = {
+          traceId: 'my-trace-id',
+          spanId: 'my-span-id',
+        };
+
+        const measurement = {
+          type: 'custom',
+          values: {
+            a: 1,
+          },
+        };
+
+        api.pushMeasurement(measurement, { spanContext });
+        expect(transport.items).toHaveLength(1);
+
+        expect((transport.items[0]?.payload as MeasurementEvent).trace).toStrictEqual({
+          trace_id: 'my-trace-id',
+          span_id: 'my-span-id',
+        });
       });
     });
   });

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -21,13 +21,18 @@ export function initializeMeasurementsAPI(
 
   let lastPayload: Pick<MeasurementEvent, 'type' | 'values' | 'context'> | null = null;
 
-  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload, { skipDedupe, context } = {}) => {
+  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload, { skipDedupe, context, spanContext } = {}) => {
     try {
       const item: TransportItem<MeasurementEvent> = {
         type: TransportItemType.MEASUREMENT,
         payload: {
           ...payload,
-          trace: tracesApi.getTraceContext(),
+          trace: spanContext
+            ? {
+                trace_id: spanContext.traceId,
+                span_id: spanContext.spanId,
+              }
+            : tracesApi.getTraceContext(),
           timestamp: payload.timestamp ?? getCurrentTimestamp(),
           context: context ?? {},
         },

--- a/packages/core/src/api/measurements/types.ts
+++ b/packages/core/src/api/measurements/types.ts
@@ -1,3 +1,5 @@
+import type { SpanContext } from '@opentelemetry/api';
+
 import type { TraceContext } from '../traces';
 
 export type MeasurementContext = Record<string, string>;
@@ -14,6 +16,7 @@ export interface MeasurementEvent<V extends { [label: string]: number } = { [lab
 export interface PushMeasurementOptions {
   skipDedupe?: boolean;
   context?: MeasurementContext;
+  spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
 }
 
 export interface MeasurementsAPI {

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -69,6 +69,30 @@ describe('faroTraceExporter.utils', () => {
     expect(mockPushEvent).toBeCalledTimes(1);
     expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.coolName');
   });
+
+  it('Call Faro event API with traceID and spanID of contained in teh span', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const data = {
+      ...testData[0],
+      scopeSpans: testData[0]?.scopeSpans.map((s) => ({ ...s })),
+    };
+    data.scopeSpans!.at(-1)!.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data as any]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[3]).toStrictEqual({
+      spanContext: {
+        spanId: '4c47d5f85e4b2aec',
+        traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+      },
+    });
+  });
 });
 
 // some unnecessary parts are removed to shorten the object a bit.

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -17,13 +17,11 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
         }
 
         const spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
-          traceId: span.traceId,
-          spanId: span.spanId,
+          traceId: span.traceId.toString(),
+          spanId: span.spanId.toString(),
         };
 
-        const faroEventAttributes: FaroEventAttributes = {
-          ...spanContext,
-        };
+        const faroEventAttributes: FaroEventAttributes = {};
 
         for (const attribute of span.attributes) {
           faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -1,3 +1,4 @@
+import type { SpanContext } from '@opentelemetry/api';
 import { ESpanKind, IResourceSpans } from '@opentelemetry/otlp-transformer';
 
 import { faro } from '@grafana/faro-core';
@@ -14,6 +15,13 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
         if (span.kind !== ESpanKind.SPAN_KIND_CLIENT) {
           continue;
         }
+
+        console.log('span :>> ', span);
+
+        const spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
+          traceId: span.traceId,
+          spanId: span.spanId,
+        };
 
         const faroEventAttributes: FaroEventAttributes = {};
 
@@ -34,7 +42,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           }
         }
 
-        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes);
+        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, { spanContext });
       }
     }
   }

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -16,8 +16,6 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           continue;
         }
 
-        console.log('span :>> ', span);
-
         const spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
           traceId: span.traceId,
           spanId: span.spanId,

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -23,7 +23,9 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           spanId: span.spanId,
         };
 
-        const faroEventAttributes: FaroEventAttributes = {};
+        const faroEventAttributes: FaroEventAttributes = {
+          ...spanContext,
+        };
 
         for (const attribute of span.attributes) {
           faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);


### PR DESCRIPTION
## Why

### Issue
The new `faro.trace.*` events which are sent  per child span have always the same  traceId and spanId. 
TraceID of course is correct when they belong to the same trace, but the spanId is different.

#### Problem
When attaching `TraceContext` (`spanId` and `traceId`) to a signal, Faro pulls the active span from the otel context and receives the IDs from this span. 

This is not always correct. 
Say we want to send a signal for a specific span:
With the old behavior each call to a Faro api, e. g. `pushEvent` will auto receive `traceId` and `spanId` from the active span, which is wrong.

#### Solution
Provide an option to inject `spanContext` for the specific span when calling an Faro api. 
The API will  pick up the `spanContext` and uses that values instead of the active span.

## What
* Update each Faro api except `pushTraces` to be able to inject a spanContext. 
  - This is not === the otel SpanContext. We only need the `traceId` and `spanId`
* Update `sendFaroEvents` in `traceEsporterUtils` to inject the spanContext of the child span (kind=client) 
* Add tests


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
