### PR TITLE
use current node lts version in nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron


### PR DESCRIPTION
## Why

nvmrc had a diferent node lts version then teh one used by the CI.

## What

Use current lts version lts/iron

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
