### PR TITLE
fix: infinite loop if session dom storage is turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): Faro updates sessions in an infinite loop if DOM Storage is not
+  available (#519).
+
 ## 1.4.2
 
 - Fix (`@grafana/faro-web-sdk`): Session started timestamp was reset on page-loads (#513).

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -3,6 +3,7 @@ import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigati
 import {
   initializeFaro as coreInit,
   getWebInstrumentations,
+  InternalLoggerLevel,
   ReactIntegration,
   ReactRouterVersion,
 } from '@grafana/faro-react';
@@ -38,6 +39,7 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
+    internalLoggerLevel: InternalLoggerLevel.VERBOSE,
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -39,7 +39,6 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
-    internalLoggerLevel: InternalLoggerLevel.VERBOSE,
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,5 +1,7 @@
 import { dateNow, faro, genShortID } from '@grafana/faro-core';
 
+import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
+
 import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import type { FaroUserSession } from './types';
@@ -60,6 +62,13 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
       return;
     }
 
+    const sessionTrackingConfig = faro.config.sessionTracking;
+    const isPersistentSessions = sessionTrackingConfig?.persistent;
+
+    if ((isPersistentSessions && !isLocalStorageAvailable) || (!isPersistentSessions && !isSessionStorageAvailable)) {
+      return;
+    }
+
     const sessionFromStorage = fetchUserSession();
 
     if (isUserSessionValid(sessionFromStorage)) {
@@ -73,7 +82,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
       storeUserSession(newSession);
 
       faro.api?.setSession(newSession.sessionMeta);
-      faro.config.sessionTracking?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
+      sessionTrackingConfig?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
     }
   };
 }


### PR DESCRIPTION
## Why

If DOM storage is diabled teh web-sdk got stuck in a loop.

This is because in the `updateSession` we fetch a session from DOM storage, validate it and then either update the last activity timestamp of the valid session or create a new session.

In case DOM storage is not available, we always get a `null` value for stored session which is invalid.
So we only update the in-memory session meta with the new session.
Creating a new session via this function is basically a session extend, so it causes a session extend event to be send, which in turn leads to that the update function is called again, which cuases teh inifnifte loop beacuse the above steps are executed over and over again. 

*Responsible part of the update function*

```ts

    if (isUserSessionValid(sessionFromStorage)) {
      storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
    } else {
      let newSession = addSessionMetadataToNextSession(
        createUserSessionObject({ isSampled: isSampled() }),
        sessionFromStorage
      );

      storeUserSession(newSession);

      faro.api?.setSession(newSession.sessionMeta);
      sessionTrackingConfig?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
    }
```
  

## What
Check if DOM storage is availble and if not don't execute the update (session_extend).

This will still gives send data and sessionID, but: 
* the session will not be auto-extended if timed out.
* A new session will be created fo reach page load

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
