### PR TITLE
235 faroroutes support for routerprovider react router v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix (`@grafana/faro-web-sdk`): Faro updates sessions in an infinite loop if DOM Storage is not
   available (#519).
+- Feat (`@grafana/faro-react`): Support instrumenting React Router v6 data routers (#518).
 
 ## 1.4.2
 

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -25,11 +25,11 @@ export function initializeFaro(): Faro {
         router: {
           version: ReactRouterVersion.V6,
           dependencies: {
-            createRoutesFromChildren,
+            createRoutesFromChildren, //?
             matchRoutes,
-            Routes,
-            useLocation,
-            useNavigationType,
+            Routes, //?
+            useLocation, //?
+            useNavigationType, //?
           },
         },
       }),

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -25,11 +25,11 @@ export function initializeFaro(): Faro {
         router: {
           version: ReactRouterVersion.V6,
           dependencies: {
-            createRoutesFromChildren, //?
+            createRoutesFromChildren,
             matchRoutes,
-            Routes, //?
-            useLocation, //?
-            useNavigationType, //?
+            Routes,
+            useLocation,
+            useNavigationType,
           },
         },
       }),

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -3,7 +3,6 @@ import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigati
 import {
   initializeFaro as coreInit,
   getWebInstrumentations,
-  InternalLoggerLevel,
   ReactIntegration,
   ReactRouterVersion,
 } from '@grafana/faro-react';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -90,7 +90,14 @@ initializeFaro({
   ],
 });
 
-// To instrument the router you need to wrap it with
+// To instrument the router you need to attach Faro instrumentations providing it to the withFaroRouterInstrumentation function
+// Do this in your App.js or other file where you create the router.
+
+const reactBrowserRouter = createBrowserRouter([
+  //...
+]);
+
+const browserRouter = withFaroRouterInstrumentation(reactBrowserRouter);
 ```
 
 ### Error Boundary

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,6 +13,11 @@ Out of the box, the package provides you the following features:
 
 ## Installation
 
+### Use with React Router 5 and 6 (without Data API)
+
+This describes how to setup Faro-React to use with React Router V5 and V6.
+If you use React Router V6 with the Data API please refer to the next section.
+
 ```ts
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
 
@@ -54,7 +59,39 @@ initializeFaro({
 });
 ```
 
+### Use with React Router v6 Data API
+
 ## Usage
+
+```ts
+import { matchRoutes } from 'react-router-dom';
+
+import { getWebInstrumentations, initializeFaro, ReactIntegration, ReactRouterVersion } from '@grafana/faro-react';
+import { TracingInstrumentation } from '@grafana/faro-web-tracing';
+
+initializeFaro({
+  // ...
+  instrumentations: [
+    // Load the default Web instrumentations
+    ...getWebInstrumentations(),
+
+    // Tracing Instrumentation is needed if you want to use the React Profiler
+    new TracingInstrumentation(),
+
+    new ReactIntegration({
+      // Only needed if you want to use the React Router instrumentation
+      router: {
+        version: ReactRouterVersion.V6_data_api,
+        dependencies: {
+          matchRoutes,
+        },
+      },
+    }),
+  ],
+});
+
+// To instrument the router you need to wrap it with
+```
 
 ### Error Boundary
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,8 +2,6 @@
 
 Faro package that enables easier integration in projects built with React.
 
-_Warning_: currently pre-release and subject to frequent breaking changes. Use at your own risk.
-
 Out of the box, the package provides you the following features:
 
 - Error Boundary - Provides additional stacktrace for errors and configuration options for pushError behavior
@@ -60,8 +58,6 @@ initializeFaro({
 ```
 
 ### Use with React Router v6 Data API
-
-## Usage
 
 ```ts
 import { matchRoutes } from 'react-router-dom';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,6 +19,7 @@ export {
   ReactRouterVersion,
   setReactRouterV4V5SSRDependencies,
   setReactRouterV6SSRDependencies,
+  withFaroRouterInstrumentation,
 } from './router';
 export type {
   ReactRouterHistory,

--- a/packages/react/src/router/index.ts
+++ b/packages/react/src/router/index.ts
@@ -18,4 +18,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
+  ReactRouterV6NextDependencies,
 } from './v6';

--- a/packages/react/src/router/index.ts
+++ b/packages/react/src/router/index.ts
@@ -6,7 +6,7 @@ export type { ReactRouterLocation, ReactRouterHistory } from './types';
 export { FaroRoute, setReactRouterV4V5SSRDependencies } from './v4v5';
 export type { ReactRouterV4V5ActiveEvent, ReactRouterV4V5Dependencies, ReactRouterV4V5RouteShape } from './v4v5';
 
-export { FaroRoutes, setReactRouterV6SSRDependencies } from './v6';
+export { FaroRoutes, setReactRouterV6SSRDependencies, withFaroRouterInstrumentation } from './v6';
 export type {
   ReactRouterV6CreateRoutesFromChildren,
   ReactRouterV6Dependencies,

--- a/packages/react/src/router/index.ts
+++ b/packages/react/src/router/index.ts
@@ -18,5 +18,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
-  ReactRouterV6NextDependencies,
+  ReactRouterV6DataApiDependencies,
 } from './v6';

--- a/packages/react/src/router/index.ts
+++ b/packages/react/src/router/index.ts
@@ -18,5 +18,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
-  ReactRouterV6DataApiDependencies,
+  ReactRouterV6DataRouterDependencies,
 } from './v6';

--- a/packages/react/src/router/initialize.ts
+++ b/packages/react/src/router/initialize.ts
@@ -3,7 +3,7 @@ import type { ReactIntegrationConfig } from '../types';
 
 import { ReactRouterVersion } from './types';
 import { initializeReactRouterV4V5Instrumentation } from './v4v5';
-import { initializeReactRouterV6Instrumentation, initializeReactRouterV6NextInstrumentation } from './v6';
+import { initializeReactRouterV6DataApiInstrumentation, initializeReactRouterV6Instrumentation } from './v6';
 
 export function initializeReactRouterInstrumentation(options: ReactIntegrationConfig): void {
   switch (options.router?.version) {
@@ -12,9 +12,9 @@ export function initializeReactRouterInstrumentation(options: ReactIntegrationCo
       initializeReactRouterV6Instrumentation(options.router.dependencies);
       break;
 
-    case ReactRouterVersion.V6_Next:
+    case ReactRouterVersion.V6_data_api:
       internalLogger.debug('Initializing React Router V6 instrumentation');
-      initializeReactRouterV6NextInstrumentation(options.router.dependencies);
+      initializeReactRouterV6DataApiInstrumentation(options.router.dependencies);
       break;
 
     case ReactRouterVersion.V5:

--- a/packages/react/src/router/initialize.ts
+++ b/packages/react/src/router/initialize.ts
@@ -3,7 +3,7 @@ import type { ReactIntegrationConfig } from '../types';
 
 import { ReactRouterVersion } from './types';
 import { initializeReactRouterV4V5Instrumentation } from './v4v5';
-import { initializeReactRouterV6Instrumentation } from './v6';
+import { initializeReactRouterV6Instrumentation, initializeReactRouterV6NextInstrumentation } from './v6';
 
 export function initializeReactRouterInstrumentation(options: ReactIntegrationConfig): void {
   switch (options.router?.version) {
@@ -14,7 +14,7 @@ export function initializeReactRouterInstrumentation(options: ReactIntegrationCo
 
     case ReactRouterVersion.V6_Next:
       internalLogger.debug('Initializing React Router V6 instrumentation');
-      initializeReactRouterV6Instrumentation(options.router.dependencies);
+      initializeReactRouterV6NextInstrumentation(options.router.dependencies);
       break;
 
     case ReactRouterVersion.V5:

--- a/packages/react/src/router/initialize.ts
+++ b/packages/react/src/router/initialize.ts
@@ -12,6 +12,11 @@ export function initializeReactRouterInstrumentation(options: ReactIntegrationCo
       initializeReactRouterV6Instrumentation(options.router.dependencies);
       break;
 
+    case ReactRouterVersion.V6_Next:
+      internalLogger.debug('Initializing React Router V6 instrumentation');
+      initializeReactRouterV6Instrumentation(options.router.dependencies);
+      break;
+
     case ReactRouterVersion.V5:
     case ReactRouterVersion.V4:
       internalLogger.debug(`Initializing React Router ${options.router.version} instrumentation`);

--- a/packages/react/src/router/initialize.ts
+++ b/packages/react/src/router/initialize.ts
@@ -3,7 +3,7 @@ import type { ReactIntegrationConfig } from '../types';
 
 import { ReactRouterVersion } from './types';
 import { initializeReactRouterV4V5Instrumentation } from './v4v5';
-import { initializeReactRouterV6DataApiInstrumentation, initializeReactRouterV6Instrumentation } from './v6';
+import { initializeReactRouterV6DataRouterInstrumentation, initializeReactRouterV6Instrumentation } from './v6';
 
 export function initializeReactRouterInstrumentation(options: ReactIntegrationConfig): void {
   switch (options.router?.version) {
@@ -12,9 +12,9 @@ export function initializeReactRouterInstrumentation(options: ReactIntegrationCo
       initializeReactRouterV6Instrumentation(options.router.dependencies);
       break;
 
-    case ReactRouterVersion.V6_data_api:
+    case ReactRouterVersion.V6_data_router:
       internalLogger.debug('Initializing React Router V6 instrumentation');
-      initializeReactRouterV6DataApiInstrumentation(options.router.dependencies);
+      initializeReactRouterV6DataRouterInstrumentation(options.router.dependencies);
       break;
 
     case ReactRouterVersion.V5:

--- a/packages/react/src/router/initialize.ts
+++ b/packages/react/src/router/initialize.ts
@@ -6,20 +6,22 @@ import { initializeReactRouterV4V5Instrumentation } from './v4v5';
 import { initializeReactRouterV6DataRouterInstrumentation, initializeReactRouterV6Instrumentation } from './v6';
 
 export function initializeReactRouterInstrumentation(options: ReactIntegrationConfig): void {
+  const initMessage = 'Initializing React Router';
+
   switch (options.router?.version) {
     case ReactRouterVersion.V6:
-      internalLogger.debug('Initializing React Router V6 instrumentation');
+      internalLogger.debug(`${initMessage} V6 instrumentation`);
       initializeReactRouterV6Instrumentation(options.router.dependencies);
       break;
 
     case ReactRouterVersion.V6_data_router:
-      internalLogger.debug('Initializing React Router V6 instrumentation');
+      internalLogger.debug(`${initMessage} V6 data router instrumentation`);
       initializeReactRouterV6DataRouterInstrumentation(options.router.dependencies);
       break;
 
     case ReactRouterVersion.V5:
     case ReactRouterVersion.V4:
-      internalLogger.debug(`Initializing React Router ${options.router.version} instrumentation`);
+      internalLogger.debug(`${initMessage} ${options.router.version} instrumentation`);
       initializeReactRouterV4V5Instrumentation(options.router.dependencies);
       break;
 

--- a/packages/react/src/router/types.ts
+++ b/packages/react/src/router/types.ts
@@ -15,7 +15,7 @@ export enum ReactRouterVersion {
   V4 = 'v4',
   V5 = 'v5',
   V6 = 'v6',
-  V6_Next = 'v6_Next',
+  V6_data_api = 'v6_data_api',
 }
 
 export enum NavigationType {

--- a/packages/react/src/router/types.ts
+++ b/packages/react/src/router/types.ts
@@ -15,7 +15,7 @@ export enum ReactRouterVersion {
   V4 = 'v4',
   V5 = 'v5',
   V6 = 'v6',
-  V6_data_api = 'v6_data_api',
+  V6_data_router = 'v6_data_router',
 }
 
 export enum NavigationType {

--- a/packages/react/src/router/types.ts
+++ b/packages/react/src/router/types.ts
@@ -15,6 +15,7 @@ export enum ReactRouterVersion {
   V4 = 'v4',
   V5 = 'v5',
   V6 = 'v6',
+  V6_Next = 'v6_Next',
 }
 
 export enum NavigationType {

--- a/packages/react/src/router/v6/FaroRoutes.tsx
+++ b/packages/react/src/router/v6/FaroRoutes.tsx
@@ -21,11 +21,6 @@ export function FaroRoutes(props: ReactRouterV6RoutesProps) {
     if (isInitialized && (navigationType === NavigationType.Push || navigationType === NavigationType.Pop)) {
       const route = getRouteFromLocation(routes, location);
       const url = globalObject.location?.href;
-      const { fromRoute, fromUrl } = lastRouteRef.current;
-
-      if (route === fromRoute && url === fromUrl) {
-        return;
-      }
 
       api.pushEvent(EVENT_ROUTE_CHANGE, {
         toRoute: route,

--- a/packages/react/src/router/v6/index.ts
+++ b/packages/react/src/router/v6/index.ts
@@ -1,6 +1,6 @@
 export { FaroRoutes } from './FaroRoutes';
 
-export { initializeReactRouterV6Instrumentation, initializeReactRouterV6NextInstrumentation } from './initialize';
+export { initializeReactRouterV6Instrumentation, initializeReactRouterV6DataApiInstrumentation } from './initialize';
 
 export { setReactRouterV6SSRDependencies } from './routerDependencies';
 
@@ -17,5 +17,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
-  ReactRouterV6NextDependencies,
+  ReactRouterV6DataApiDependencies,
 } from './types';

--- a/packages/react/src/router/v6/index.ts
+++ b/packages/react/src/router/v6/index.ts
@@ -4,6 +4,8 @@ export { initializeReactRouterV6Instrumentation } from './initialize';
 
 export { setReactRouterV6SSRDependencies } from './routerDependencies';
 
+export { withFaroRouterInstrumentation } from './withFaroRouterInstrumentation';
+
 export type {
   ReactRouterV6CreateRoutesFromChildren,
   ReactRouterV6Dependencies,

--- a/packages/react/src/router/v6/index.ts
+++ b/packages/react/src/router/v6/index.ts
@@ -17,4 +17,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
+  ReactRouterV6NextDependencies,
 } from './types';

--- a/packages/react/src/router/v6/index.ts
+++ b/packages/react/src/router/v6/index.ts
@@ -1,6 +1,6 @@
 export { FaroRoutes } from './FaroRoutes';
 
-export { initializeReactRouterV6Instrumentation } from './initialize';
+export { initializeReactRouterV6Instrumentation, initializeReactRouterV6NextInstrumentation } from './initialize';
 
 export { setReactRouterV6SSRDependencies } from './routerDependencies';
 

--- a/packages/react/src/router/v6/index.ts
+++ b/packages/react/src/router/v6/index.ts
@@ -1,6 +1,6 @@
 export { FaroRoutes } from './FaroRoutes';
 
-export { initializeReactRouterV6Instrumentation, initializeReactRouterV6DataApiInstrumentation } from './initialize';
+export { initializeReactRouterV6Instrumentation, initializeReactRouterV6DataRouterInstrumentation } from './initialize';
 
 export { setReactRouterV6SSRDependencies } from './routerDependencies';
 
@@ -17,5 +17,5 @@ export type {
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
-  ReactRouterV6DataApiDependencies,
+  ReactRouterV6DataRouterDependencies,
 } from './types';

--- a/packages/react/src/router/v6/initialize.ts
+++ b/packages/react/src/router/v6/initialize.ts
@@ -1,11 +1,14 @@
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { FaroRoutes } from './FaroRoutes';
-import { setReactRouterV6Dependencies } from './routerDependencies';
-import type { ReactRouterV6Dependencies } from './types';
+import { setReactRouterV6Dependencies, setReactRouterV6NextDependencies } from './routerDependencies';
+import type { ReactRouterV6Dependencies, ReactRouterV6NextDependencies } from './types';
 
 export function initializeReactRouterV6Instrumentation(dependencies: ReactRouterV6Dependencies): void {
   hoistNonReactStatics(FaroRoutes, dependencies.Routes);
-
   setReactRouterV6Dependencies(dependencies);
+}
+
+export function initializeReactRouterNextV6Instrumentation(dependencies: ReactRouterV6NextDependencies): void {
+  setReactRouterV6NextDependencies(dependencies);
 }

--- a/packages/react/src/router/v6/initialize.ts
+++ b/packages/react/src/router/v6/initialize.ts
@@ -9,6 +9,6 @@ export function initializeReactRouterV6Instrumentation(dependencies: ReactRouter
   setReactRouterV6Dependencies(dependencies);
 }
 
-export function initializeReactRouterNextV6Instrumentation(dependencies: ReactRouterV6NextDependencies): void {
+export function initializeReactRouterV6NextInstrumentation(dependencies: ReactRouterV6NextDependencies): void {
   setReactRouterV6NextDependencies(dependencies);
 }

--- a/packages/react/src/router/v6/initialize.ts
+++ b/packages/react/src/router/v6/initialize.ts
@@ -1,14 +1,14 @@
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { FaroRoutes } from './FaroRoutes';
-import { setReactRouterV6Dependencies, setReactRouterV6NextDependencies } from './routerDependencies';
-import type { ReactRouterV6Dependencies, ReactRouterV6NextDependencies } from './types';
+import { setReactRouterV6DataApiDependencies, setReactRouterV6Dependencies } from './routerDependencies';
+import type { ReactRouterV6DataApiDependencies, ReactRouterV6Dependencies } from './types';
 
 export function initializeReactRouterV6Instrumentation(dependencies: ReactRouterV6Dependencies): void {
   hoistNonReactStatics(FaroRoutes, dependencies.Routes);
   setReactRouterV6Dependencies(dependencies);
 }
 
-export function initializeReactRouterV6NextInstrumentation(dependencies: ReactRouterV6NextDependencies): void {
-  setReactRouterV6NextDependencies(dependencies);
+export function initializeReactRouterV6DataApiInstrumentation(dependencies: ReactRouterV6DataApiDependencies): void {
+  setReactRouterV6DataApiDependencies(dependencies);
 }

--- a/packages/react/src/router/v6/initialize.ts
+++ b/packages/react/src/router/v6/initialize.ts
@@ -1,14 +1,19 @@
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { FaroRoutes } from './FaroRoutes';
-import { setReactRouterV6DataApiDependencies, setReactRouterV6Dependencies } from './routerDependencies';
-import type { ReactRouterV6DataApiDependencies, ReactRouterV6Dependencies } from './types';
+import {
+  setReactRouterV6DataRouterDependencies as setReactRouterV6DataRouterDependencies,
+  setReactRouterV6Dependencies,
+} from './routerDependencies';
+import type { ReactRouterV6DataRouterDependencies, ReactRouterV6Dependencies } from './types';
 
 export function initializeReactRouterV6Instrumentation(dependencies: ReactRouterV6Dependencies): void {
   hoistNonReactStatics(FaroRoutes, dependencies.Routes);
   setReactRouterV6Dependencies(dependencies);
 }
 
-export function initializeReactRouterV6DataApiInstrumentation(dependencies: ReactRouterV6DataApiDependencies): void {
-  setReactRouterV6DataApiDependencies(dependencies);
+export function initializeReactRouterV6DataRouterInstrumentation(
+  dependencies: ReactRouterV6DataRouterDependencies
+): void {
+  setReactRouterV6DataRouterDependencies(dependencies);
 }

--- a/packages/react/src/router/v6/routerDependencies.ts
+++ b/packages/react/src/router/v6/routerDependencies.ts
@@ -1,6 +1,6 @@
 import type {
   ReactRouterV6CreateRoutesFromChildren,
-  ReactRouterV6DataApiDependencies,
+  ReactRouterV6DataRouterDependencies,
   ReactRouterV6Dependencies,
   ReactRouterV6MatchRoutes,
   ReactRouterV6RoutesShape,
@@ -29,7 +29,7 @@ export function setReactRouterV6SSRDependencies(newDependencies: Pick<ReactRoute
   Routes = newDependencies.Routes;
 }
 
-export function setReactRouterV6DataApiDependencies(newDependencies: ReactRouterV6DataApiDependencies): void {
+export function setReactRouterV6DataRouterDependencies(newDependencies: ReactRouterV6DataRouterDependencies): void {
   isInitialized = true;
   matchRoutes = newDependencies.matchRoutes;
 }

--- a/packages/react/src/router/v6/routerDependencies.ts
+++ b/packages/react/src/router/v6/routerDependencies.ts
@@ -2,6 +2,7 @@ import type {
   ReactRouterV6CreateRoutesFromChildren,
   ReactRouterV6Dependencies,
   ReactRouterV6MatchRoutes,
+  ReactRouterV6NextDependencies,
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
@@ -26,4 +27,9 @@ export function setReactRouterV6Dependencies(newDependencies: ReactRouterV6Depen
 
 export function setReactRouterV6SSRDependencies(newDependencies: Pick<ReactRouterV6Dependencies, 'Routes'>): void {
   Routes = newDependencies.Routes;
+}
+
+export function setReactRouterV6NextDependencies(newDependencies: ReactRouterV6NextDependencies): void {
+  isInitialized = true;
+  matchRoutes = newDependencies.matchRoutes;
 }

--- a/packages/react/src/router/v6/routerDependencies.ts
+++ b/packages/react/src/router/v6/routerDependencies.ts
@@ -1,8 +1,8 @@
 import type {
   ReactRouterV6CreateRoutesFromChildren,
+  ReactRouterV6DataApiDependencies,
   ReactRouterV6Dependencies,
   ReactRouterV6MatchRoutes,
-  ReactRouterV6NextDependencies,
   ReactRouterV6RoutesShape,
   ReactRouterV6UseLocation,
   ReactRouterV6UseNavigationType,
@@ -29,7 +29,7 @@ export function setReactRouterV6SSRDependencies(newDependencies: Pick<ReactRoute
   Routes = newDependencies.Routes;
 }
 
-export function setReactRouterV6NextDependencies(newDependencies: ReactRouterV6NextDependencies): void {
+export function setReactRouterV6DataApiDependencies(newDependencies: ReactRouterV6DataApiDependencies): void {
   isInitialized = true;
   matchRoutes = newDependencies.matchRoutes;
 }

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -64,7 +64,7 @@ export interface ReactRouterV6Dependencies {
   useNavigationType: ReactRouterV6UseNavigationType;
 }
 
-export interface ReactRouterV6DataApiDependencies {
+export interface ReactRouterV6DataRouterDependencies {
   matchRoutes: ReactRouterV6MatchRoutes;
 }
 

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -64,7 +64,7 @@ export interface ReactRouterV6Dependencies {
   useNavigationType: ReactRouterV6UseNavigationType;
 }
 
-export interface ReactRouterV6NextDependencies {
+export interface ReactRouterV6DataApiDependencies {
   matchRoutes: ReactRouterV6MatchRoutes;
 }
 

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -64,6 +64,10 @@ export interface ReactRouterV6Dependencies {
   useNavigationType: ReactRouterV6UseNavigationType;
 }
 
+export interface ReactRouterV6NextDependencies {
+  matchRoutes: ReactRouterV6MatchRoutes;
+}
+
 export type EventRouteTransitionAttributes = {
   fromRoute?: string;
   fromUrl?: string;

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -46,12 +46,6 @@ export function withFaroRouterInstrumentation<R extends Router = Router>(router:
         ...lastRoute,
       });
 
-      console.log('pushEvent', {
-        toRoute: route,
-        toUrl: globalObject.location?.href,
-        ...lastRoute,
-      });
-
       lastRoute = {
         fromRoute: route,
         fromUrl: url,

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -20,8 +20,6 @@ interface Router {
 
 /**
  * To use with React Router 6.4 data APIs.
- * For React Router versions prior to 6.4 wrap routes with the <FaroRoutes /> component.
- * Please consult the documentation for more information
  */
 export function withFaroRouterInstrumentation<R extends Router = Router>(router: R) {
   let lastRoute: EventRouteTransitionAttributes = {};

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -19,7 +19,7 @@ interface Router {
 }
 
 /**
- * To instrument React Router >= 6.4.
+ * To use with React Router 6.4 data APIs.
  * For React Router versions prior to 6.4 wrap routes with the <FaroRoutes /> component.
  * Please consult the documentation for more information
  */

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -32,11 +32,6 @@ export function withFaroRouterInstrumentation<R extends Router = Router>(router:
     if (isInitialized && (navigationType === NavigationType.Push || navigationType === NavigationType.Pop)) {
       const route = getRouteFromLocation(routes, location);
       const url = globalObject.location?.href;
-      const { fromRoute, fromUrl } = lastRoute;
-
-      if (route === fromRoute && url === fromUrl) {
-        return;
-      }
 
       api.pushEvent(EVENT_ROUTE_CHANGE, {
         toRoute: route,

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -1,0 +1,63 @@
+import { EVENT_ROUTE_CHANGE, globalObject } from '@grafana/faro-web-sdk';
+
+import { api } from '../../dependencies';
+import { NavigationType, ReactRouterLocation } from '../types';
+
+import { isInitialized } from './routerDependencies';
+import type { EventRouteTransitionAttributes, ReactRouterV6RouteObject } from './types';
+import { getRouteFromLocation } from './utils';
+
+interface RouterState {
+  historyAction: NavigationType | any;
+  location: ReactRouterLocation;
+}
+
+interface Router {
+  state: RouterState;
+  routes: ReactRouterV6RouteObject[];
+  subscribe(fn: (state: RouterState) => void): () => void;
+}
+
+/**
+ * To instrument React Router >= 6.4.
+ * For React Router versions prior to 6.4 wrap routes with the <FaroRoutes /> component.
+ * Please consult the documentation for more information
+ */
+export function withFaroRouterInstrumentation<R extends Router = Router>(router: R) {
+  let lastRoute: EventRouteTransitionAttributes = {};
+
+  router.subscribe((state) => {
+    const navigationType: NavigationType = state.historyAction;
+    const location = state.location;
+    const routes = router.routes;
+
+    if (isInitialized && (navigationType === NavigationType.Push || navigationType === NavigationType.Pop)) {
+      const route = getRouteFromLocation(routes, location);
+      const url = globalObject.location?.href;
+      const { fromRoute, fromUrl } = lastRoute;
+
+      if (route === fromRoute && url === fromUrl) {
+        return;
+      }
+
+      api.pushEvent(EVENT_ROUTE_CHANGE, {
+        toRoute: route,
+        toUrl: globalObject.location?.href,
+        ...lastRoute,
+      });
+
+      console.log('pushEvent', {
+        toRoute: route,
+        toUrl: globalObject.location?.href,
+        ...lastRoute,
+      });
+
+      lastRoute = {
+        fromRoute: route,
+        fromUrl: url,
+      };
+    }
+  });
+
+  return router;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   ReactRouterV4V5Dependencies,
-  ReactRouterV6DataApiDependencies,
+  ReactRouterV6DataRouterDependencies,
   ReactRouterV6Dependencies,
   ReactRouterVersion,
 } from './router';
@@ -15,11 +15,11 @@ export interface ReactRouterV6Config {
   dependencies: ReactRouterV6Dependencies;
 }
 
-export interface ReactRouterV6DataApiConfig {
-  version: ReactRouterVersion.V6_data_api;
-  dependencies: ReactRouterV6DataApiDependencies;
+export interface ReactRouterV6DataRouterConfig {
+  version: ReactRouterVersion.V6_data_router;
+  dependencies: ReactRouterV6DataRouterDependencies;
 }
 
 export interface ReactIntegrationConfig {
-  router?: ReactRouterV4V5Config | ReactRouterV6Config | ReactRouterV6DataApiConfig;
+  router?: ReactRouterV4V5Config | ReactRouterV6Config | ReactRouterV6DataRouterConfig;
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,7 +1,7 @@
 import type {
   ReactRouterV4V5Dependencies,
+  ReactRouterV6DataApiDependencies,
   ReactRouterV6Dependencies,
-  ReactRouterV6NextDependencies,
   ReactRouterVersion,
 } from './router';
 
@@ -15,11 +15,11 @@ export interface ReactRouterV6Config {
   dependencies: ReactRouterV6Dependencies;
 }
 
-export interface ReactRouterV6NextConfig {
-  version: ReactRouterVersion.V6_Next;
-  dependencies: ReactRouterV6NextDependencies;
+export interface ReactRouterV6DataApiConfig {
+  version: ReactRouterVersion.V6_data_api;
+  dependencies: ReactRouterV6DataApiDependencies;
 }
 
 export interface ReactIntegrationConfig {
-  router?: ReactRouterV4V5Config | ReactRouterV6Config | ReactRouterV6NextConfig;
+  router?: ReactRouterV4V5Config | ReactRouterV6Config | ReactRouterV6DataApiConfig;
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,9 @@
-import type { ReactRouterV4V5Dependencies, ReactRouterV6Dependencies, ReactRouterVersion } from './router';
+import type {
+  ReactRouterV4V5Dependencies,
+  ReactRouterV6Dependencies,
+  ReactRouterV6NextDependencies,
+  ReactRouterVersion,
+} from './router';
 
 export interface ReactRouterV4V5Config {
   version: ReactRouterVersion.V4 | ReactRouterVersion.V5;
@@ -10,6 +15,11 @@ export interface ReactRouterV6Config {
   dependencies: ReactRouterV6Dependencies;
 }
 
+export interface ReactRouterV6NextConfig {
+  version: ReactRouterVersion.V6_Next;
+  dependencies: ReactRouterV6NextDependencies;
+}
+
 export interface ReactIntegrationConfig {
-  router?: ReactRouterV4V5Config | ReactRouterV6Config;
+  router?: ReactRouterV4V5Config | ReactRouterV6Config | ReactRouterV6NextConfig;
 }


### PR DESCRIPTION
## Why
This PR adds support for the React Router V6 which is using the new [RouterProvider](https://reactrouter.com/en/main/routers/router-provider) which supporting the new Data Routers.

[Setting up Routes with `RouterProvider` works differently then before](https://reactrouter.com/en/main/upgrading/v6-data#migrating-to-routerprovider).
On result of this is that we can't wrap the React Routes with `FaroRoutes` anymore. 
Also wrapping the `RouterProvider` with `FaroRoutes` also doesn't work because `FaroRoutes` are using `useLocation` internally which is not available outside of the Data Routers.

To instrument the new routers we created the `withFaroRouterInstrumentation(router)` which subscribe to route changes of the passed router and sends the respective Faro route change events.

`withFaroRouterInstrumentation(router)` work with all current data routers which are:
* [createBrowserRouter](https://reactrouter.com/en/main/routers/create-browser-router#createbrowserrouter)
* [createHashRouter](https://reactrouter.com/en/main/routers/create-hash-router)
* [createMemoryRouter](https://reactrouter.com/en/main/routers/create-memory-router)

Because setting up data routers is differently then other V6 routers, the Faro React setup is different as well:

```ts
 new ReactIntegration({
        router: {
          version: ReactRouterVersion.V6_data_router,
          dependencies: {
            matchRoutes,
          },
        },
      }),
```
 
**Note**
To test the new router you can use below branch of the Faro demo which uses the data router.
To test the data routers mentioned above just open the `App.tsx` file and replace `createBrowserRouter` with `createHashRouter` or `createMemoryRouter`.
👉🏼 Don't forget to rebuild the demo after you made changes to App.tsx

* [react-router-upgrade-playground](https://github.com/grafana/faro-web-sdk/tree/react-router-upgrade-playground)

## What
* create `withFaroRouterInstrumentation(router)` function to instrument the data routers
* Create data router specific init function which needs less dependencies


## Links

Related issue: https://github.com/grafana/faro-web-sdk/issues/235

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
