### PR TITLE
chore(docs): Update Faro-React docs, add upgrade instructions

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -11,10 +11,9 @@ Out of the box, the package provides you the following features:
 
 ## Installation
 
-### Use with React Router 5 and 6 (no Data Routers)
+### React Router without Data Routers
 
-This describes how to setup Faro-React to use with React Router V5 and V6.
-If you use React Router V6 with the Data API please refer to the next section.
+To set up Faro-React with React Router V5 or V6 without Data routers, add the following code snippet to your project. If you use React Router V6 with Data Routers, refer to the React Router with Data Routers section.
 
 ```ts
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
@@ -57,7 +56,7 @@ initializeFaro({
 });
 ```
 
-### Use with React Router v6 Data Routers
+### Use with React Router with Data Routers
 
 ```ts
 import { matchRoutes } from 'react-router-dom';
@@ -138,7 +137,7 @@ const pushErrorOptions: PushErrorOptions = {
 
 ### Router
 
-### V6
+#### V6
 
 ```tsx
 import { FaroRoutes } from '@grafana/faro-react';
@@ -150,7 +149,7 @@ import { FaroRoutes } from '@grafana/faro-react';
 </FaroRoutes>;
 ```
 
-### V6 Data Router
+#### V6 Data Router
 
 1. Create a data router (createBrowserRouter, createHashRouter, createMemoryRouter)
 2. Instrument the data router to receive route changes by wrapping it with `withFaroRouterInstrumentation()`
@@ -163,7 +162,7 @@ const reactBrowserRouter = createBrowserRouter([
 const browserRouter = withFaroRouterInstrumentation(reactBrowserRouter);
 ```
 
-### V4/v5
+#### V4/v5
 
 ```tsx
 import { FaroRoute } from '@grafana/faro-react';
@@ -187,7 +186,7 @@ import { FaroRoute } from '@grafana/faro-react';
    - `useLocation`
    - `useNavigationType`
 
-**Example: updating dependencies**
+Example: updating dependencies
 
 ```ts
 initializeFaro({
@@ -222,7 +221,7 @@ initializeFaro({
    2.1 Remove `<FaroRoutes>` component. This will not work anymore with V6 data routers.
    2.2 Create a data router and wrap it with `withFaroRouterInstrumentation(dataRouter)`
 
-**Example: Instrument Router**
+Example: Instrument Router
 
 ```ts
 const reactBrowserRouter = createBrowserRouter([

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -77,7 +77,7 @@ initializeFaro({
     new ReactIntegration({
       // Only needed if you want to use the React Router instrumentation
       router: {
-        version: ReactRouterVersion.V6_data_api,
+        version: ReactRouterVersion.V6_data_router,
         dependencies: {
           matchRoutes,
         },
@@ -180,7 +180,7 @@ import { FaroRoute } from '@grafana/faro-react';
 #### Upgrading from instrumented V6 router to V6 data router
 
 1. Change router config
-   1.1 Change `version` property from `ReactRouterVersion.V6` to `ReactRouterVersion.V6_data_api`.
+   1.1 Change `version` property from `ReactRouterVersion.V6` to `ReactRouterVersion.V6_data_router`.
    1.2 Remove the following dependencies from teh dependencies object
    - `createRoutesFromChildren`
    - `Routes`
@@ -202,8 +202,8 @@ initializeFaro({
     new ReactIntegration({
       // Only needed if you want to use the React Router instrumentation
       router: {
-        // version: ReactRouterVersion.V6 // => change to .V6_data_api,
-        version: ReactRouterVersion.V6_data_api,
+        // version: ReactRouterVersion.V6 // => change to .V6_data_router,
+        version: ReactRouterVersion.V6_data_router,
         dependencies: {
           matchRoutes,
           // +++ remove the following dependencies +++

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,9 @@ Out of the box, the package provides you the following features:
 
 ### React Router without Data Routers
 
-To set up Faro-React with React Router V5 or V6 without Data routers, add the following code snippet to your project. If you use React Router V6 with Data Routers, refer to the React Router with Data Routers section.
+To set up Faro-React with React Router V5 or V6 without Data routers, add the following code snippet
+to your project. If you use React Router V6 with Data Routers, refer to the React Router with Data
+Routers section.
 
 ```ts
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
@@ -178,13 +180,15 @@ import { FaroRoute } from '@grafana/faro-react';
 
 #### Upgrading from instrumented V6 router to V6 data router
 
-1. Change router config
-   1.1 Change `version` property from `ReactRouterVersion.V6` to `ReactRouterVersion.V6_data_router`.
-   1.2 Remove the following dependencies from teh dependencies object
-   - `createRoutesFromChildren`
-   - `Routes`
-   - `useLocation`
-   - `useNavigationType`
+##### Change router config
+
+1. Change `version` property from `ReactRouterVersion.V6` to `ReactRouterVersion.V6_data_router`.
+2. Remove the following dependencies from the dependencies object
+
+- `createRoutesFromChildren`
+- `Routes`
+- `useLocation`
+- `useNavigationType`
 
 Example: updating dependencies
 
@@ -217,9 +221,10 @@ initializeFaro({
 });
 ```
 
-2. Change Router instrumentation
-   2.1 Remove `<FaroRoutes>` component. This will not work anymore with V6 data routers.
-   2.2 Create a data router and wrap it with `withFaroRouterInstrumentation(dataRouter)`
+##### Change Router instrumentation
+
+1. Remove `<FaroRoutes>` component. This will not work anymore with V6 data routers.
+2. Create a data router and wrap it with `withFaroRouterInstrumentation(dataRouter)`
 
 Example: Instrument Router
 


### PR DESCRIPTION
## Why

Upgrade Faro React docs to reflect new capabilities for data routers.

## What

* Include how to instrument Data Routers
* Include upgrade guide from V6 to V6 Data Routers 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated
