### PR TITLE
chore(sessions): remove structured clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Chore(`@grafana/faro-web-sdk`): Get rid of structureClone. It caused breakage in some
+  sandboxed environments because of injected proxy objects (#536).
+
 ## 1.5.0
 
 - Feat(`@grafana/faro-web-sdk`): Add responseStatus to performance events (#526).

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -657,4 +657,33 @@ describe('SessionInstrumentation', () => {
     expect(sessionFromStorage.sessionId).toBe(sessionId);
     expect(sessionFromStorage.started).toBe(started);
   });
+
+  it('Removes is sampled attribute before transport item is sent.', () => {
+    const mockNewSessionId = '123';
+
+    const transport = new MockTransport();
+
+    initializeFaro(
+      mockConfig({
+        transports: [transport],
+        instrumentations: [new SessionInstrumentation()],
+        sessionTracking: {
+          enabled: true,
+          samplingRate: 1,
+          session: { id: mockNewSessionId, attributes: { foo: 'bar' } },
+        },
+      })
+    );
+
+    expect(transport.items).toHaveLength(1);
+
+    const event = transport.items[0]! as TransportItem<EventEvent>;
+    expect(event.payload.name).toEqual(EVENT_SESSION_START);
+    expect(event.meta.session).toStrictEqual({
+      id: mockNewSessionId,
+      attributes: {
+        foo: 'bar',
+      },
+    });
+  });
 });

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -119,15 +119,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
       const attributes = item.meta.session?.attributes;
 
       if (attributes && attributes?.['isSampled'] === 'true') {
-        let newItem: TransportItem;
-
-        // Structured clone is supported in all major browsers
-        // but for old browsers we need a fallback
-        if ('structuredClone' in window) {
-          newItem = structuredClone(item);
-        } else {
-          newItem = JSON.parse(JSON.stringify(item));
-        }
+        let newItem: TransportItem = JSON.parse(JSON.stringify(item));
 
         const newAttributes = newItem.meta.session?.attributes;
         delete newAttributes?.['isSampled'];


### PR DESCRIPTION
## Why

Structured clone. caused issues in sandboxes which wrap some things in proxy objects.

JSON.stringify omits invalid objects or sets them to null.

Did no own benchmarks but scimming a bit trhrough teh web it seems that we don't gain any performance benefits when using `structuredClone`.

Last but not list this simplifies the code and we get reid of  statement as well.

## What

*  Remove `structuredClone` and use the JSON method to deep copy objects.

## Links

* [Slack 1](https://raintank-corp.slack.com/archives/C04LHN01GN7/p1710930121069309)
* [Slack 2](https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1710498855153949)
* [MDN JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
