### PR TITLE
Update use-angular.md, Add etWebInstrumentations import

### DIFF
--- a/docs/sources/tutorials/use-angular.md
+++ b/docs/sources/tutorials/use-angular.md
@@ -3,7 +3,7 @@
 Create file `faro-initializer.ts` and add your SDK configuration:
 
 ```typescript
-import { initializeFaro } from '@grafana/faro-web-sdk';
+import { initializeFaro, getWebInstrumentations } from '@grafana/faro-web-sdk';
 
 export function faroInitializer(): Function {
   return async () => {


### PR DESCRIPTION
## Why

`getWebInstrumentations` was not imported and is needed

## What

Import `getWebInstrumentations`

## Checklist

- [n/a] Tests added
- [n/a] Changelog updated
- [x] Documentation updated
