### PR TITLE
Set correct span error state for xmhlhttprequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Enhancement (`@grafana/faro-web-tracing`): ensure that span status is always set to error for
+  erroneous xhr requests (#644).
+
 ## 1.8.1
 
 - Enhancement (`@grafana/faro-web-tracing`): ensure that span status is always set to error for

--- a/cypress/e2e/demo/errors.cy.ts
+++ b/cypress/e2e/demo/errors.cy.ts
@@ -13,9 +13,14 @@ context('Errors', () => {
       value: 'test is not defined',
     },
     {
-      title: 'unhandled error',
+      title: 'unhandled fetch error',
       btnName: 'fetch-error',
       value: 'Failed to fetch',
+    },
+    {
+      title: 'unhandled xhr error',
+      btnName: 'xhr-error',
+      value: 'Network error',
     },
     {
       title: 'unhandled rejection',
@@ -27,6 +32,8 @@ context('Errors', () => {
   ].forEach(({ title, btnName, type = 'Error', value, expectStacktrace = true }) => {
     it(`will capture ${title}`, () => {
       cy.interceptCollector((body) => {
+        console.log('body :>> ', body);
+
         const item = body.exceptions?.find(
           (item: ExceptionEvent) =>
             item?.type === type &&

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -25,7 +25,12 @@ export function initializeFaro(): Faro {
         instrumentationOptions: {
           fetchInstrumentationOptions: {
             applyCustomAttributesOnSpan: () => {
-              console.log('hello from fetch');
+              console.log('fetchInstrumentationOptions: applyCustomAttributesOnSpan');
+            },
+          },
+          xhrInstrumentationOptions: {
+            applyCustomAttributesOnSpan: () => {
+              console.log('xhrInstrumentationOptions: applyCustomAttributesOnSpan');
             },
           },
         },

--- a/demo/src/client/pages/Features/ErrorInstrumentation.tsx
+++ b/demo/src/client/pages/Features/ErrorInstrumentation.tsx
@@ -19,6 +19,12 @@ export function ErrorInstrumentation() {
     });
   };
 
+  const xhrError = () => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', 'http://localhost:64999');
+    xhr.send();
+  };
+
   const promiseReject = () => {
     new Promise((_accept, reject) => {
       reject('This is a rejected promise');
@@ -41,6 +47,9 @@ export function ErrorInstrumentation() {
         </Button>
         <Button data-cy="btn-fetch-error" onClick={fetchError}>
           Fetch Error
+        </Button>
+        <Button data-cy="btn-fetch-error" onClick={xhrError}>
+          XHR Error
         </Button>
         <Button data-cy="btn-promise-reject" onClick={promiseReject}>
           Promise Reject

--- a/demo/src/client/pages/Features/ErrorInstrumentation.tsx
+++ b/demo/src/client/pages/Features/ErrorInstrumentation.tsx
@@ -20,9 +20,12 @@ export function ErrorInstrumentation() {
   };
 
   const xhrError = () => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', 'http://localhost:64999');
-    xhr.send();
+    return new Promise((_resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', 'http://localhost:64999');
+      xhr.onerror = () => reject(new Error('Network error'));
+      xhr.send();
+    });
   };
 
   const promiseReject = () => {
@@ -48,8 +51,8 @@ export function ErrorInstrumentation() {
         <Button data-cy="btn-fetch-error" onClick={fetchError}>
           Fetch Error
         </Button>
-        <Button data-cy="btn-fetch-error" onClick={xhrError}>
-          XHR Error
+        <Button data-cy="btn-xhr-error" onClick={xhrError}>
+          XHR Error (promise)
         </Button>
         <Button data-cy="btn-promise-reject" onClick={promiseReject}>
           Promise Reject

--- a/demo/src/client/pages/Features/TracingInstrumentation.tsx
+++ b/demo/src/client/pages/Features/TracingInstrumentation.tsx
@@ -9,6 +9,12 @@ export function TracingInstrumentation() {
     fetch('/');
   };
 
+  const xhrSuccess = () => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/');
+    xhr.send();
+  };
+
   const traceWithLog = () => {
     const otel = faro.api.getOTEL();
 
@@ -29,6 +35,9 @@ export function TracingInstrumentation() {
       <ButtonGroup>
         <Button data-cy="btn-fetch-success" onClick={fetchSuccess}>
           Fetch Success
+        </Button>
+        <Button data-cy="btn-fetch-success" onClick={xhrSuccess}>
+          XHR Success
         </Button>
         <Button data-cy="btn-trace-with-log" onClick={traceWithLog}>
           Trace with Log

--- a/demo/src/client/pages/Features/TracingInstrumentation.tsx
+++ b/demo/src/client/pages/Features/TracingInstrumentation.tsx
@@ -36,7 +36,7 @@ export function TracingInstrumentation() {
         <Button data-cy="btn-fetch-success" onClick={fetchSuccess}>
           Fetch Success
         </Button>
-        <Button data-cy="btn-fetch-success" onClick={xhrSuccess}>
+        <Button data-cy="btn-xhr-success" onClick={xhrSuccess}>
           XHR Success
         </Button>
         <Button data-cy="btn-trace-with-log" onClick={traceWithLog}>

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -15,7 +15,10 @@ import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
-import { fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';
+import {
+  fetchCustomAttributeFunctionWithDefaults,
+  xhrCustomAttributeFunctionWithDefaults,
+} from './instrumentationUtils';
 import { getSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
@@ -97,7 +100,9 @@ export class TracingInstrumentation extends BaseInstrumentation {
             ),
           },
           xhrInstrumentationOptions: {
-            ...this.options.instrumentationOptions?.xhrInstrumentationOptions,
+            applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
+              this.options.instrumentationOptions?.xhrInstrumentationOptions?.applyCustomAttributesOnSpan
+            ),
           },
         }),
     });

--- a/packages/web-tracing/src/instrumentationUtils.test.ts
+++ b/packages/web-tracing/src/instrumentationUtils.test.ts
@@ -28,7 +28,7 @@ describe('faroTraceExporter.utils', () => {
     expect(span.setStatus).not.toBeCalled();
   });
 
-  it('calls setSpanStatusOnFetchError and callback if provided', () => {
+  it('calls custom setSpanStatusOnFetchError from fetchInstrumentationOptions and callback if provided', () => {
     const mock = jest.fn();
     jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnFetchError').mockImplementationOnce(mock);
 
@@ -41,5 +41,37 @@ describe('faroTraceExporter.utils', () => {
 
     expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
     expect(callback).toBeCalledWith(span, request, response);
+  });
+
+  test.each([500, 599, 400, 499])('set span status on XMLHttpRequest error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on XMLHttpRequest success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls custom setSpanStatusOnFetchError from xhrInstrumentationOptions and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnXMLHttpRequestError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: 500 } as XMLHttpRequest;
+    const callback = jest.fn();
+
+    instrumentationUtilsMock.xhrCustomAttributeFunctionWithDefaults(callback)(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, xhr);
   });
 });


### PR DESCRIPTION
## Why

The underlying instrumentation does not always set the correct span error status for erroneous XHR requests.
This PR ensures that the span error status is reliably set.

## What
* Use `applyCustomAttributesOnSpan` for `XMLHttpRequestInstrumentation` to set the span status
* Update the Faro demo to trigger XHR requests for success and error. 
* For demo purposes add a custom `applyCustomAttributesOnSpan` for xhr and fetch requests which prints a console.log.

## Links

## Screenshots


https://github.com/grafana/faro-web-sdk/assets/47627413/9f033a59-4af4-43d5-98d6-6b1ac0780d70


## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
