### PR TITLE
feat(web-sdk): forward logArgsSerializer in initializeFaro to the core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Feature (`@grafana/faro-core`): sourcemap uploads - add `bundleId` to the `MetaApp` `Meta` object
   (#476).
 - Feature (`@grafana/faro-web-sdk`): track window dimensions via the `browser meta` (#594).
+- Feature (`@grafana/faro-web-sdk`): If `logArgsSerializer` is set in the config
+  of `initializeFaro`, it will be forwarded to the core (#589).
 
 ## 1.7.2
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -14,6 +14,7 @@ export type {
   StacktraceParser,
 } from './exceptions';
 
+export { defaultLogArgsSerializer } from './logs';
 export type { LogContext, LogEvent, LogArgsSerializer, LogsAPI, PushLogOptions } from './logs';
 
 export type { MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from './measurements';

--- a/packages/core/src/api/logs/const.ts
+++ b/packages/core/src/api/logs/const.ts
@@ -1,0 +1,12 @@
+import type { LogArgsSerializer } from './types';
+
+export const defaultLogArgsSerializer: LogArgsSerializer = (args) =>
+  args
+    .map((arg) => {
+      try {
+        return String(arg);
+      } catch (err) {
+        return '';
+      }
+    })
+    .join(' ');

--- a/packages/core/src/api/logs/index.ts
+++ b/packages/core/src/api/logs/index.ts
@@ -1,3 +1,5 @@
+export { defaultLogArgsSerializer } from './const';
+
 export { initializeLogsAPI } from './initialize';
 
 export type { LogContext, LogEvent, LogArgsSerializer, LogsAPI, PushLogOptions } from './types';

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -7,6 +7,7 @@ import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, defaultLogLevel, getCurrentTimestamp, isNull } from '../../utils';
 import type { TracesAPI } from '../traces';
 
+import { defaultLogArgsSerializer } from './const';
 import type { LogEvent, LogsAPI } from './types';
 
 export function initializeLogsAPI(
@@ -21,18 +22,7 @@ export function initializeLogsAPI(
 
   let lastPayload: Pick<LogEvent, 'message' | 'level' | 'context'> | null = null;
 
-  const logArgsSerializer =
-    config.logArgsSerializer ??
-    ((args) =>
-      args
-        .map((arg) => {
-          try {
-            return String(arg);
-          } catch (err) {
-            return '';
-          }
-        })
-        .join(' '));
+  const logArgsSerializer = config.logArgsSerializer ?? defaultLogArgsSerializer;
 
   const pushLog: LogsAPI['pushLog'] = (args, { context, level, skipDedupe, spanContext } = {}) => {
     try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { defaultExceptionType } from './api';
+export { defaultExceptionType, defaultLogArgsSerializer } from './api';
 export type {
   API,
   APIEvent,
@@ -9,6 +9,7 @@ export type {
   ExceptionStackFrame,
   ExceptionsAPI,
   ExtendedError,
+  LogArgsSerializer,
   LogContext,
   LogEvent,
   LogsAPI,

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -1,4 +1,5 @@
-import { isFunction } from '@grafana/faro-core';
+import { defaultLogArgsSerializer, isFunction } from '@grafana/faro-core';
+import type { LogArgsSerializer } from '@grafana/faro-core';
 
 import { defaultMetas } from '../metas/const';
 
@@ -51,5 +52,32 @@ describe('defaultMetas', () => {
     expect(defaultMetas.map((item) => (isFunction(item) ? item() : item))).not.toContainEqual({
       k6: { isK6Browser: true },
     });
+  });
+});
+
+describe('config', () => {
+  it('includes custom logArgsSerializer if one was provided', () => {
+    const customLogArgsSerializer: LogArgsSerializer = () => 'test';
+
+    const browserConfig = {
+      url: 'http://example.com/my-collector',
+      app: {},
+      logArgsSerializer: customLogArgsSerializer,
+    };
+    const config = makeCoreConfig(browserConfig);
+
+    expect(config).toBeTruthy();
+    expect(config?.logArgsSerializer).toBe(customLogArgsSerializer);
+  });
+
+  it('includes default logArgsSerializer if no custom one was provided', () => {
+    const browserConfig = {
+      url: 'http://example.com/my-collector',
+      app: {},
+    };
+    const config = makeCoreConfig(browserConfig);
+
+    expect(config).toBeTruthy();
+    expect(config?.logArgsSerializer).toBe(defaultLogArgsSerializer);
   });
 });

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -3,6 +3,7 @@ import {
   defaultBatchingConfig,
   defaultGlobalObjectKey,
   defaultInternalLoggerLevel,
+  defaultLogArgsSerializer,
   defaultUnpatchedConsole,
   isObject,
 } from '@grafana/faro-core';
@@ -67,6 +68,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config | undefined
     instrumentations: browserConfig.instrumentations ?? getWebInstrumentations(),
     internalLoggerLevel: browserConfig.internalLoggerLevel ?? defaultInternalLoggerLevel,
     isolate: browserConfig.isolate ?? false,
+    logArgsSerializer: browserConfig.logArgsSerializer ?? defaultLogArgsSerializer,
     metas: createMetas(),
     parseStacktrace,
     paused: browserConfig.paused ?? false,


### PR DESCRIPTION
## Why

https://github.com/grafana/faro-web-sdk/pull/580 introduced the `logArgsSerializer` option in the core. But it isn't usable through `initializeFaro` from the web-sdk since the `makeCoreConfig` doesn't forward the option.

## What

I tried to follow the patterns of the surrounding code, which is why I introduced the new `defaultLogArgsSerializer` to use as a fallback. If `logArgsSerializer` is not set on the browser config this default is used.

I didn't find any documentation that could be updated alongside with this change. If there is a place I should document this, please let me know.

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
