### PR TITLE
Set span status on erroneus fetch requests (#641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.8.1
+
 - Enhancement (`@grafana/faro-web-tracing`): ensure that span status is always set to error for
   erroneous fetch requests (#641).
 


### PR DESCRIPTION
## Why

Fix a problem where span status wasn't corretly set in web-tracing fetch

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
