### PR TITLE
590 grafana cloud create new session if 400 session invalid is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-web-sdk`): Auto extend a session if the Faro receiver indicates that a
+  session is invalid (#591).
+
 ## 1.7.3
 
 - Feature (`@grafana/faro-core`): source map uploads - add `bundleId` to the `MetaApp` `Meta` object

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -15,11 +15,14 @@ import { createSession } from '../../metas';
 
 import { type FaroUserSession, isSampled } from './sessionManager';
 import { PersistentSessionsManager } from './sessionManager/PersistentSessionsManager';
-import { createUserSessionObject, isUserSessionValid } from './sessionManager/sessionManagerUtils';
-import { VolatileSessionsManager } from './sessionManager/VolatileSessionManager';
+import {
+  createUserSessionObject,
+  getSessionManagerByConfig,
+  isUserSessionValid,
+} from './sessionManager/sessionManagerUtils';
+import type { SessionManager } from './sessionManager/types';
 
 type LifecycleType = typeof EVENT_SESSION_RESUME | typeof EVENT_SESSION_START;
-type SessionManager = typeof VolatileSessionsManager | typeof PersistentSessionsManager;
 
 export class SessionInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-session';
@@ -141,7 +144,7 @@ export class SessionInstrumentation extends BaseInstrumentation {
     const sessionTrackingConfig = this.config.sessionTracking;
 
     if (sessionTrackingConfig?.enabled) {
-      const SessionManager = sessionTrackingConfig?.persistent ? PersistentSessionsManager : VolatileSessionsManager;
+      const SessionManager = getSessionManagerByConfig(sessionTrackingConfig);
 
       this.registerBeforeSendHook(SessionManager);
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
@@ -5,8 +5,11 @@ export const SESSION_EXPIRATION_TIME = 4 * 60 * 60 * 1000; // hrs
 export const SESSION_INACTIVITY_TIME = 15 * 60 * 1000; // minutes
 export const STORAGE_UPDATE_DELAY = 1 * 1000; // seconds
 
+/**
+ * @deprecated MAX_SESSION_PERSISTENCE_TIME_BUFFER is not used anymore. The constant will be removed in the future
+ */
 export const MAX_SESSION_PERSISTENCE_TIME_BUFFER = 1 * 60 * 1000;
-export const MAX_SESSION_PERSISTENCE_TIME = SESSION_INACTIVITY_TIME + MAX_SESSION_PERSISTENCE_TIME_BUFFER;
+export const MAX_SESSION_PERSISTENCE_TIME = SESSION_INACTIVITY_TIME;
 
 export const defaultSessionTrackingConfig: Config['sessionTracking'] = {
   enabled: true,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -301,4 +301,44 @@ describe('sessionManagerUtils', () => {
       },
     });
   });
+
+  it('forces userSessionUpdater to expand the current user session.', () => {
+    const mockOnSessionChange = jest.fn();
+
+    const config = mockConfig({
+      sessionTracking: {
+        enabled: true,
+        onSessionChange: mockOnSessionChange,
+      },
+    });
+
+    const faro = initializeFaro(config);
+
+    const mockIsUserSessionValid = jest.fn();
+    jest.spyOn(mockSessionManagerUtils, 'isUserSessionValid').mockImplementationOnce(() => {
+      mockIsUserSessionValid();
+      return true;
+    });
+
+    const mockFetchUserSession = jest.fn();
+    const mockStoreUserSession = jest.fn();
+
+    const updateSession = getUserSessionUpdater({
+      fetchUserSession: mockFetchUserSession,
+      storeUserSession: mockStoreUserSession,
+    });
+
+    const mockSetSession = jest.fn();
+    jest.spyOn(faro.api, 'setSession').mockImplementationOnce(mockSetSession);
+
+    updateSession({ forceSessionExtend: true });
+
+    expect(mockFetchUserSession).toHaveBeenCalledTimes(1);
+
+    expect(mockIsUserSessionValid).not.toHaveBeenCalled();
+
+    expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
+    expect(mockSetSession).toHaveBeenCalledTimes(1);
+    expect(mockOnSessionChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -1,16 +1,19 @@
-import { initializeFaro } from '@grafana/faro-core';
 import * as faroCore from '@grafana/faro-core';
+import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
+import { PersistentSessionsManager } from './PersistentSessionsManager';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import * as mockSessionManagerUtils from './sessionManagerUtils';
 import {
   addSessionMetadataToNextSession,
   createUserSessionObject,
+  getSessionManagerByConfig,
   getUserSessionUpdater,
   isUserSessionValid,
 } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
+import { VolatileSessionsManager } from './VolatileSessionManager';
 
 const fakeSystemTime = new Date('2023-01-01').getTime();
 const mockSessionId = '123';
@@ -340,5 +343,13 @@ describe('sessionManagerUtils', () => {
     expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
     expect(mockSetSession).toHaveBeenCalledTimes(1);
     expect(mockOnSessionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('Returns the configured session manager.', () => {
+    let SessionManager = getSessionManagerByConfig({ persistent: false /* default */ });
+    expect(new SessionManager()).toBeInstanceOf(VolatileSessionsManager);
+
+    SessionManager = getSessionManagerByConfig({ persistent: true });
+    expect(new SessionManager()).toBeInstanceOf(PersistentSessionsManager);
   });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -76,7 +76,7 @@ export function getUserSessionUpdater({
 
     const sessionFromStorage = fetchUserSession();
 
-    if (forceSessionExtend !== true && isUserSessionValid(sessionFromStorage)) {
+    if (forceSessionExtend === false && isUserSessionValid(sessionFromStorage)) {
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
     } else {
       let newSession = addSessionMetadataToNextSession(

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -56,8 +56,13 @@ type GetUserSessionUpdaterParams = {
   fetchUserSession: () => FaroUserSession | null;
 };
 
-export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: GetUserSessionUpdaterParams): () => void {
-  return function updateSession(): void {
+type UpdateSessionParams = { forceSessionExtend: boolean };
+
+export function getUserSessionUpdater({
+  fetchUserSession,
+  storeUserSession,
+}: GetUserSessionUpdaterParams): (options?: UpdateSessionParams) => void {
+  return function updateSession({ forceSessionExtend } = { forceSessionExtend: false }): void {
     if (!fetchUserSession || !storeUserSession) {
       return;
     }
@@ -71,7 +76,7 @@ export function getUserSessionUpdater({ fetchUserSession, storeUserSession }: Ge
 
     const sessionFromStorage = fetchUserSession();
 
-    if (isUserSessionValid(sessionFromStorage)) {
+    if (forceSessionExtend !== true && isUserSessionValid(sessionFromStorage)) {
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
     } else {
       let newSession = addSessionMetadataToNextSession(

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -3,11 +3,10 @@ import type { Config } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
-import { PersistentSessionsManager } from './PersistentSessionsManager';
+import { PersistentSessionsManager, VolatileSessionsManager } from '.';
 import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
 import type { FaroUserSession, SessionManager } from './types';
-import { VolatileSessionsManager } from './VolatileSessionManager';
 
 type CreateUserSessionObjectParams = {
   sessionId?: string;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,10 +1,13 @@
 import { dateNow, faro, genShortID } from '@grafana/faro-core';
+import type { Config } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
+import { PersistentSessionsManager } from './PersistentSessionsManager';
 import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
-import type { FaroUserSession } from './types';
+import type { FaroUserSession, SessionManager } from './types';
+import { VolatileSessionsManager } from './VolatileSessionManager';
 
 type CreateUserSessionObjectParams = {
   sessionId?: string;
@@ -107,4 +110,8 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
   };
 
   return sessionWithMeta;
+}
+
+export function getSessionManagerByConfig(sessionTrackingConfig: Config['sessionTracking']): SessionManager {
+  return sessionTrackingConfig?.persistent ? PersistentSessionsManager : VolatileSessionsManager;
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/types.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/types.ts
@@ -1,5 +1,8 @@
 import type { MetaSession } from '@grafana/faro-core';
 
+import type { PersistentSessionsManager } from './PersistentSessionsManager';
+import type { VolatileSessionsManager } from './VolatileSessionManager';
+
 export interface FaroUserSession {
   sessionId: string;
   lastActivity: number;
@@ -7,3 +10,5 @@ export interface FaroUserSession {
   isSampled: boolean;
   sessionMeta?: MetaSession;
 }
+
+export type SessionManager = typeof VolatileSessionsManager | typeof PersistentSessionsManager;

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -79,9 +79,8 @@ export class FetchTransport extends BaseTransport {
         })
           .then(async (response) => {
             if (response.status === ACCEPTED) {
-              // TODO: clarify if we verify the value or if existence of the header indicates an invalid session
-              // const isExpired = response.headers.get('X-Faro-Session-Status') !== null;
               const isExpired = response.headers.get('X-Faro-Session-Status') === 'invalid';
+
               if (isExpired) {
                 extendFaroSession(this.config, this.logDebug);
               }


### PR DESCRIPTION
## Why
We noticed an edge case where stored session timings drift and the collector rejects session even if Faro automatically extend the session.

The receiver was updated to deal with this.
Anyways to be on the save side we will handle the response in Faro and create a new Session if needed.

## What
The Faro receiver now returns a 202 with the custom header `X-Faro-Session-Status` with value `invalid` if a session is invalid.
The header is not attached for 202 response of a valid session.

## Links
* [Faro receiver PR](https://github.com/grafana/app-o11y-kwl-endpoint/pull/438)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
