### PR TITLE
prepare release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Next
 
-## 1.8.3
+## 1.9.0
 
 - Enhancement (`@grafana/faro-web-sdk`): Provide and option to pass a correction timestamp via the
   Faro API (#658).
 
-- Bug (`@grafana/faro-web-sdk`): Adjust the timestamp of a navigation or resource event to reflect
-  the actual time the event occurred, rather than the signal's creation time. (#658).
+- Fix (`@grafana/faro-web-sdk`): Adjust the timestamp of a navigation or resource event to reflect
+  the actual time the event occurred, rather than the signal creation time. (#658).
 
 - Change: (`@grafana/faro-web-tracing`) The underlying XHR and Fetch instrumentation are now
   configured to ignore network events by default. This behavior can be enabled back through the


### PR DESCRIPTION
## Why

Minor version upgrade because web-tracing now doen't add network events by default.  

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
