### PR TITLE
chore(otlp-http-transport): consume response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix (`@grafana/faro-transport-otlp-http [experimental]`): Properly consume response body (#664).
+
 ## 1.9.0
 
 - Enhancement (`@grafana/faro-web-sdk`): Provide and option to pass a correction timestamp via the

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix (`@grafana/faro-transport-otlp-http`): Properly consume response body (#664).
+
 ## 1.8.0
 
 - Dependencies (`@grafana/faro-transport-otlp-http`): upgrade otel deps (#621).

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -402,4 +402,20 @@ describe('OtlpHttpTransport', () => {
     const ignoreUrls = faro.transports.transports.flatMap((transport) => transport.getIgnoreUrls());
     expect(ignoreUrls).toStrictEqual([tracesURL, logsURL, ...globalIgnoreUrls]);
   });
+
+  it('consumes the response body', async () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'www.example.com/v1/logs',
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    const mockResponseTextFn = jest.fn(() => Promise.resolve({}));
+    fetch.mockImplementationOnce(() => Promise.resolve({ status: 200, text: mockResponseTextFn }));
+
+    await transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockResponseTextFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -1,4 +1,12 @@
-import { BaseTransport, createPromiseBuffer, isArray, PromiseBuffer, TransportItem, VERSION } from '@grafana/faro-core';
+import {
+  BaseTransport,
+  createPromiseBuffer,
+  isArray,
+  noop,
+  PromiseBuffer,
+  TransportItem,
+  VERSION,
+} from '@grafana/faro-core';
 import type { Patterns } from '@grafana/faro-core';
 
 import { OtelPayload, OtelTransportPayload } from './payload';
@@ -108,6 +116,8 @@ export class OtlpHttpTransport extends BaseTransport {
                 this.logWarn(`Too many requests, backing off until ${disabledUntil}`);
               }
 
+              // read the body so the connection can be closed
+              response.text().catch(noop);
               return response;
             })
             .catch((error) => {


### PR DESCRIPTION
## Why

The otlp-http-transport didn't consume the response body which can cause issue like memory leaks, hanging requests, sever not releasing resources etc.

## What
* Consume response body


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
