### PR TITLE
Add missing parsing time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Feature(`@grafana/faro-web-sdk`): Add parsing time to FaroNavigationTiming (#541).
 - Chore(`@grafana/faro-web-sdk`): Get rid of structureClone. It caused breakage in some
   sandboxed environments because of injected proxy objects (#536).
 

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -6,7 +6,7 @@ import { webStorageType } from '../../utils/webStorage';
 import { getNavigationTimings } from './navigation';
 import { NAVIGATION_ID_STORAGE_KEY } from './performanceConstants';
 import * as performanceUtilsModule from './performanceUtils';
-import { calculateFaroNavigationTiming, calculateFaroResourceTiming } from './performanceUtils';
+import { createFaroNavigationTiming, createFaroResourceTiming } from './performanceUtils';
 import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 
 describe('Navigation observer', () => {
@@ -79,8 +79,8 @@ describe('Navigation observer', () => {
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
     expect(mockPushEvent).toHaveBeenCalledWith('faro.performance.navigation', {
-      ...calculateFaroResourceTiming(performanceNavigationEntry),
-      ...calculateFaroNavigationTiming(performanceNavigationEntry),
+      ...createFaroResourceTiming(performanceNavigationEntry),
+      ...createFaroNavigationTiming(performanceNavigationEntry),
       faroNavigationId: mockNavigationId,
       faroPreviousNavigationId: 'unknown',
     });
@@ -100,8 +100,8 @@ describe('Navigation observer', () => {
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
     expect(mockPushEvent).toHaveBeenCalledWith('faro.performance.navigation', {
-      ...calculateFaroResourceTiming(performanceNavigationEntry),
-      ...calculateFaroNavigationTiming(performanceNavigationEntry),
+      ...createFaroResourceTiming(performanceNavigationEntry),
+      ...createFaroNavigationTiming(performanceNavigationEntry),
       faroNavigationId: mockNewNavigationId,
       faroPreviousNavigationId: mockPreviousNavigationId,
     });

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -4,7 +4,7 @@ import type { EventsAPI } from '@grafana/faro-core';
 import { getItem, setItem, webStorageType } from '../../utils';
 
 import { NAVIGATION_ENTRY, NAVIGATION_ID_STORAGE_KEY } from './performanceConstants';
-import { calculateFaroNavigationTiming, entryUrlIsIgnored } from './performanceUtils';
+import { createFaroNavigationTiming, entryUrlIsIgnored } from './performanceUtils';
 import type { FaroNavigationItem } from './types';
 
 export function getNavigationTimings(
@@ -26,7 +26,7 @@ export function getNavigationTimings(
     const faroPreviousNavigationId = getItem(NAVIGATION_ID_STORAGE_KEY, webStorageType.session) ?? 'unknown';
 
     const faroNavigationEntry: FaroNavigationItem = {
-      ...calculateFaroNavigationTiming(navigationEntryRaw.toJSON()),
+      ...createFaroNavigationTiming(navigationEntryRaw.toJSON()),
       faroNavigationId: genShortID(),
       faroPreviousNavigationId,
     };

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -2,6 +2,17 @@ import { createFaroNavigationTiming, createFaroResourceTiming } from './performa
 import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 import type { FaroNavigationTiming, FaroResourceTiming } from './types';
 
+Object.defineProperty(window, 'performance', {
+  configurable: true,
+  value: {
+    timeOrigin: 0,
+    timing: {
+      domLoading: 542,
+    },
+  },
+  writable: true,
+});
+
 describe('performanceUtils', () => {
   it(`calculates navigation timing`, () => {
     const faroNavigationTiming = createFaroNavigationTiming(performanceNavigationEntry);
@@ -9,6 +20,7 @@ describe('performanceUtils', () => {
       visibilityState: 'visible',
       duration: '2700',
       pageLoadTime: '2441',
+      documentParsingTime: '705',
       domProcessingTime: '1431',
       onLoadTime: '22',
       domContentLoadHandlerTime: '3',

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -97,4 +97,17 @@ describe('performanceUtils', () => {
     // For browsers which do not support the responseStatus property
     expect(createFaroResourceTiming({} as any).renderBlockingStatus).toBe('unknown');
   });
+
+  it(`Sets documentParsingTime to "unknown" in case it is not supported by a certain browser`, () => {
+    Object.defineProperty(window, 'performance', {
+      configurable: true,
+      value: {
+        timeOrigin: 0,
+      },
+      writable: true,
+    });
+
+    const faroNavigationTiming = createFaroNavigationTiming(performanceNavigationEntry);
+    expect(faroNavigationTiming.documentParsingTime).toBe('unknown');
+  });
 });

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -1,10 +1,10 @@
-import { calculateFaroNavigationTiming, calculateFaroResourceTiming } from './performanceUtils';
+import { createFaroNavigationTiming, createFaroResourceTiming } from './performanceUtils';
 import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 import type { FaroNavigationTiming, FaroResourceTiming } from './types';
 
 describe('performanceUtils', () => {
   it(`calculates navigation timing`, () => {
-    const faroNavigationTiming = calculateFaroNavigationTiming(performanceNavigationEntry);
+    const faroNavigationTiming = createFaroNavigationTiming(performanceNavigationEntry);
     expect(faroNavigationTiming).toStrictEqual({
       visibilityState: 'visible',
       duration: '2700',
@@ -35,7 +35,7 @@ describe('performanceUtils', () => {
   });
 
   it(`calculates resource timings`, () => {
-    const faroResourceTiming = calculateFaroResourceTiming(performanceResourceEntry);
+    const faroResourceTiming = createFaroResourceTiming(performanceResourceEntry);
     expect(faroResourceTiming).toStrictEqual({
       name: 'http://example.com/awesome-image',
       duration: '370',
@@ -58,33 +58,31 @@ describe('performanceUtils', () => {
   });
 
   it(`calculates cacheHitStatus`, () => {
-    expect(calculateFaroResourceTiming({ transferSize: 0 } as any).cacheHitStatus).toBe('fullLoad');
-    expect(calculateFaroResourceTiming({ transferSize: 1 } as any).cacheHitStatus).toBe('fullLoad');
+    expect(createFaroResourceTiming({ transferSize: 0 } as any).cacheHitStatus).toBe('fullLoad');
+    expect(createFaroResourceTiming({ transferSize: 1 } as any).cacheHitStatus).toBe('fullLoad');
 
-    expect(calculateFaroResourceTiming({ transferSize: 0, decodedBodySize: 1 } as any).cacheHitStatus).toBe('cache');
+    expect(createFaroResourceTiming({ transferSize: 0, decodedBodySize: 1 } as any).cacheHitStatus).toBe('cache');
 
-    expect(calculateFaroResourceTiming({ transferSize: 1, encodedBodySize: 0 } as any).cacheHitStatus).toBe('fullLoad');
-    expect(calculateFaroResourceTiming({ transferSize: 1, encodedBodySize: 1 } as any).cacheHitStatus).toBe('fullLoad');
-    expect(calculateFaroResourceTiming({ transferSize: 1, encodedBodySize: 2 } as any).cacheHitStatus).toBe(
+    expect(createFaroResourceTiming({ transferSize: 1, encodedBodySize: 0 } as any).cacheHitStatus).toBe('fullLoad');
+    expect(createFaroResourceTiming({ transferSize: 1, encodedBodySize: 1 } as any).cacheHitStatus).toBe('fullLoad');
+    expect(createFaroResourceTiming({ transferSize: 1, encodedBodySize: 2 } as any).cacheHitStatus).toBe(
       'conditionalFetch'
     );
 
     // For browsers supporting the responseStatus property
     expect(
-      calculateFaroResourceTiming({ transferSize: 1, encodedBodySize: 1, responseStatus: 200 } as any).cacheHitStatus
+      createFaroResourceTiming({ transferSize: 1, encodedBodySize: 1, responseStatus: 200 } as any).cacheHitStatus
     ).toBe('fullLoad');
     expect(
-      calculateFaroResourceTiming({ transferSize: 1, encodedBodySize: 1, responseStatus: 304 } as any).cacheHitStatus
+      createFaroResourceTiming({ transferSize: 1, encodedBodySize: 1, responseStatus: 304 } as any).cacheHitStatus
     ).toBe('conditionalFetch');
   });
 
   it(`Sets renderBlockingStatus`, () => {
     // For browsers supporting the responseStatus property
-    expect(calculateFaroResourceTiming({ renderBlockingStatus: 'blocking' } as any).renderBlockingStatus).toBe(
-      'blocking'
-    );
+    expect(createFaroResourceTiming({ renderBlockingStatus: 'blocking' } as any).renderBlockingStatus).toBe('blocking');
 
     // For browsers which do not support the responseStatus property
-    expect(calculateFaroResourceTiming({} as any).renderBlockingStatus).toBe('unknown');
+    expect(createFaroResourceTiming({} as any).renderBlockingStatus).toBe('unknown');
   });
 });

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -126,11 +126,6 @@ export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNaviga
 
 function getDocumentParsingTime(domInteractive: number): string {
   let parserStart;
-  console.log('performance.timeOrigin :>> ', performance.timeOrigin);
-  console.log('performance :>> ', performance);
-  console.log('performance.timing :>> ', performance.timing);
-  console.log('performance.timing.domLoading :>> ', performance.timing?.domLoading);
-
   if (performance.timing?.domLoading != null) {
     // the browser is about to start parsing the first received bytes of the HTML document.
     // This property is deprecated but there isn't a really good alternative atm.

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -23,7 +23,7 @@ export function onDocumentReady(handleReady: () => void) {
   }
 }
 
-export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourceTiming): FaroResourceTiming {
+export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTiming): FaroResourceTiming {
   const {
     connectEnd,
     connectStart,
@@ -92,7 +92,7 @@ export function calculateFaroResourceTiming(resourceEntryRaw: PerformanceResourc
   }
 }
 
-export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNavigationTiming): FaroNavigationTiming {
+export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNavigationTiming): FaroNavigationTiming {
   const {
     activationStart,
     domComplete,
@@ -119,7 +119,7 @@ export function calculateFaroNavigationTiming(navigationEntryRaw: PerformanceNav
 
     type: type,
 
-    ...calculateFaroResourceTiming(navigationEntryRaw),
+    ...createFaroResourceTiming(navigationEntryRaw),
   };
 }
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -109,6 +109,7 @@ export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNaviga
   return {
     visibilityState: document.visibilityState,
     pageLoadTime: toFaroPerformanceTimingString(domComplete - fetchStart),
+    documentParsingTime: getDocumentParsingTime(domInteractive),
     domProcessingTime: toFaroPerformanceTimingString(domComplete - domInteractive),
     domContentLoadHandlerTime: toFaroPerformanceTimingString(domContentLoadedEventEnd - domContentLoadedEventStart),
     onLoadTime: toFaroPerformanceTimingString(loadEventEnd - loadEventStart),
@@ -121,6 +122,23 @@ export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNaviga
 
     ...createFaroResourceTiming(navigationEntryRaw),
   };
+}
+
+function getDocumentParsingTime(domInteractive: number): string {
+  let parserStart;
+  console.log('performance.timeOrigin :>> ', performance.timeOrigin);
+  console.log('performance :>> ', performance);
+  console.log('performance.timing :>> ', performance.timing);
+  console.log('performance.timing.domLoading :>> ', performance.timing?.domLoading);
+
+  if (performance.timing?.domLoading != null) {
+    // the browser is about to start parsing the first received bytes of the HTML document.
+    // This property is deprecated but there isn't a really good alternative atm.
+    // For now we stick with domLoading and keep researching a better alternative.
+    parserStart = performance.timing.domLoading - performance.timeOrigin;
+  }
+
+  return toFaroPerformanceTimingString(parserStart ? domInteractive - parserStart : undefined);
 }
 
 function toFaroPerformanceTimingString(v: unknown): string {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -106,10 +106,12 @@ export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNaviga
     type,
   } = navigationEntryRaw;
 
+  const parserStart = getDocumentParsingTime();
+
   return {
     visibilityState: document.visibilityState,
     pageLoadTime: toFaroPerformanceTimingString(domComplete - fetchStart),
-    documentParsingTime: getDocumentParsingTime(domInteractive),
+    documentParsingTime: toFaroPerformanceTimingString(parserStart ? domInteractive - parserStart : null),
     domProcessingTime: toFaroPerformanceTimingString(domComplete - domInteractive),
     domContentLoadHandlerTime: toFaroPerformanceTimingString(domContentLoadedEventEnd - domContentLoadedEventStart),
     onLoadTime: toFaroPerformanceTimingString(loadEventEnd - loadEventStart),
@@ -124,16 +126,15 @@ export function createFaroNavigationTiming(navigationEntryRaw: PerformanceNaviga
   };
 }
 
-function getDocumentParsingTime(domInteractive: number): string {
-  let parserStart;
+function getDocumentParsingTime(): number | null {
   if (performance.timing?.domLoading != null) {
     // the browser is about to start parsing the first received bytes of the HTML document.
     // This property is deprecated but there isn't a really good alternative atm.
     // For now we stick with domLoading and keep researching a better alternative.
-    parserStart = performance.timing.domLoading - performance.timeOrigin;
+    return performance.timing.domLoading - performance.timeOrigin;
   }
 
-  return toFaroPerformanceTimingString(parserStart ? domInteractive - parserStart : undefined);
+  return null;
 }
 
 function toFaroPerformanceTimingString(v: unknown): string {

--- a/packages/web-sdk/src/instrumentations/performance/resource.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.test.ts
@@ -1,7 +1,7 @@
 import * as faroCoreModule from '@grafana/faro-core';
 
 import * as performanceUtilsModule from './performanceUtils';
-import { calculateFaroResourceTiming } from './performanceUtils';
+import { createFaroResourceTiming } from './performanceUtils';
 import { performanceResourceEntry } from './performanceUtilsTestData';
 import { observeResourceTimings } from './resource';
 
@@ -70,7 +70,7 @@ describe('Navigation observer', () => {
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
     expect(mockPushEvent).toHaveBeenCalledWith('faro.performance.resource', {
-      ...calculateFaroResourceTiming(performanceResourceEntry),
+      ...createFaroResourceTiming(performanceResourceEntry),
       faroNavigationId: mockNavigationId,
       faroResourceId: mockResourceId,
     });

--- a/packages/web-sdk/src/instrumentations/performance/resource.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.ts
@@ -2,7 +2,7 @@ import { genShortID } from '@grafana/faro-core';
 import type { EventsAPI } from '@grafana/faro-core';
 
 import { RESOURCE_ENTRY } from './performanceConstants';
-import { calculateFaroResourceTiming, entryUrlIsIgnored } from './performanceUtils';
+import { createFaroResourceTiming, entryUrlIsIgnored } from './performanceUtils';
 
 export function observeResourceTimings(
   faroNavigationId: string,
@@ -18,7 +18,7 @@ export function observeResourceTimings(
       }
 
       const faroResourceEntry = {
-        ...calculateFaroResourceTiming(resourceEntryRaw.toJSON()),
+        ...createFaroResourceTiming(resourceEntryRaw.toJSON()),
         faroNavigationId,
         faroResourceId: genShortID(),
       };

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -2,6 +2,7 @@ export type FaroNavigationTiming = Readonly<
   {
     duration: string;
     visibilityState: DocumentVisibilityState;
+    documentParsingTime: string;
     domProcessingTime: string;
     pageLoadTime: string;
     domContentLoadHandlerTime: string;


### PR DESCRIPTION
## Why

When comparing page-load time with time spent in the browser, let's say dom and render timings + response time, there is notable delta between the sum of the latter timings and page-load time.

After some investigation, the results are:

Faro is working correct and we derive all timings as they should be, but why the delta?

We did some manual math and it turns out that the delta is _mostly_ related to the time the browser needs to parse the document.

![IMG_5973](https://github.com/grafana/faro-web-sdk/assets/47627413/435ae79e-1e8e-4b39-a8f3-33fd6ae287b4)


So the plan is calculate parser time as well.

### How to calculate the parser time
Unfortunately the current performance timeline doesn't provide and event to retrospectively get the timestamp when the parser is starting it's work. In the image below you can see that we have `responseEnd` followed by `domInteractive`.
One could argue  that we simply can use `domInteractive - responseEnd`, but this can not be used because the browser may start parsing even before the last bit of the response has arrived.

<img width="801" alt="image" src="https://github.com/grafana/faro-web-sdk/assets/47627413/2a5bdd35-b312-4fef-87ba-9e8e31a949ea">

When reading the [docs for domInteractive](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domInteractive) we see that this property represents the time immediately before the documents ready state is set to "interactive"

> The domInteractive read-only property returns a [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp) representing the time immediately before the user agent sets the document's [readyState](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) to "interactive". ——MDN

So let's have a look if we can utilize the documents `readyState` to get that timestamp.
Turns out: yes, but!

When the parsers start it's work the`document.readyState` property changes to 'loading' (see [mdn Document: readyState property](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState)). 

This could be a suitable strategy in case we fetch the `readyState` at the beginning of the `<head>` of the `index.html` file.
But this is not working for us because we can't control when Faro is initialized. Some user may defer loading and so on. 
Also we need a good mechanism to ensure that fetching the `readyState` is done before everything else. 
Another option would be to put this work on the user side and have user adding extra logic specific to enable use fetching that timestamp. Even if we provide copy&paste code this is no option and very error prone because people will likely forget to do that.

<img width="288" alt="image" src="https://github.com/grafana/faro-web-sdk/assets/47627413/fe8ece4c-44cb-46dc-b935-72bebbcb6945">

### PerformanceTiming: domLoading property to the rescue
The old, deprecated, `performance.timing` object provides the `domLoading` property which is moment when the parser is starting its work.

> The legacy PerformanceTiming.domLoading read-only property returns an unsigned long long representing the moment, in milliseconds since the UNIX epoch, when the parser started its work, that is when its [Document.readyState](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) changes to 'loading' and the corresponding [readystatechange](https://developer.mozilla.org/en-US/docs/Web/API/Document/readystatechange_event) event is thrown. ——MDN

performance.timing.domLoading is deprecated but still supported in all browsers.

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domLoading#browser_compatibility) at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

According to the [w3 docs for domLoading](https://www.w3.org/TR/2015/WD-navigation-timing-2-20150527/#widl-PerformanceNavigationTiming-domLoading) the reason for the deprecation is:

> The domLoading attribute is deprecated and may be removed in future versions of this specification. Due to differences in when a Document object is created in existing user agents, the value returned by the domLoading is implementation specific and should not be used in meaningful metrics.——W3 Docs

### Solution
The [`domLoading` property can be used to calculate the parser time](https://web.dev/articles/critical-rendering-path/measure-crp#navigation-timing). 

<img width="446" alt="image" src="https://github.com/grafana/faro-web-sdk/assets/47627413/ca5bc706-9458-4433-8b79-e785376bbdce">

Even if the metric is different across user agents I still see value in providing the information and close the gap in numbers mentioned above.

One downside is that we are using a deprecated API, so we need to:
* ensure to not break Faro in case a browser vendor removes it 
* keep an eye on browser api updates to react early
* keep researching a better solution  

## What
* Calculate parser time by using the `domLoading` property

## Links

* [Documentation PR](https://github.com/grafana/website/pull/19129)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
