### PR TITLE
Update types to work with v6 data routers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enhancement (`@grafana/faro-core`): Config has now a parameter `logArgsSerializer` to set a custom serializer for
   log arguments (#564). This is useful if log message args are complex and might produce `[object Object]` in the logs.
 - Fix (`@grafana/faro-web-tracing`): Fix an import issue causing builds to fail (#581).
+- Fix (`@grafana/faro-react`): Fix type issues in react data route wrapper `withFaroRouterInstrumentation` (#584).
 
 ## 1.7.0
 

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -2,6 +2,24 @@ import type { ReactElement, ReactNode } from 'react';
 
 import type { ReactRouterLocation } from '../types';
 
+interface IndexRouteObjectV6DataRouter {
+  caseSensitive?: boolean;
+  children?: undefined;
+  element?: React.ReactNode | null;
+  index?: true;
+  path?: string;
+}
+
+export interface NonIndexRouteObjectV6DataRouter {
+  caseSensitive?: boolean;
+  children?: RouteObjectV6DataRouter[];
+  element?: React.ReactNode | null;
+  index?: false;
+  path?: string;
+}
+
+export type RouteObjectV6DataRouter = IndexRouteObjectV6DataRouter | NonIndexRouteObjectV6DataRouter;
+
 export interface ReactRouterV6BaseRouteObject {
   action?: (...args: any[]) => any;
   caseSensitive?: boolean;

--- a/packages/react/src/router/v6/types.ts
+++ b/packages/react/src/router/v6/types.ts
@@ -6,7 +6,7 @@ interface IndexRouteObjectV6DataRouter {
   caseSensitive?: boolean;
   children?: undefined;
   element?: React.ReactNode | null;
-  index?: true;
+  index: true;
   path?: string;
 }
 

--- a/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
+++ b/packages/react/src/router/v6/withFaroRouterInstrumentation.ts
@@ -4,7 +4,7 @@ import { api } from '../../dependencies';
 import { NavigationType, ReactRouterLocation } from '../types';
 
 import { isInitialized } from './routerDependencies';
-import type { EventRouteTransitionAttributes, ReactRouterV6RouteObject } from './types';
+import type { EventRouteTransitionAttributes, RouteObjectV6DataRouter } from './types';
 import { getRouteFromLocation } from './utils';
 
 interface RouterState {
@@ -14,7 +14,7 @@ interface RouterState {
 
 interface Router {
   state: RouterState;
-  routes: ReactRouterV6RouteObject[];
+  routes: RouteObjectV6DataRouter[];
   subscribe(fn: (state: RouterState) => void): () => void;
 }
 


### PR DESCRIPTION
## Why

There was type issue with newest react (data) router.
Add specific types for `Index` and `NonIndex` routes.
We took the necessary properties from the `RouteObject` type as defined by the remix/react router.  

## What
Update types in `withFaroRouterInstrumentation` to satisfy the React Router `RouteObject` type.

## Links

## Screenshots 

### Before

<img width="1023" alt="Screenshot 2024-05-06 at 12 41 41" src="https://github.com/grafana/faro-web-sdk/assets/47627413/34842b23-43db-4497-a585-7ba619adda90">

### After
<img width="784" alt="Screenshot 2024-05-06 at 12 41 10" src="https://github.com/grafana/faro-web-sdk/assets/47627413/26f4c405-2f84-4e80-8b31-f7cc23ffe0c2">


## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
