### PR TITLE
chore(docs): link cloud docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The repository consists of multiple packages that can be combined depending on y
 
 ## Get started
 
+> [!NOTE]
+> For more information, you can find the Faro documentation in the [Grafana Cloud docs for Faro](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/).
+
 See [quick start for web applications][faro-quick-start].
 
 ## Packages


### PR DESCRIPTION
## Why

We don't have dedicated OSS Faro docs yet.
Since there's currently no difference between the Faro docs for OSS and cloud we link them in the README.

## What
* Link cloud docs in README file

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated
