### PR TITLE
feat(k6): add  testRunId to k6 meta if available in k6 object

### DIFF
--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -113,6 +113,16 @@ Properties:
 
 - `name` - the name of the current view
 
+### K6
+
+The K6 meta is only added if Faro is running in a K6 environment.
+It derives the information from the existence of the K6 object in the browser window (`window.k6`).
+
+Starting with K6 v0.50.0, the property `testRunId` is attached to the K6 object, which is the
+test run ID of the current K6 test and can be used to reference the respective K6 test.
+If available, Faro adds this property to the K6 meta as well.
+It is fully managed by Faro and is not meant to be altered outside of Faro.
+
 ## Metas SDK
 
 The metas SDK is the internal handler for the metas component. It is responsible for keeping track of the current metas

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -71,6 +71,7 @@ export interface MetaView {
 
 export interface MetaK6 {
   isK6Browser?: boolean;
+  testRunId?: string;
 }
 
 export interface Meta {

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -5,7 +5,30 @@ import { defaultMetas } from '../metas/const';
 import { makeCoreConfig } from './makeCoreConfig';
 
 describe('defaultMetas', () => {
-  it('includes K6Meta in defaultMetas for k6 (lab) sessions', () => {
+  it('includes K6Meta in defaultMetas for k6 (lab) sessions configured K6 properties.', () => {
+    (global as any).k6 = {
+      testRunId: 'abcde',
+    };
+
+    const browserConfig = {
+      url: 'http://example.com/my-collector',
+      app: {},
+    };
+    const config = makeCoreConfig(browserConfig);
+
+    expect(config).toBeTruthy();
+    expect(config?.metas).toHaveLength(3);
+    expect(config?.metas.map((item) => (isFunction(item) ? item() : item))).toContainEqual({
+      k6: {
+        isK6Browser: true,
+        testRunId: 'abcde',
+      },
+    });
+
+    delete (global as any).k6;
+  });
+
+  it('does not include K6 Object properties if not set', () => {
     (global as any).k6 = {};
 
     const browserConfig = {

--- a/packages/web-sdk/src/metas/k6/meta.ts
+++ b/packages/web-sdk/src/metas/k6/meta.ts
@@ -1,7 +1,7 @@
 import type { Meta, MetaItem } from '@grafana/faro-core';
 
 type K6Properties = {
-  testRunId?: number | string;
+  testRunId?: string;
 };
 
 export const k6Meta: MetaItem<Pick<Meta, 'k6'>> = () => {

--- a/packages/web-sdk/src/metas/k6/meta.ts
+++ b/packages/web-sdk/src/metas/k6/meta.ts
@@ -1,9 +1,17 @@
 import type { Meta, MetaItem } from '@grafana/faro-core';
 
+type K6Properties = {
+  testRunId?: number | string;
+};
+
 export const k6Meta: MetaItem<Pick<Meta, 'k6'>> = () => {
+  const k6Properties: K6Properties = (window as any).k6;
+
   return {
     k6: {
+      // we only add the k6 meta if Faro is running inside a k6 environment, so this is always true
       isK6Browser: true,
+      ...(k6Properties?.testRunId && { testRunId: k6Properties?.testRunId }),
     },
   };
 };


### PR DESCRIPTION
## Why

Starting from k6 v0.50.0 the `window.k6` object will contain the `testRunId` field populated with the test run ID.
The test run ID can be used to reference the test run in Grafana Cloud, as well as to distinguish tests executed in the K6 browser farm from local ones.

The ETA for k6 v0.50.0 release is March 25th

## What
Update the k6 meta to include `testRunId` if available

## Links

[Docs PR website, cloud docs](https://github.com/grafana/website/pull/18955)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
