### PR TITLE
feat: LogArgsSerializer to customize how args are converter to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-core`): Config has now a parameter `logArgsSerializer` to set a custom serializer for log arguments (#564). This is usuful if log message args are complex and might produce `[object Object]` in the logs.
+
 ## 1.7.0
 
 - Enhancement (`@grafana/faro-web-sdk`): provide option to globally

--- a/docs/sources/developer/architecture/components/api.md
+++ b/docs/sources/developer/architecture/components/api.md
@@ -37,6 +37,14 @@ Methods:
 
 - `pushLog` - sends a log
 
+Logging arguments (`console.info('Hello', {foo: 'bar'})`) are by default each transformed into a string and concatenated by a space. If you want to use a different transformation, you can provide a custom `logArgsSerializer` function in the config object.
+
+```javascript
+initializeFaro({
+  logArgsSerializer: (args) => args.map((arg) => JSON.stringify(arg)).join(' ')
+});
+```
+
 ### Measurements
 
 Measurements are signals which can be seen as metrics.

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -14,7 +14,7 @@ export type {
   StacktraceParser,
 } from './exceptions';
 
-export type { LogContext, LogEvent, LogsAPI, PushLogOptions } from './logs';
+export type { LogContext, LogEvent, LogArgsSerializer, LogsAPI, PushLogOptions } from './logs';
 
 export type { MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from './measurements';
 

--- a/packages/core/src/api/logs/index.ts
+++ b/packages/core/src/api/logs/index.ts
@@ -1,3 +1,3 @@
 export { initializeLogsAPI } from './initialize';
 
-export type { LogContext, LogEvent, LogsAPI, PushLogOptions } from './types';
+export type { LogContext, LogEvent, LogArgsSerializer, LogsAPI, PushLogOptions } from './types';

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -21,20 +21,25 @@ export function initializeLogsAPI(
 
   let lastPayload: Pick<LogEvent, 'message' | 'level' | 'context'> | null = null;
 
+  const logArgsSerializer =
+    config.logArgsSerializer ??
+    ((args) =>
+      args
+        .map((arg) => {
+          try {
+            return String(arg);
+          } catch (err) {
+            return '';
+          }
+        })
+        .join(' '));
+
   const pushLog: LogsAPI['pushLog'] = (args, { context, level, skipDedupe, spanContext } = {}) => {
     try {
       const item: TransportItem<LogEvent> = {
         type: TransportItemType.LOG,
         payload: {
-          message: args
-            .map((arg) => {
-              try {
-                return String(arg);
-              } catch (err) {
-                return '';
-              }
-            })
-            .join(' '),
+          message: logArgsSerializer(args),
           level: level ?? defaultLogLevel,
           context: context ?? {},
           timestamp: getCurrentTimestamp(),

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -24,3 +24,5 @@ export interface PushLogOptions {
 export interface LogsAPI {
   pushLog: (args: unknown[], options?: PushLogOptions) => void;
 }
+
+export type LogArgsSerializer = (args: unknown[]) => string;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,4 +1,4 @@
-import type { APIEvent, StacktraceParser } from '../api';
+import type { APIEvent, LogArgsSerializer, StacktraceParser } from '../api';
 import type { Instrumentation } from '../instrumentations';
 import type { InternalLoggerLevel } from '../internalLogger';
 import type { Meta, MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '../metas';
@@ -17,6 +17,7 @@ export interface Config<P = APIEvent> {
   instrumentations: Instrumentation[];
   internalLoggerLevel: InternalLoggerLevel;
   isolate: boolean;
+  logArgsSerializer?: LogArgsSerializer;
   metas: MetaItem[];
   parseStacktrace: StacktraceParser;
   paused: boolean;


### PR DESCRIPTION
## Why

The default behaviour in `pushLogs` stringifies all arguments in a very simple way. This results in potential `[object Object]` log messages if some one or some third party library decides to put complex logs arguments e.g. `console.info({foo: "bar"})`

## What

This PR extends the faro config with a `logArgsSerializer` paremeter that allows to override the default behaviour and put in a custom args renderer

fixes #564

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
