### PR TITLE
Pass span context in console instrumentation if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): span context is now passed to pushLogs in the console instrumentation (#632).
+
 ## 1.8.0
 
 - Feature (`@grafana/faro-web-sdk`): track `web vitals` attribution (#595).

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -21,7 +21,7 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         /* eslint-disable-next-line no-console */
         console[level] = (...args) => {
           try {
-            this.api.pushLog(args, { level });
+            this.api.pushLog(args, { level, spanContext: this.currentSpanContext() });
           } catch (err) {
             this.logError(err);
           } finally {
@@ -29,5 +29,9 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
           }
         };
       });
+  }
+  private currentSpanContext(): { traceId: string; spanId: string } | undefined {
+    const traceContext = this.api.getTraceContext();
+    return traceContext ? { traceId: traceContext.trace_id, spanId: traceContext.span_id } : undefined;
   }
 }


### PR DESCRIPTION
fixes #632

## Why
The console instrumentation was not provided to `pushLogs`. This PR appends optional span context if a trace context exits

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
