### PR TITLE
chore(web-tracing): ignore network events by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 - Enhancement (`@grafana/faro-web-sdk`): Provide and option to pass a correction timestamp via the
   Faro API (#658).
+
 - Bug (`@grafana/faro-web-sdk`): Adjust the timestamp of a navigation or resource event to reflect
   the actual time the event occurred, rather than the signal's creation time. (#658).
+
+- Change: (`@grafana/faro-web-tracing`) The underlying XHR and Fetch instrumentation are now
+  configured to ignore network events by default. This behavior can be enabled back through the
+  options in the WebTracing class.
 
 ## 1.8.2
 

--- a/packages/web-tracing/src/getDefaultInstrumentations.test.ts
+++ b/packages/web-tracing/src/getDefaultInstrumentations.test.ts
@@ -1,0 +1,64 @@
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+
+import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+
+jest.mock('@opentelemetry/instrumentation-fetch');
+jest.mock('@opentelemetry/instrumentation-xml-http-request');
+
+describe('getDefaultOTELInstrumentations', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an array of instrumentations', () => {
+    const instrumentations = getDefaultOTELInstrumentations();
+    expect(instrumentations).toBeInstanceOf(Array);
+    expect(instrumentations[0]).toBeInstanceOf(FetchInstrumentation);
+    expect(instrumentations[1]).toBeInstanceOf(XMLHttpRequestInstrumentation);
+  });
+
+  it('should apply default options', () => {
+    getDefaultOTELInstrumentations();
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+
+  it('should apply custom options', () => {
+    const ignoreUrls = ['example.com'];
+    const propagateTraceHeaderCorsUrls = ['example2.com'];
+
+    getDefaultOTELInstrumentations({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      fetchInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+      xhrInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+    });
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+});

--- a/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
+++ b/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
@@ -1,6 +1,10 @@
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
+import {
+  fetchCustomAttributeFunctionWithDefaults,
+  xhrCustomAttributeFunctionWithDefaults,
+} from './instrumentationUtils';
 import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
 
 const initialInstrumentationsOptions = {
@@ -13,8 +17,45 @@ export function getDefaultOTELInstrumentations(
 ): InstrumentationOption[] {
   const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
 
-  return [
-    new FetchInstrumentation({ ...sharedOptions, ...fetchInstrumentationOptions }),
-    new XMLHttpRequestInstrumentation({ ...sharedOptions, ...xhrInstrumentationOptions }),
-  ];
+  const fetchOpts = createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions);
+  const xhrOpts = createXhrInstrumentationOptions(xhrInstrumentationOptions, sharedOptions);
+
+  return [new FetchInstrumentation(fetchOpts), new XMLHttpRequestInstrumentation(xhrOpts)];
+}
+function createFetchInstrumentationOptions(
+  fetchInstrumentationOptions: DefaultInstrumentationsOptions['fetchInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+
+    ignoreNetworkEvents: true,
+
+    // keep this here to overwrite the defaults above if provided by the users
+    ...fetchInstrumentationOptions,
+
+    // always keep this function
+    applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
+      fetchInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
+}
+
+function createXhrInstrumentationOptions(
+  xhrInstrumentationOptions: DefaultInstrumentationsOptions['xhrInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+
+    ignoreNetworkEvents: true,
+
+    // keep this here to overwrite the defaults above if provided by the users
+    ...xhrInstrumentationOptions,
+
+    // always keep this function
+    applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
+      xhrInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
 }

--- a/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
+++ b/packages/web-tracing/src/getDefaultOTELInstrumentations.ts
@@ -7,14 +7,7 @@ import {
 } from './instrumentationUtils';
 import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
 
-const initialInstrumentationsOptions = {
-  ignoreUrls: [],
-  propagateTraceHeaderCorsUrls: [],
-};
-
-export function getDefaultOTELInstrumentations(
-  options: DefaultInstrumentationsOptions = initialInstrumentationsOptions
-): InstrumentationOption[] {
+export function getDefaultOTELInstrumentations(options: DefaultInstrumentationsOptions = {}): InstrumentationOption[] {
   const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
 
   const fetchOpts = createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions);
@@ -28,12 +21,9 @@ function createFetchInstrumentationOptions(
 ) {
   return {
     ...sharedOptions,
-
     ignoreNetworkEvents: true,
-
     // keep this here to overwrite the defaults above if provided by the users
     ...fetchInstrumentationOptions,
-
     // always keep this function
     applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
       fetchInstrumentationOptions?.applyCustomAttributesOnSpan
@@ -47,12 +37,9 @@ function createXhrInstrumentationOptions(
 ) {
   return {
     ...sharedOptions,
-
     ignoreNetworkEvents: true,
-
     // keep this here to overwrite the defaults above if provided by the users
     ...xhrInstrumentationOptions,
-
     // always keep this function
     applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
       xhrInstrumentationOptions?.applyCustomAttributesOnSpan

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -15,10 +15,6 @@ import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
-import {
-  fetchCustomAttributeFunctionWithDefaults,
-  xhrCustomAttributeFunctionWithDefaults,
-} from './instrumentationUtils';
 import { getSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
@@ -88,22 +84,17 @@ export class TracingInstrumentation extends BaseInstrumentation {
       contextManager: options.contextManager ?? new ZoneContextManager(),
     });
 
+    const { propagateTraceHeaderCorsUrls, fetchInstrumentationOptions, xhrInstrumentationOptions } =
+      this.options.instrumentationOptions ?? {};
+
     registerInstrumentations({
       instrumentations:
         options.instrumentations ??
         getDefaultOTELInstrumentations({
           ignoreUrls: this.getIgnoreUrls(),
-          propagateTraceHeaderCorsUrls: this.options.instrumentationOptions?.propagateTraceHeaderCorsUrls,
-          fetchInstrumentationOptions: {
-            applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
-              this.options.instrumentationOptions?.fetchInstrumentationOptions?.applyCustomAttributesOnSpan
-            ),
-          },
-          xhrInstrumentationOptions: {
-            applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
-              this.options.instrumentationOptions?.xhrInstrumentationOptions?.applyCustomAttributesOnSpan
-            ),
-          },
+          propagateTraceHeaderCorsUrls,
+          fetchInstrumentationOptions,
+          xhrInstrumentationOptions,
         }),
     });
 

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -33,9 +33,11 @@ export type DefaultInstrumentationsOptions = {
 
   fetchInstrumentationOptions?: {
     applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
   };
 
   xhrInstrumentationOptions?: {
     applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
   };
 };


### PR DESCRIPTION
## Why

The opentelemetry.js fetch and xhr instrumentation add some extra network event by default.

For a lot of users it is not useful and creates unnecessary additional payload as well.
Faro's already tracks resource events so the data is redundant.

Note: 
currently the resource instrumentation doesn't map the resource to its respective trace id
 

## What
* Disable network events by default
* Refactor option creation and move it into `getDefaultWebInstrumentations()` because it doesn't belong to the instrumentation class
* Allow users to enable network events via the `TracingInstrumentation()` class.


## Links

* [Docs PR](https://github.com/grafana/website/pull/21098)
* [List of network events](https://github.com/open-telemetry/opentelemetry-js/blob/d4035eb9733c101d53780033a4e58caebec73619/packages/opentelemetry-sdk-trace-web/src/utils.ts#L96) 

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
