### PR TITLE
docs: remove pre-release note from web-sdk and web-tracing readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Docs(`@grafana/faro-web-sdk`, `@grafana/faro-web-tracing`): Remove pre-release warning (#550).
+
 ## 1.5.1
 
 - Feature(`@grafana/faro-web-sdk`): Add parsing time to FaroNavigationTiming (#541).

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -5,8 +5,6 @@ Faro is a SDK that can instrument frontend JavaScript applications to collect te
 
 Grafana Agent can then send this data to either [Loki][grafana-logs] or [Tempo][grafana-traces].
 
-_Warning_: currently pre-release and subject to frequent breaking changes. Use at your own risk.
-
 ## Get started
 
 See [quick start for web applications][quick-start].

--- a/packages/web-tracing/README.md
+++ b/packages/web-tracing/README.md
@@ -5,8 +5,6 @@ This package provides tools for integrating [OpenTelemetry][opentelemetry-js] ba
 
 See [quick start document][quick-start] for instructions how to set up and use.
 
-_Warning_: currently pre-release and subject to frequent breaking changes. Use at your own risk.
-
 [faro-web-sdk-package]: https://github.com/grafana/faro-web-sdk/tree/main/packages/web-sdk
 [opentelemetry-js]: https://opentelemetry.io/docs/instrumentation/js/
 [quick-start]: https://github.com/grafana/faro-web-sdk/blob/main/docs/sources/tutorials/quick-start-browser.md


### PR DESCRIPTION
## Why

The README files in the web-sdk and web-tracing packages still had the pre-release warning.

## What
* Remove pre-release warning from web-sdk and web-tracing package

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
