### PR TITLE
652 navigation timing is off set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+## 1.8.3
+
+- Enhancement (`@grafana/faro-web-sdk`): Provide and option to pass a correction timestamp via the
+  Faro API (#658).
+- Bug (`@grafana/faro-web-sdk`): Adjust the timestamp of a navigation or resource event to reflect
+  the actual time the event occurred, rather than the signal's creation time. (#658).
+
 ## 1.8.2
 
 - Enhancement (`@grafana/faro-web-tracing`): ensure that span status is always set to error for

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -13,6 +13,7 @@ import { env } from '../utils';
 
 export function initializeFaro(): Faro {
   const faro = coreInit({
+    // url: 'https://faro-collector-prod-us-central-0.grafana.net/collect/2b420d8dde37317f7458f034cf3e3e44',
     url: `http://localhost:${env.faro.portAppReceiver}/collect`,
     apiKey: env.faro.apiKey,
     trackWebVitalsAttribution: true,

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -13,7 +13,6 @@ import { env } from '../utils';
 
 export function initializeFaro(): Faro {
   const faro = coreInit({
-    // url: 'https://faro-collector-prod-us-central-0.grafana.net/collect/2b420d8dde37317f7458f034cf3e3e44',
     url: `http://localhost:${env.faro.portAppReceiver}/collect`,
     apiKey: env.faro.apiKey,
     trackWebVitalsAttribution: true,

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -116,7 +116,7 @@ describe('api.events', () => {
         });
       });
 
-      it('Sets the timestamp to teh provided custom timestamp', () => {
+      it('Sets the timestamp to the provided custom timestamp', () => {
         api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
         expect(transport.items).toHaveLength(1);
         expect((transport.items[0]?.payload as EventEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -115,6 +115,12 @@ describe('api.events', () => {
           span_id: 'my-span-id',
         });
       });
+
+      it('Sets the timestamp to teh provided custom timestamp', () => {
+        api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+        expect(transport.items).toHaveLength(1);
+        expect((transport.items[0]?.payload as EventEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+      });
     });
   });
 });

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -4,6 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, getCurrentTimestamp, isNull } from '../../utils';
+import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
 import type { EventEvent, EventsAPI } from './types';
@@ -18,7 +19,18 @@ export function initializeEventsAPI(
 ): EventsAPI {
   let lastPayload: Pick<EventEvent, 'name' | 'domain' | 'attributes'> | null = null;
 
-  const pushEvent: EventsAPI['pushEvent'] = (name, attributes, domain, { skipDedupe, spanContext } = {}) => {
+  const pushEvent: EventsAPI['pushEvent'] = (
+    name,
+    attributes,
+    domain,
+    { skipDedupe, spanContext, timestampOverwriteMs } = {}
+  ) => {
+    console.log(
+      'timestampAdjust :>> ',
+      timestampOverwriteMs ? new Date(timestampOverwriteMs).toISOString() : 'undefined'
+    );
+    console.log('currentTimestamp :>> ', getCurrentTimestamp());
+
     try {
       const item: TransportItem<EventEvent> = {
         meta: metas.value,
@@ -26,7 +38,7 @@ export function initializeEventsAPI(
           name,
           domain: domain ?? config.eventDomain,
           attributes,
-          timestamp: getCurrentTimestamp(),
+          timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {
                 trace_id: spanContext.traceId,

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -25,12 +25,6 @@ export function initializeEventsAPI(
     domain,
     { skipDedupe, spanContext, timestampOverwriteMs } = {}
   ) => {
-    console.log(
-      'timestampAdjust :>> ',
-      timestampOverwriteMs ? new Date(timestampOverwriteMs).toISOString() : 'undefined'
-    );
-    console.log('currentTimestamp :>> ', getCurrentTimestamp());
-
     try {
       const item: TransportItem<EventEvent> = {
         meta: metas.value,

--- a/packages/core/src/api/events/types.ts
+++ b/packages/core/src/api/events/types.ts
@@ -16,11 +16,7 @@ export interface EventEvent {
 export interface PushEventOptions {
   skipDedupe?: boolean;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
-  /**
-   * Custom timestamp in milliseconds.
-   * Useful for events where the real start time happened ate a different time to when the event was pushed.
-   */
-  timestampOverwriteMs?: string;
+  timestampOverwriteMs?: number;
 }
 
 export interface EventsAPI {

--- a/packages/core/src/api/events/types.ts
+++ b/packages/core/src/api/events/types.ts
@@ -16,6 +16,11 @@ export interface EventEvent {
 export interface PushEventOptions {
   skipDedupe?: boolean;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
+  /**
+   * Custom timestamp in milliseconds.
+   * Useful for events where the real start time happened ate a different time to when the event was pushed.
+   */
+  timestampOverwriteMs?: string;
 }
 
 export interface EventsAPI {

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -194,6 +194,12 @@ describe('api.exceptions', () => {
           span_id: 'my-span-id',
         });
       });
+
+      it('Sets the timestamp to the provided custom timestamp', () => {
+        api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+        expect(transport.items).toHaveLength(1);
+        expect((transport.items[0]?.payload as ExceptionEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+      });
     });
   });
 });

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -5,6 +5,7 @@ import { TransportItemType } from '../../transports';
 import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, getCurrentTimestamp, isNull } from '../../utils';
+import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
 import { defaultExceptionType } from './const';
@@ -36,7 +37,7 @@ export function initializeExceptionsAPI(
 
   const pushError: ExceptionsAPI['pushError'] = (
     error,
-    { skipDedupe, stackFrames, type, context, spanContext } = {}
+    { skipDedupe, stackFrames, type, context, spanContext, timestampOverwriteMs } = {}
   ) => {
     type = type || error.name || defaultExceptionType;
 
@@ -45,7 +46,7 @@ export function initializeExceptionsAPI(
       payload: {
         type,
         value: error.message,
-        timestamp: getCurrentTimestamp(),
+        timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
         trace: spanContext
           ? {
               trace_id: spanContext.traceId,

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -41,6 +41,7 @@ export interface PushErrorOptions {
   type?: string;
   context?: ExceptionContext;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
+  timestampOverwriteMs?: number;
 }
 
 export interface ExceptionsAPI {

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -129,5 +129,11 @@ describe('api.logs', () => {
         expect((transport.items[0]?.payload as LogEvent).message).toBe('[1,"test",{"a":1}]');
       });
     });
+
+    it('Sets the timestamp to the provided custom timestamp', () => {
+      api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+      expect(transport.items).toHaveLength(1);
+      expect((transport.items[0]?.payload as LogEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+    });
   });
 });

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -5,6 +5,7 @@ import { TransportItem, TransportItemType } from '../../transports';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, defaultLogLevel, getCurrentTimestamp, isNull } from '../../utils';
+import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
 import { defaultLogArgsSerializer } from './const';
@@ -24,7 +25,10 @@ export function initializeLogsAPI(
 
   const logArgsSerializer = config.logArgsSerializer ?? defaultLogArgsSerializer;
 
-  const pushLog: LogsAPI['pushLog'] = (args, { context, level, skipDedupe, spanContext } = {}) => {
+  const pushLog: LogsAPI['pushLog'] = (
+    args,
+    { context, level, skipDedupe, spanContext, timestampOverwriteMs } = {}
+  ) => {
     try {
       const item: TransportItem<LogEvent> = {
         type: TransportItemType.LOG,
@@ -32,7 +36,7 @@ export function initializeLogsAPI(
           message: logArgsSerializer(args),
           level: level ?? defaultLogLevel,
           context: context ?? {},
-          timestamp: getCurrentTimestamp(),
+          timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {
                 trace_id: spanContext.traceId,

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -19,6 +19,7 @@ export interface PushLogOptions {
   level?: LogLevel;
   skipDedupe?: boolean;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
+  timestampOverwriteMs?: number;
 }
 
 export interface LogsAPI {

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -192,5 +192,11 @@ describe('api.measurements', () => {
         });
       });
     });
+
+    it('Sets the timestamp to the provided custom timestamp', () => {
+      api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+      expect(transport.items).toHaveLength(1);
+      expect((transport.items[0]?.payload as MeasurementEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+    });
   });
 });

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -5,6 +5,7 @@ import { TransportItem, TransportItemType } from '../../transports';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, getCurrentTimestamp, isNull } from '../../utils';
+import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
 import type { MeasurementEvent, MeasurementsAPI } from './types';
@@ -21,7 +22,10 @@ export function initializeMeasurementsAPI(
 
   let lastPayload: Pick<MeasurementEvent, 'type' | 'values' | 'context'> | null = null;
 
-  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (payload, { skipDedupe, context, spanContext } = {}) => {
+  const pushMeasurement: MeasurementsAPI['pushMeasurement'] = (
+    payload,
+    { skipDedupe, context, spanContext, timestampOverwriteMs } = {}
+  ) => {
     try {
       const item: TransportItem<MeasurementEvent> = {
         type: TransportItemType.MEASUREMENT,
@@ -33,7 +37,7 @@ export function initializeMeasurementsAPI(
                 span_id: spanContext.spanId,
               }
             : tracesApi.getTraceContext(),
-          timestamp: payload.timestamp ?? getCurrentTimestamp(),
+          timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           context: context ?? {},
         },
         meta: metas.value,

--- a/packages/core/src/api/measurements/types.ts
+++ b/packages/core/src/api/measurements/types.ts
@@ -17,6 +17,7 @@ export interface PushMeasurementOptions {
   skipDedupe?: boolean;
   context?: MeasurementContext;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
+  timestampOverwriteMs?: number;
 }
 
 export interface MeasurementsAPI {

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -1,3 +1,11 @@
 export function dateNow(): number {
   return Date.now();
 }
+
+export function getCurrentTimestamp(): string {
+  return new Date().toISOString();
+}
+
+export function timestampToIsoString(value: string): string {
+  return new Date(value).toISOString();
+}

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -6,6 +6,6 @@ export function getCurrentTimestamp(): string {
   return new Date().toISOString();
 }
 
-export function timestampToIsoString(value: string): string {
+export function timestampToIsoString(value: number): string {
   return new Date(value).toISOString();
 }

--- a/packages/core/src/utils/getCurrentTimestamp.ts
+++ b/packages/core/src/utils/getCurrentTimestamp.ts
@@ -1,3 +1,0 @@
-export function getCurrentTimestamp(): string {
-  return new Date().toISOString();
-}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,7 +2,7 @@ export type { BaseObject, BaseObjectKey, BaseObjectPrimitiveValue, BaseObjectVal
 
 export { deepEqual } from './deepEqual';
 
-export { getCurrentTimestamp } from './getCurrentTimestamp';
+export { getCurrentTimestamp } from './date';
 
 export {
   isArray,

--- a/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.test.ts
@@ -10,6 +10,13 @@ import { createFaroNavigationTiming, createFaroResourceTiming } from './performa
 import { performanceNavigationEntry, performanceResourceEntry } from './performanceUtilsTestData';
 
 describe('Navigation observer', () => {
+  const originalTimeOrigin = performance.timeOrigin;
+  const mockTimeOriginValue = 1722437937;
+  Object.defineProperty(performance, 'timeOrigin', {
+    value: mockTimeOriginValue,
+    configurable: true,
+  });
+
   class MockPerformanceObserver {
     constructor(private cb: PerformanceObserverCallback) {}
 
@@ -50,7 +57,13 @@ describe('Navigation observer', () => {
 
   afterAll(() => {
     jest.restoreAllMocks();
+
     (global as any).PerformanceObserver = originalPerformanceObserver;
+
+    Object.defineProperty(performance, 'timeOrigin', {
+      value: originalTimeOrigin,
+      configurable: true,
+    });
   });
 
   it('Ignores entries where name matches ignoredUrls entry', () => {
@@ -89,6 +102,7 @@ describe('Navigation observer', () => {
       undefined,
       {
         spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
+        timestampOverwriteMs: mockTimeOriginValue,
       }
     );
   });
@@ -105,6 +119,7 @@ describe('Navigation observer', () => {
     expect(mockPushEvent).toHaveBeenCalledTimes(1);
     expect(mockPushEvent).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), undefined, {
       spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
+      timestampOverwriteMs: mockTimeOriginValue,
     });
   });
 
@@ -132,6 +147,7 @@ describe('Navigation observer', () => {
       undefined,
       {
         spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
+        timestampOverwriteMs: mockTimeOriginValue,
       }
     );
   });

--- a/packages/web-sdk/src/instrumentations/performance/navigation.ts
+++ b/packages/web-sdk/src/instrumentations/performance/navigation.ts
@@ -40,7 +40,10 @@ export function getNavigationTimings(
 
     setItem(NAVIGATION_ID_STORAGE_KEY, faroNavigationEntry.faroNavigationId, webStorageType.session);
 
-    pushEvent('faro.performance.navigation', faroNavigationEntry, undefined, { spanContext });
+    pushEvent('faro.performance.navigation', faroNavigationEntry, undefined, {
+      spanContext,
+      timestampOverwriteMs: performance.timeOrigin + navEntryJson.startTime,
+    });
 
     faroNavigationEntryResolve(faroNavigationEntry);
   });

--- a/packages/web-sdk/src/instrumentations/performance/resource.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.test.ts
@@ -8,6 +8,13 @@ import { performanceResourceEntry } from './performanceUtilsTestData';
 import { observeResourceTimings } from './resource';
 
 describe('Resource observer', () => {
+  const originalTimeOrigin = performance.timeOrigin;
+  const mockTimeOriginValue = 1000;
+  Object.defineProperty(performance, 'timeOrigin', {
+    value: mockTimeOriginValue,
+    configurable: true,
+  });
+
   class MockPerformanceObserver {
     constructor(private cb: PerformanceObserverCallback) {}
 
@@ -58,7 +65,13 @@ describe('Resource observer', () => {
 
   afterAll(() => {
     jest.restoreAllMocks();
+
     (global as any).PerformanceObserver = originalPerformanceObserver;
+
+    Object.defineProperty(performance, 'timeOrigin', {
+      value: originalTimeOrigin,
+      configurable: true,
+    });
   });
 
   it('Ignores entries where name matches ignoredUrls entry', () => {
@@ -101,7 +114,10 @@ describe('Resource observer', () => {
         faroResourceId: mockResourceId,
       },
       undefined,
-      { spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' } }
+      {
+        spanContext: { traceId: '0af7651916cd43dd8448eb211c80319c', spanId: 'b7ad6b7169203331' },
+        timestampOverwriteMs: mockTimeOriginValue + performanceResourceEntry.startTime,
+      }
     );
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/resource.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.ts
@@ -28,21 +28,24 @@ export function observeResourceTimings(
         return;
       }
 
-      const resourceEntryRawJSON = resourceEntryRaw.toJSON();
+      const resourceEntryJson = resourceEntryRaw.toJSON();
 
-      let spanContext: SpanContext = getSpanContextFromServerTiming(resourceEntryRawJSON?.serverTiming);
+      let spanContext: SpanContext = getSpanContextFromServerTiming(resourceEntryJson?.serverTiming);
 
       if (
-        (trackResources == null && includePerformanceEntry(resourceEntryRawJSON, DEFAULT_TRACK_RESOURCES)) ||
+        (trackResources == null && includePerformanceEntry(resourceEntryJson, DEFAULT_TRACK_RESOURCES)) ||
         trackResources
       ) {
         const faroResourceEntry = {
-          ...createFaroResourceTiming(resourceEntryRawJSON),
+          ...createFaroResourceTiming(resourceEntryJson),
           faroNavigationId,
           faroResourceId: genShortID(),
         };
 
-        pushEvent('faro.performance.resource', faroResourceEntry, undefined, { spanContext });
+        pushEvent('faro.performance.resource', faroResourceEntry, undefined, {
+          spanContext,
+          timestampOverwriteMs: performance.timeOrigin + resourceEntryJson.startTime,
+        });
       }
     }
   });


### PR DESCRIPTION
## Why

The timestamp of a signal sent via the Faro API represents the exact moment when the respective API was called.
This precision is sufficient for most cases but for some it's not.

**Example:**
Faro's performance instrumentation collects the relevant data after the document's readyState changes to 'complete' [1]. When the performance item is sent via the Faro API, the timestamp reflects the moment the Faro signal is created, not the actual time when the event occurred. The option to provide a timestamp adjustment resolves this discrepancy.

To solve above issue we:
* Provide an option to to pass a timestamp overwrite to all Faro APIs (except pushTrace API)
* Calculate the actual timestamp of when a resource or navigation event occurred and pass this value as the correction timestamp

We calculate the actual occurrences of a navigation / resource item with the following code:  
`const actualTimestamp = performance.timeOrigin + entry.startTime;`

* [performance.timeOrigin](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin) is the time of the start of the navigation context
* [entry.startTime](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/startTime): is the start time of the navigation/resource relative to the `performance.timeOrigin`.


[1] [document.readyState](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) complete denotes that the document and all sub-resources have finished loading

## What 
* Update Faro APIs to allow to inject an adjustment timestamp
* Update performance and resource instrumentation to calculate and provide an adjustment timestamp to use the timestamp when the event occurred instead of the timestamp when Faro created the Signal.

## Links

* [Docs PR (internal)](https://github.com/grafana/website/pull/21093)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
