### PR TITLE
feat: collect tracecontext through server-timing for nav and resource timings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -35,3 +35,4 @@ yarn-error.log*
 # App plugin
 infra/grafana/plugins/
 infra/grafana/plugins-provisioning/*.yaml
+.yarn/releases/*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enhancement (`@grafana/faro-web-sdk`): Auto extend a session if the Faro receiver indicates that a
   session is invalid (#591).
 - Feature (`@grafana/faro-web-sdk`): track `web vitals` attribution (#595).
+- Feature (`@grafana/faro-web-sdk`): set span context for navigation events (#595).
 - Fix (`@grafana/faro-react`): Mark `react-router-dom` peer dependency as optional (#617).
 
 ## 1.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Enhancement (`@grafana/faro-web-sdk`): Auto extend a session if the Faro receiver indicates that a
   session is invalid (#591).
 - Feature (`@grafana/faro-web-sdk`): track `web vitals` attribution (#595).
-- Feature (`@grafana/faro-web-sdk`): set span context for navigation events (#595).
+- Feature (`@grafana/faro-web-sdk`): set span context for navigation events (#608).
 - Fix (`@grafana/faro-react`): Mark `react-router-dom` peer dependency as optional (#617).
 
 ## 1.7.3

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="shortcut icon" href="/favicon.png" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" />
 
     <!--app-tracing-->
 

--- a/demo/src/server/middlewares/index.ts
+++ b/demo/src/server/middlewares/index.ts
@@ -3,3 +3,5 @@ export { authMiddleware } from './auth';
 export { tokenMiddleware } from './token';
 
 export { traceparentMiddleware } from './traceparent';
+
+export { serverTimingMiddleware } from './serverTiming';

--- a/demo/src/server/middlewares/serverTiming.ts
+++ b/demo/src/server/middlewares/serverTiming.ts
@@ -1,0 +1,17 @@
+import type { RequestHandler } from '../utils';
+import { trace } from '@opentelemetry/api';
+
+export const serverTimingMiddleware: RequestHandler = async (req, res, next) => {
+  const span = trace.getActiveSpan();
+
+  // inject server-timing header and format as traceparent
+  // {version}-{trace_id}-{span_id}-{trace_flags}
+  res.setHeader(
+    'Server-Timing',
+    `traceparent;desc="00-${span?.spanContext().traceId}-${span?.spanContext().spanId}-${span
+      ?.spanContext()
+      .traceFlags.toString()}"`
+  );
+
+  next();
+};

--- a/demo/src/server/middlewares/serverTiming.ts
+++ b/demo/src/server/middlewares/serverTiming.ts
@@ -1,5 +1,6 @@
-import type { RequestHandler } from '../utils';
 import { trace } from '@opentelemetry/api';
+
+import type { RequestHandler } from '../utils';
 
 export const serverTimingMiddleware: RequestHandler = async (req, res, next) => {
   const span = trace.getActiveSpan();

--- a/demo/src/server/middlewares/serverTiming.ts
+++ b/demo/src/server/middlewares/serverTiming.ts
@@ -2,7 +2,7 @@ import { trace } from '@opentelemetry/api';
 
 import type { RequestHandler } from '../utils';
 
-export const serverTimingMiddleware: RequestHandler = async (req, res, next) => {
+export const serverTimingMiddleware: RequestHandler = async (_req, res, next) => {
   const span = trace.getActiveSpan();
 
   // inject server-timing header and format as traceparent

--- a/demo/src/server/middlewares/serverTiming.ts
+++ b/demo/src/server/middlewares/serverTiming.ts
@@ -5,14 +5,12 @@ import type { RequestHandler } from '../utils';
 export const serverTimingMiddleware: RequestHandler = async (_req, res, next) => {
   const span = trace.getActiveSpan();
 
-  // inject server-timing header and format as traceparent
-  // {version}-{trace_id}-{span_id}-{trace_flags}
-  res.setHeader(
-    'Server-Timing',
-    `traceparent;desc="00-${span?.spanContext().traceId}-${span?.spanContext().spanId}-${span
-      ?.spanContext()
-      .traceFlags.toString()}"`
-  );
+  if (span != null) {
+    const { traceId, spanId, traceFlags } = span.spanContext();
+    const w3cTraceparent = `traceparent;desc="00-${traceId}-${spanId}-${traceFlags}"`;
+
+    res.setHeader('Server-Timing', w3cTraceparent);
+  }
 
   next();
 };

--- a/demo/src/server/routes/registerRoutes.ts
+++ b/demo/src/server/routes/registerRoutes.ts
@@ -1,6 +1,6 @@
 import { Express, Router } from 'express';
 
-import { tokenMiddleware, traceparentMiddleware } from '../middlewares';
+import { serverTimingMiddleware, tokenMiddleware, traceparentMiddleware } from '../middlewares';
 
 import { registerApiRoutes } from './api';
 import { registerMetricsRoutes } from './metrics';
@@ -8,6 +8,8 @@ import { registerRenderRoutes } from './render';
 
 export async function registerRoutes(app: Express): Promise<Router> {
   const globalRouter = Router();
+
+  app.use(serverTimingMiddleware);
 
   app.use(tokenMiddleware);
 

--- a/packages/core/src/api/events/index.ts
+++ b/packages/core/src/api/events/index.ts
@@ -1,2 +1,2 @@
-export type { EventAttributes, EventEvent, EventsAPI } from './types';
+export type { EventAttributes, EventEvent, EventsAPI, PushEventOptions } from './types';
 export { initializeEventsAPI } from './initialize';

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,7 +1,7 @@
 export { initializeAPI } from './initialize';
 export type { API, APIEvent } from './types';
 
-export type { EventAttributes, EventEvent, EventsAPI } from './events';
+export type { EventAttributes, EventEvent, EventsAPI, PushEventOptions } from './events';
 
 export { defaultExceptionType } from './exceptions';
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
   MetaAPI,
   OTELApi,
   PushErrorOptions,
+  PushEventOptions,
   PushLogOptions,
   PushMeasurementOptions,
   Stacktrace,

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -104,7 +104,7 @@ describe('Navigation observer', () => {
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
     expect(mockPushEvent).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), expect.anything(), {
-      spanContext: { traceId: '1234', spanId: '5678' },
+      spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -86,7 +86,7 @@ describe('Navigation observer', () => {
         faroNavigationId: mockNavigationId,
         faroPreviousNavigationId: 'unknown',
       },
-      expect.anything(),
+      undefined,
       {
         spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
       }
@@ -103,7 +103,7 @@ describe('Navigation observer', () => {
     getNavigationTimings(mockPushEvent, ['']);
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), expect.anything(), {
+    expect(mockPushEvent).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), undefined, {
       spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
     });
   });
@@ -121,12 +121,19 @@ describe('Navigation observer', () => {
     getNavigationTimings(mockPushEvent, ['']);
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenCalledWith('faro.performance.navigation', {
-      ...createFaroResourceTiming(performanceNavigationEntry),
-      ...createFaroNavigationTiming(performanceNavigationEntry),
-      faroNavigationId: mockNewNavigationId,
-      faroPreviousNavigationId: mockPreviousNavigationId,
-    });
+    expect(mockPushEvent).toHaveBeenCalledWith(
+      'faro.performance.navigation',
+      {
+        ...createFaroResourceTiming(performanceNavigationEntry),
+        ...createFaroNavigationTiming(performanceNavigationEntry),
+        faroNavigationId: mockNewNavigationId,
+        faroPreviousNavigationId: mockPreviousNavigationId,
+      },
+      undefined,
+      {
+        spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
+      }
+    );
   });
 
   it('Stores navigationId in sessionStorage', () => {

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -88,7 +88,7 @@ describe('Navigation observer', () => {
       },
       expect.anything(),
       {
-        spanContext: { traceId: '1234', spanId: '5678' },
+        spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
       }
     );
   });

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -86,6 +86,26 @@ describe('Navigation observer', () => {
     });
   });
 
+  it('Captures Server-Timings for w3c trace context', () => {
+    const mockPushEvent = jest.fn();
+    jest.spyOn(performanceUtilsModule, 'entryUrlIsIgnored').mockReturnValueOnce(false);
+
+    const mockNavigationId = '123';
+    jest.spyOn(faroCoreModule, 'genShortID').mockReturnValueOnce(mockNavigationId);
+
+    getNavigationTimings(mockPushEvent, ['']);
+
+    expect(mockPushEvent).toHaveBeenCalledTimes(1);
+    expect(mockPushEvent).toHaveBeenNthCalledWith(1,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        {
+          spanContext: { traceId: '1234', spanId: '5678' }
+        }
+    );
+  });
+
   it('Builds entry for subsequent navigation', () => {
     const mockPushEvent = jest.fn();
     jest.spyOn(performanceUtilsModule, 'entryUrlIsIgnored').mockReturnValueOnce(false);

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -78,12 +78,19 @@ describe('Navigation observer', () => {
     getNavigationTimings(mockPushEvent, ['']);
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenCalledWith('faro.performance.navigation', {
-      ...createFaroResourceTiming(performanceNavigationEntry),
-      ...createFaroNavigationTiming(performanceNavigationEntry),
-      faroNavigationId: mockNavigationId,
-      faroPreviousNavigationId: 'unknown',
-    });
+    expect(mockPushEvent).toHaveBeenCalledWith(
+      'faro.performance.navigation',
+      {
+        ...createFaroResourceTiming(performanceNavigationEntry),
+        ...createFaroNavigationTiming(performanceNavigationEntry),
+        faroNavigationId: mockNavigationId,
+        faroPreviousNavigationId: 'unknown',
+      },
+      expect.anything(),
+      {
+        spanContext: { traceId: '1234', spanId: '5678' },
+      }
+    );
   });
 
   it('Captures Server-Timings for w3c trace context', () => {
@@ -96,14 +103,9 @@ describe('Navigation observer', () => {
     getNavigationTimings(mockPushEvent, ['']);
 
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
-    expect(mockPushEvent).toHaveBeenNthCalledWith(1,
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        {
-          spanContext: { traceId: '1234', spanId: '5678' }
-        }
-    );
+    expect(mockPushEvent).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), expect.anything(), {
+      spanContext: { traceId: '1234', spanId: '5678' },
+    });
   });
 
   it('Builds entry for subsequent navigation', () => {

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -33,13 +33,18 @@ export function getNavigationTimings(
       spanId: '',
     };
 
-    for (const { name, description } of navEntryJson) {
-      if ("traceparent" === name) {
-        const [version, traceId, spanId, sampled] = description.split("-");
-
-        spanContext.traceId = traceId;
-        spanContext.spanId = spanId;
-      }
+    if ('serverTiming' in navEntryJson) {
+        const serverTiming = navEntryJson.serverTiming;
+        if (serverTiming.length > 0) {
+          for (let i = 0; i < serverTiming.length; i++) {
+            if (serverTiming[i][0] === 'traceparent') {
+              const [version, traceId, spanId, sampled] = serverTiming[i][1].split('-');
+              spanContext.traceId = traceId;
+              spanContext.spanId = spanId;
+              break;
+            }
+          }
+        }
     }
 
     const faroPreviousNavigationId = getItem(NAVIGATION_ID_STORAGE_KEY, webStorageType.session) ?? 'unknown';

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -1,6 +1,5 @@
 import { genShortID } from '@grafana/faro-core';
-import type { EventsAPI } from '@grafana/faro-core';
-import type {PushEventOptions} from "@grafana/faro-core/src/api/events/types";
+import type { EventsAPI, PushEventOptions } from '@grafana/faro-core';
 
 import { getItem, setItem, webStorageType } from '../../utils';
 import { NAVIGATION_ID_STORAGE_KEY } from '../instrumentationConstants';

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -1,5 +1,6 @@
 import { genShortID } from '@grafana/faro-core';
-import type { EventsAPI, PushEventOptions } from '@grafana/faro-core';
+import type { EventsAPI } from '@grafana/faro-core';
+import type {PushEventOptions} from "@grafana/faro-core/src/api/events/types";
 
 import { getItem, setItem, webStorageType } from '../../utils';
 import { NAVIGATION_ID_STORAGE_KEY } from '../instrumentationConstants';

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -24,13 +24,13 @@ export function getNavigationTimings(
       return;
     }
 
-    let trace_context = {};
+    let spanContext = {};
     for (const { name, description, duration } of navigationEntryRaw.toJSON()) {
       if ("traceparent" === name) {
         const [version, traceId, spanId, sampled] = description.split("-");
 
-        trace_context.trace_id = traceId;
-        trace_context.span_id = spanId;
+        spanContext.trace_id = traceId;
+        spanContext.span_id = spanId;
       }
     }
 
@@ -44,7 +44,7 @@ export function getNavigationTimings(
 
     setItem(NAVIGATION_ID_STORAGE_KEY, faroNavigationEntry.faroNavigationId, webStorageType.session);
 
-    pushEvent('faro.performance.navigation', faroNavigationEntry);
+    pushEvent('faro.performance.navigation', faroNavigationEntry, undefined, { spanContext });
 
     faroNavigationEntryResolve(faroNavigationEntry);
   });

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -1,5 +1,5 @@
 import { genShortID } from '@grafana/faro-core';
-import type { EventsAPI } from '@grafana/faro-core';
+import type { EventsAPI, PushEventOptions } from '@grafana/faro-core';
 
 import { getItem, setItem, webStorageType } from '../../utils';
 import { NAVIGATION_ID_STORAGE_KEY } from '../instrumentationConstants';
@@ -7,6 +7,8 @@ import { NAVIGATION_ID_STORAGE_KEY } from '../instrumentationConstants';
 import { NAVIGATION_ENTRY } from './performanceConstants';
 import { createFaroNavigationTiming, entryUrlIsIgnored } from './performanceUtils';
 import type { FaroNavigationItem } from './types';
+
+type SpanContext = PushEventOptions['spanContext']
 
 export function getNavigationTimings(
   pushEvent: EventsAPI['pushEvent'],
@@ -24,20 +26,26 @@ export function getNavigationTimings(
       return;
     }
 
-    let spanContext = {};
-    for (const { name, description, duration } of navigationEntryRaw.toJSON()) {
+    const navEntryJson = navigationEntryRaw.toJSON();
+
+    let spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
+      traceId: '',
+      spanId: '',
+    };
+
+    for (const { name, description } of navEntryJson) {
       if ("traceparent" === name) {
         const [version, traceId, spanId, sampled] = description.split("-");
 
-        spanContext.trace_id = traceId;
-        spanContext.span_id = spanId;
+        spanContext.traceId = traceId;
+        spanContext.spanId = spanId;
       }
     }
 
     const faroPreviousNavigationId = getItem(NAVIGATION_ID_STORAGE_KEY, webStorageType.session) ?? 'unknown';
 
     const faroNavigationEntry: FaroNavigationItem = {
-      ...createFaroNavigationTiming(navigationEntryRaw.toJSON()),
+      ...createFaroNavigationTiming(navEntryJson),
       faroNavigationId: genShortID(),
       faroPreviousNavigationId,
     };

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -24,6 +24,16 @@ export function getNavigationTimings(
       return;
     }
 
+    let trace_context = {};
+    for (const { name, description, duration } of navigationEntryRaw.toJSON()) {
+      if ("traceparent" === name) {
+        const [version, traceId, spanId, sampled] = description.split("-");
+
+        trace_context.trace_id = traceId;
+        trace_context.span_id = spanId;
+      }
+    }
+
     const faroPreviousNavigationId = getItem(NAVIGATION_ID_STORAGE_KEY, webStorageType.session) ?? 'unknown';
 
     const faroNavigationEntry: FaroNavigationItem = {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -2,7 +2,7 @@ import {
   createFaroNavigationTiming,
   createFaroResourceTiming,
   getSpanContextFromServerTiming,
-  includePerformanceEntry
+  includePerformanceEntry,
 } from './performanceUtils';
 import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 import type { FaroNavigationTiming, FaroResourceTiming } from './types';
@@ -168,10 +168,9 @@ describe('performanceUtils', () => {
     const serverTimings: PerformanceServerTiming[] = [
       {
         name: 'traceparent',
-        description: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        description: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
         duration: 0,
-        toJSON(): any {
-        }
+        toJSON(): any {},
       },
     ];
 
@@ -185,8 +184,7 @@ describe('performanceUtils', () => {
         name: 'traceparent',
         description: '00-1234-5678-01-02',
         duration: 0,
-        toJSON(): any {
-        }
+        toJSON(): any {},
       },
     ];
 
@@ -202,4 +200,3 @@ describe('performanceUtils', () => {
     expect(spanContextUndefined).toBeUndefined();
   });
 });
-

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -168,7 +168,7 @@ describe('performanceUtils', () => {
     const serverTimings: PerformanceServerTiming[] = [
       {
         name: 'traceparent',
-        description: '00-1234-5678-01',
+        description: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         duration: 0,
         toJSON(): any {
         }

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -175,7 +175,7 @@ describe('performanceUtils', () => {
     ];
 
     const spanContext = getSpanContextFromServerTiming(serverTimings);
-    expect(spanContext).toStrictEqual({ traceId: '1234', spanId: '5678' });
+    expect(spanContext).toStrictEqual({ traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' });
   });
 
   it('Ignores incoming traceparent server-timings if they are not conformant to w3c trace-context', () => {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -2,7 +2,7 @@ import { isArray, type PushEventOptions } from '@grafana/faro-core';
 
 import type { CacheType, FaroNavigationTiming, FaroResourceTiming } from './types';
 
-const w3cTraceparentFormat = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{2}$/;
+const w3cTraceparentFormat = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{1,2}$/;
 
 type SpanContext = PushEventOptions['spanContext'];
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -66,6 +66,11 @@ export const performanceResourceEntry = {
   decodedBodySize: 10526,
   serverTiming: [
     {
+      name: 'traceparent',
+      duration: 0,
+      description: '00-1234-5678-01',
+    },
+    {
       name: 'foo',
       duration: 0,
       description: 'bar',

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -26,7 +26,7 @@ export const performanceNavigationEntry = {
     {
       name: 'traceparent',
       duration: 0,
-      description: '00-1234-5678-01',
+      description: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
     },
   ],
   unloadEventStart: 0,
@@ -68,7 +68,7 @@ export const performanceResourceEntry = {
     {
       name: 'traceparent',
       duration: 0,
-      description: '00-1234-5678-01',
+      description: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
     },
     {
       name: 'foo',

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -24,10 +24,10 @@ export const performanceNavigationEntry = {
   decodedBodySize: 530675,
   serverTiming: [
     {
-        name: 'traceparent',
-        duration: 0,
-        description: '00-1234-5678-01',
-    }
+      name: 'traceparent',
+      duration: 0,
+      description: '00-1234-5678-01',
+    },
   ],
   unloadEventStart: 0,
   unloadEventEnd: 0,

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -22,7 +22,13 @@ export const performanceNavigationEntry = {
   transferSize: 127601,
   encodedBodySize: 126111,
   decodedBodySize: 530675,
-  serverTiming: [],
+  serverTiming: [
+    {
+        name: 'traceparent',
+        duration: 0,
+        description: '00-1234-5678-01',
+    }
+  ],
   unloadEventStart: 0,
   unloadEventEnd: 0,
   domInteractive: 1247,

--- a/packages/web-sdk/src/instrumentations/performance/resource.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.test.ts
@@ -78,7 +78,7 @@ describe('Resource observer', () => {
     expect(mockPushEvent).not.toHaveBeenCalled();
   });
 
-  it('Builds entry for first navigation', () => {
+  it('Builds entry for first resource', () => {
     const mockPushEvent = jest.fn();
     jest.spyOn(performanceUtilsModule, 'entryUrlIsIgnored').mockReturnValueOnce(false);
 

--- a/packages/web-sdk/src/instrumentations/performance/resource.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.test.ts
@@ -92,11 +92,17 @@ describe('Resource observer', () => {
 
     expect(mockPushEvent).toHaveBeenCalledTimes(3);
 
-    expect(mockPushEvent).toHaveBeenNthCalledWith(1, 'faro.performance.resource', {
-      ...createFaroResourceTiming(performanceResourceEntry),
-      faroNavigationId: mockNavigationId,
-      faroResourceId: mockResourceId,
-    });
+    expect(mockPushEvent).toHaveBeenNthCalledWith(
+      1,
+      'faro.performance.resource',
+      {
+        ...createFaroResourceTiming(performanceResourceEntry),
+        faroNavigationId: mockNavigationId,
+        faroResourceId: mockResourceId,
+      },
+      undefined,
+      { spanContext: { traceId: '1234', spanId: '5678' } }
+    );
   });
 
   it('Tracks default resource entries if trackResource is unset', () => {

--- a/packages/web-sdk/src/instrumentations/performance/resource.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.test.ts
@@ -101,7 +101,7 @@ describe('Resource observer', () => {
         faroResourceId: mockResourceId,
       },
       undefined,
-      { spanContext: { traceId: '1234', spanId: '5678' } }
+      { spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' } }
     );
   });
 


### PR DESCRIPTION
## Why

Create correlation between faro events for navigations by attaching a server-sent identifier

## What

Extract server-timing contents and use it to add span context.

Enhance demo to send trace parent via server-timing.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated


Fixes: #452
