### PR TITLE
512 session manager started timestamp is reset on page load aka session resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Fix (`@grafana/faro-web-sdk`): Session started timestamp was reset on page-loads (#507).
+- Fix (`@grafana/faro-web-sdk`): Session started timestamp was reset on page-loads (#513).
 
 ## 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): Session started timestamp was reset on page-loads (#507).
+
 ## 1.4.1
 
 - Enhancement (`@grafana/faro-web-tracing`): Dedupe Faro trace events (#507).

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -131,16 +131,14 @@ export class SessionInstrumentation extends BaseInstrumentation {
   initialize() {
     this.logDebug('init session instrumentation');
 
-    const sessionTracking = this.config.sessionTracking;
+    const sessionTrackingConfig = this.config.sessionTracking;
 
-    if (sessionTracking?.enabled) {
-      const SessionManager = this.config.sessionTracking?.persistent
-        ? PersistentSessionsManager
-        : VolatileSessionsManager;
+    if (sessionTrackingConfig?.enabled) {
+      const SessionManager = sessionTrackingConfig?.persistent ? PersistentSessionsManager : VolatileSessionsManager;
 
       this.registerBeforeSendHook(SessionManager);
 
-      const { sessionMeta: initialSessionMeta, lifecycleType } = this.createInitialSessionMeta(sessionTracking);
+      const { sessionMeta: initialSessionMeta, lifecycleType } = this.createInitialSessionMeta(sessionTrackingConfig);
 
       SessionManager.storeUserSession({
         ...createUserSessionObject({

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -6,11 +6,15 @@ import type { FaroUserSession } from './types';
 
 type CreateUserSessionObjectParams = {
   sessionId?: string;
+  started?: number;
+  lastActivity?: number;
   isSampled?: boolean;
 };
 
 export function createUserSessionObject({
   sessionId,
+  started,
+  lastActivity,
   isSampled = true,
 }: CreateUserSessionObjectParams = {}): FaroUserSession {
   const now = dateNow();
@@ -23,8 +27,8 @@ export function createUserSessionObject({
 
   return {
     sessionId,
-    lastActivity: now,
-    started: now,
+    lastActivity: lastActivity ?? now,
+    started: started ?? now,
     isSampled: isSampled,
   };
 }


### PR DESCRIPTION
## Why
The started timestamp of a Faro session was reset for valid, resumed sessions on page-load.
This will lead to start time drifting between client an backend which eventually leads to rejected sessions because the session reached the lifetime limit.


## What
* Keep original start time for resumed valid sessions so backend and client timestamps are always in sync. 

## Links

Fixes issue: #512 

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
