### PR TITLE
fix typo

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -308,7 +308,7 @@ const pushErrorOptions: PushErrorOptions = {
 </FaroErrorBoundary>;
 ```
 
-## React erver side rendering support
+## React server side rendering support
 
 Follow this guide to learn how to initialize your Faro instrumentation to support React Server Side
 Rendering (SSR) for:


### PR DESCRIPTION
## Why

Because typos are annoying.

## What

Changed the lesser known english word "erver" to the more known "server".

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated
