### PR TITLE
Set span status on erroneus fetch requests

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -21,7 +21,15 @@ export function initializeFaro(): Faro {
         captureConsole: true,
       }),
 
-      new TracingInstrumentation(),
+      new TracingInstrumentation({
+        instrumentationOptions: {
+          fetchInstrumentationOptions: {
+            applyCustomAttributesOnSpan: () => {
+              console.log('hello from fetch');
+            },
+          },
+        },
+      }),
       new ReactIntegration({
         router: {
           version: ReactRouterVersion.V6,

--- a/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
+++ b/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
@@ -1,20 +1,20 @@
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
-import type { InstrumentationOption, MatchUrlDefinitions } from './types';
+import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
 
-type DefaultInstrumentationsOptions = {
-  ignoreUrls?: MatchUrlDefinitions;
-  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
-};
-
-const initialIntrumentationsOptions = {
+const initialInstrumentationsOptions = {
   ignoreUrls: [],
   propagateTraceHeaderCorsUrls: [],
 };
 
 export function getDefaultOTELInstrumentations(
-  options: DefaultInstrumentationsOptions = initialIntrumentationsOptions
+  options: DefaultInstrumentationsOptions = initialInstrumentationsOptions
 ): InstrumentationOption[] {
-  return [new FetchInstrumentation(options), new XMLHttpRequestInstrumentation(options)];
+  const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
+
+  return [
+    new FetchInstrumentation({ ...sharedOptions, ...fetchInstrumentationOptions }),
+    new XMLHttpRequestInstrumentation({ ...sharedOptions, ...xhrInstrumentationOptions }),
+  ];
 }

--- a/packages/web-tracing/src/index.ts
+++ b/packages/web-tracing/src/index.ts
@@ -9,3 +9,5 @@ export { TracingInstrumentation } from './instrumentation';
 export { getSamplingDecision } from './sampler';
 
 export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';
+
+export { setSpanStatusOnFetchError, fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -15,6 +15,7 @@ import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+import { fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';
 import { getSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
@@ -90,6 +91,14 @@ export class TracingInstrumentation extends BaseInstrumentation {
         getDefaultOTELInstrumentations({
           ignoreUrls: this.getIgnoreUrls(),
           propagateTraceHeaderCorsUrls: this.options.instrumentationOptions?.propagateTraceHeaderCorsUrls,
+          fetchInstrumentationOptions: {
+            applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
+              this.options.instrumentationOptions?.fetchInstrumentationOptions?.applyCustomAttributesOnSpan
+            ),
+          },
+          xhrInstrumentationOptions: {
+            ...this.options.instrumentationOptions?.xhrInstrumentationOptions,
+          },
         }),
     });
 

--- a/packages/web-tracing/src/instrumentationUtils.test.ts
+++ b/packages/web-tracing/src/instrumentationUtils.test.ts
@@ -1,0 +1,45 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+
+import { fetchCustomAttributeFunctionWithDefaults, setSpanStatusOnFetchError } from './instrumentationUtils';
+import * as instrumentationUtilsMock from './instrumentationUtils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([500, 599, 400, 499, new Error()])('set span status on fetch error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = result instanceof Error ? result : ({ status: result } as Response);
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on fetch success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: result } as Response;
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls setSpanStatusOnFetchError and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnFetchError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: 500 } as Response;
+    const callback = jest.fn();
+
+    fetchCustomAttributeFunctionWithDefaults(callback)(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, request, response);
+  });
+});

--- a/packages/web-tracing/src/instrumentationUtils.ts
+++ b/packages/web-tracing/src/instrumentationUtils.ts
@@ -1,0 +1,38 @@
+import { Span, SpanStatusCode } from '@opentelemetry/api';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+
+export interface FetchError {
+  status?: number;
+  message: string;
+}
+
+/**
+ * Adds HTTP status code to every span.
+ *
+ * The fetch instrumentation does not always set the span status to error as defined by the spec.
+ * To work around that issue we manually set the span status.
+ *
+ * Issue: https://github.com/open-telemetry/opentelemetry-js/issues/3564
+ * Spec: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#status
+ */
+export function setSpanStatusOnFetchError(span: Span, _request: Request | RequestInit, result: Response | FetchError) {
+  const httpStatusCode = result instanceof Error ? 0 : result.status;
+
+  if (httpStatusCode == null) {
+    return;
+  }
+
+  const isError = httpStatusCode === 0;
+  const isClientOrServerError = httpStatusCode >= 400 && httpStatusCode < 600;
+
+  if (isError || isClientOrServerError) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}
+
+export function fetchCustomAttributeFunctionWithDefaults(callback?: FetchCustomAttributeFunction) {
+  return (span: Span, request: Request | RequestInit, result: Response | FetchError) => {
+    setSpanStatusOnFetchError(span, request, result);
+    callback?.(span, request, result);
+  };
+}

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -1,5 +1,7 @@
 import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
 import type { ResourceAttributes } from '@opentelemetry/resources';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
@@ -20,9 +22,20 @@ export interface TracingInstrumentationOptions {
   contextManager?: ContextManager;
   instrumentations?: InstrumentationOption[];
   spanProcessor?: SpanProcessor;
-  instrumentationOptions?: {
-    propagateTraceHeaderCorsUrls: MatchUrlDefinitions;
-  };
+  instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
 }
 
 export type MatchUrlDefinitions = Patterns;
+
+export type DefaultInstrumentationsOptions = {
+  ignoreUrls?: MatchUrlDefinitions;
+  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
+
+  fetchInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+  };
+
+  xhrInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+  };
+};


### PR DESCRIPTION
## Why
The otel instrumentation-fetch does not always set the correct span status which leads to cases were span status is is unset even if the fetch is erroneous.

## What
* Provide option to inject custom attribute processors via the Faro config
* Always add the default processor function for instrumentation-fetch which sets the span status as defined by the otel spec, even if a customer provides a custom processor

## Links
* [Fetch instrumentation issue with setting span status](https://github.com/open-telemetry/opentelemetry-js/issues/3564)
* [OTEL spec for setting the span status](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#status)

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
