### PR TITLE
fix: mark peer deps `react-dom` and `react-router-dom` as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enhancement (`@grafana/faro-web-sdk`): Auto extend a session if the Faro receiver indicates that a
   session is invalid (#591).
 - Feature (`@grafana/faro-web-sdk`): track `web vitals` attribution (#595).
+- Fix (`@grafana/faro-react`): Mark `react-router-dom` peer dependency as optional (#617).
 
 ## 1.7.3
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,6 +68,14 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    },
+    "react-router-dom": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Why

<!-- Add a clear and concise description of why that changes are needed. -->

`react-router-dom` is an optional dependency, and should be marked as such.

`react-dom` only exists since `react-router-dom` has its own peer dep on it.

## What

Use `peerDependenciesMeta` (works in all package managers)

<!-- Add a clear and concise description of what you changed. -->

## Links

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
