### PR TITLE
Track window dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Feature (`@grafana/faro-core`): sourcemap uploads - add `bundleId` to the `MetaApp` `Meta` object (#476).
+- Feature (`@grafana/faro-web-sdk`): track window dimensions via the `browser meta` (#594).
 
 ## 1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- Feature (`@grafana/faro-core`): sourcemap uploads - add `bundleId` to the `MetaApp` `Meta` object (#476).
+- Feature (`@grafana/faro-core`): sourcemap uploads - add `bundleId` to the `MetaApp` `Meta` object
+  (#476).
 - Feature (`@grafana/faro-web-sdk`): track window dimensions via the `browser meta` (#594).
 
 ## 1.7.2

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -23,8 +23,8 @@ Properties:
 
 ### Browser
 
-The `browser` meta helps with identifying the environment where the app is running and it should not change across a
-session. Altough it is not handled automatically by the core package, nor is it the responsibility of the end-user to
+The `browser` meta helps with identifying the environment where the app is running and some extra it should not change across a
+session. Although it is not handled automatically by the core package, nor is it the responsibility of the end-user to
 define it. Wrapper packages like `web-sdk` should handle it.
 
 Properties:
@@ -33,6 +33,11 @@ Properties:
 - `version` - the version of the browser
 - `os` - the operating system name and version where the browser is running
 - `mobile` - a flag indication if the browser is running on a mobile device
+- `userAgent` -
+- `language` -
+- `brands` -
+- `windowWidth` -
+- `windowHeight` -
 
 ### Page
 

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -36,8 +36,8 @@ Properties:
 - `userAgent` - details about the browser version, operating system, device type and other things
 - `language` - preferred language of the user. Usually this is language of the browser UI
 - `brands` - brands of the browser and its significant version numbers
-- `windowWidth` - height of the layout viewport
-- `windowHeight` - width of the layout viewport
+- `viewportWidth` - height of the layout viewport
+- `viewportHeight` - width of the layout viewport
 
 ### Page
 

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -23,9 +23,10 @@ Properties:
 
 ### Browser
 
-The `browser` meta helps with identifying the environment where the app is running and some extra it should not change across a
-session. Although it is not handled automatically by the core package, nor is it the responsibility of the end-user to
-define it. Wrapper packages like `web-sdk` should handle it.
+The `browser` meta helps with identifying the environment where the app is running and some extra it
+should not change across a session. Although it is not handled automatically by the core package,
+nor is it the responsibility of the end-user to define it. Wrapper packages like `web-sdk` should
+handle it.
 
 Properties:
 

--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -33,11 +33,11 @@ Properties:
 - `version` - the version of the browser
 - `os` - the operating system name and version where the browser is running
 - `mobile` - a flag indication if the browser is running on a mobile device
-- `userAgent` -
-- `language` -
-- `brands` -
-- `windowWidth` -
-- `windowHeight` -
+- `userAgent` - details about the browser version, operating system, device type and other things
+- `language` - preferred language of the user. Usually this is language of the browser UI
+- `brands` - brands of the browser and its significant version numbers
+- `windowWidth` - height of the layout viewport
+- `windowHeight` - width of the layout viewport
 
 ### Page
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Feature (`@grafana/faro-transport-otlp-http`): Add resource attributes for viewport dimensions
+  (#594).
+
 ## 1.3.6
 
 - Enhancement (`@grafana/faro-transport-otlp-http`): Turn off beaconing if request body exceeds a

--- a/experimental/transport-otlp-http/src/payload/transform/toResourceLog.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toResourceLog.test.ts
@@ -24,6 +24,8 @@ const item: Readonly<TransportItem<LogEvent>> = {
         { brand: 'Not(A:Brand', version: '8' },
         { brand: 'Chromium', version: '111' },
       ],
+      viewportHeight: '1080',
+      viewportWidth: '1920',
     },
     sdk: {
       name: 'integration-web-sdk-name',
@@ -141,6 +143,18 @@ const matchResourcePayload = {
     {
       key: 'browser.version',
       value: { stringValue: 'browser-v109.0' },
+    },
+    {
+      key: 'browser.screen_width',
+      value: {
+        stringValue: '1920',
+      },
+    },
+    {
+      key: 'browser.screen_height',
+      value: {
+        stringValue: '1080',
+      },
     },
     {
       key: 'telemetry.sdk.name',

--- a/experimental/transport-otlp-http/src/payload/transform/toResourceSpan.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toResourceSpan.test.ts
@@ -133,6 +133,8 @@ const item: Readonly<TransportItem<TraceEvent>> = {
       mobile: false,
       userAgent: 'browser-ua-string',
       language: 'browser-language',
+      viewportHeight: '1080',
+      viewportWidth: '1920',
     },
     sdk: {
       name: 'integration-web-sdk-name',
@@ -188,6 +190,18 @@ const matchResourceSpanPayload = {
       {
         key: 'browser.version',
         value: { stringValue: 'browser-v109.0' },
+      },
+      {
+        key: 'browser.screen_width',
+        value: {
+          stringValue: '1920',
+        },
+      },
+      {
+        key: 'browser.screen_height',
+        value: {
+          stringValue: '1080',
+        },
       },
       {
         key: 'telemetry.sdk.name',

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -241,6 +241,8 @@ function toResource(transportItem: TransportItem): Readonly<Resource> {
       toAttribute('browser.os', browser?.os),
       toAttribute('browser.name', browser?.name),
       toAttribute('browser.version', browser?.version),
+      toAttribute('browser.screen_width', browser?.viewportWidth),
+      toAttribute('browser.screen_height', browser?.viewportHeight),
 
       toAttribute(SemanticResourceAttributes.TELEMETRY_SDK_NAME, sdk?.name),
       toAttribute(SemanticResourceAttributes.TELEMETRY_SDK_VERSION, sdk?.version),

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -64,8 +64,8 @@ export interface MetaBrowser {
   userAgent?: string;
   language?: string;
   brands?: NavigatorUABrandVersion[] | string;
-  windowWidth?: string;
-  windowHeight?: string;
+  viewportWidth?: string;
+  viewportHeight?: string;
 }
 
 export interface MetaView {

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -64,6 +64,8 @@ export interface MetaBrowser {
   userAgent?: string;
   language?: string;
   brands?: NavigatorUABrandVersion[] | string;
+  windowWidth?: string;
+  windowHeight?: string;
 }
 
 export interface MetaView {

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -21,6 +21,8 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       language: language ?? unknown,
       mobile,
       brands: brands ?? unknown,
+      windowWidth: `${window.innerWidth}`,
+      windowHeight: `${window.innerHeight}`,
     },
   };
 

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -21,8 +21,8 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       language: language ?? unknown,
       mobile,
       brands: brands ?? unknown,
-      windowWidth: `${window.innerWidth}`,
-      windowHeight: `${window.innerHeight}`,
+      viewportWidth: `${window.innerWidth}`,
+      viewportHeight: `${window.innerHeight}`,
     },
   };
 


### PR DESCRIPTION
## Why
Track layout viewport dimension.

This can e. g. provide insights about different behavior in different viewports, enables to filter signals by viewport size and more.

## What
* add two new properties to the browser meta: `viewportWidth` and `viewportHeight`

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
