### PR TITLE
chore(otlp-http-transport): update semantic attributes

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "no-duplicate-heading": {
+    "siblings_only": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   URLs of other instances by default (#684).
 
 - Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
-  (#684).
+  (#687).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@
 - Enhancement (`@grafana/faro-web-sdk`): Isolated Faro instances now exclude the default collector
   URLs of other instances by default (#684).
 
+- Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
+  (#684).
+
+### Breaking
+
+- Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
+  for browser (#684).
+  - `browser.user_agent` is replaced by `user_agent.original`
+  - `browser.os` is replaced by `browser.platform`
+
 ## 1.10.0
+
+- Change (`@grafana/faro-web-sdk`): don't automatically send a `view_change` event for the default
+  view (#647)
 
 - Dependencies (`@grafana/faro-web-tracing`): upgrade otel deps (#670)
   - Note: some attributes have been changed due to otel semantic attributes spec or are now aligned
@@ -16,6 +29,8 @@
       `deployment.environment.name`.
     - `session_id` is now deprecated and will be replaced by `session.id`
 - Dependencies (`@grafana/faro-core`): upgrade otel deps (#670).
+
+### Breaking
 
 - Dependencies (`@grafana/faro-transport-otlp-http [experimental]`): upgrade otel deps (#670)
 
@@ -26,9 +41,6 @@
     - `enduser.attributes` is replaced by `user.attributes`,
     - `http.url` is replaced by `url.full`
     - `deployment.environment` is replaced by `deployment.environment.name`
-
-- Change (`@grafana/faro-web-sdk`): don't automatically send a `view_change` event for the default
-  view (#647)
 
 ## 1.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
   (#687).
 
-### Breaking
+**Breaking**
 
 - Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
   for browser (#684).
@@ -30,7 +30,7 @@
     - `session_id` is now deprecated and will be replaced by `session.id`
 - Dependencies (`@grafana/faro-core`): upgrade otel deps (#670).
 
-### Breaking
+**Breaking**
 
 - Dependencies (`@grafana/faro-transport-otlp-http [experimental]`): upgrade otel deps (#670)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
   (#687).
 
-**Breaking**
+### Breaking
 
 - Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
   for browser (#684).
@@ -30,7 +30,7 @@
     - `session_id` is now deprecated and will be replaced by `session.id`
 - Dependencies (`@grafana/faro-core`): upgrade otel deps (#670).
 
-**Breaking**
+### Breaking
 
 - Dependencies (`@grafana/faro-transport-otlp-http [experimental]`): upgrade otel deps (#670)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Next
 
+## 1.10.1
+
+- Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
+  (#684).
+
+### Breaking
+
+- Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
+  for browser (#684).
+  - `browser.user_agent` is replaced by `user_agent.original`
+  - `browser.os` is replaced by `browser.platform`
+
 ## 1.10.0
 
 - Dependencies (`@grafana/faro-transport-otlp-http`): upgrade otel deps (#670).

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Breaking
 
 - Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
-  for browser (#684).
+  for browser (#687).
   - `browser.user_agent` is replaced by `user_agent.original`
   - `browser.os` is replaced by `browser.platform`
 

--- a/experimental/transport-otlp-http/src/payload/transform/toResourceLog.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toResourceLog.test.ts
@@ -58,7 +58,7 @@ const matchResourcePayload = {
     },
 
     {
-      key: 'browser.user_agent',
+      key: 'user_agent.original',
       value: { stringValue: 'browser-ua-string' },
     },
     {
@@ -129,13 +129,9 @@ const matchResourcePayload = {
       },
     },
     {
-      key: 'browser.os',
+      key: 'browser.platform',
       value: { stringValue: 'browser-operating-system' },
     },
-    // {
-    //   key: 'browser.platform',
-    //   value: { stringValue: 'browser-MyOperationSystem' },
-    // },
     {
       key: 'browser.name',
       value: { stringValue: 'browser-name' },

--- a/experimental/transport-otlp-http/src/payload/transform/toResourceSpan.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toResourceSpan.test.ts
@@ -168,7 +168,7 @@ const matchResourceSpanPayload = {
       },
 
       {
-        key: 'browser.user_agent',
+        key: 'user_agent.original',
         value: { stringValue: 'browser-ua-string' },
       },
       {
@@ -176,13 +176,9 @@ const matchResourceSpanPayload = {
         value: { stringValue: 'browser-language' },
       },
       {
-        key: 'browser.os',
+        key: 'browser.platform',
         value: { stringValue: 'browser-operating-system' },
       },
-      // {
-      //   key: 'browser.platform',
-      //   value: { stringValue: 'browser-MyOperationSystem' },
-      // },
       {
         key: 'browser.name',
         value: { stringValue: 'browser-name' },

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -8,10 +8,16 @@ import {
   ATTR_TELEMETRY_SDK_NAME,
   ATTR_TELEMETRY_SDK_VERSION,
   ATTR_URL_FULL,
+  ATTR_USER_AGENT_ORIGINAL,
   TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS,
 } from '@opentelemetry/semantic-conventions';
 import {
+  ATTR_BROWSER_BRANDS,
+  ATTR_BROWSER_LANGUAGE,
+  ATTR_BROWSER_MOBILE,
+  ATTR_BROWSER_PLATFORM,
   ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAMESPACE,
   ATTR_USER_EMAIL,
   ATTR_USER_ID,
   ATTR_USER_NAME,
@@ -47,20 +53,6 @@ import type {
   StringValueNonNullable,
   TraceTransform,
 } from './types';
-
-/**
- * Seems currently to be missing in the semantic-conventions npm package.
- * See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#todos
- *
- * Attributes are as defined by the Otel docs
- */
-const SemanticBrowserAttributes = {
-  BROWSER_BRANDS: 'browser.brands',
-  BROWSER_PLATFORM: 'browser.platform',
-  BROWSER_MOBILE: 'browser.mobile',
-  BROWSER_USER_AGENT: 'browser.user_agent',
-  BROWSER_LANGUAGE: 'browser.language',
-} as const;
 
 export function getLogTransforms(
   internalLogger: InternalLogger,
@@ -248,11 +240,11 @@ function toResource(transportItem: TransportItem): Readonly<Resource> {
 
   return {
     attributes: [
-      toAttribute(SemanticBrowserAttributes.BROWSER_MOBILE, browser?.mobile),
-      toAttribute(SemanticBrowserAttributes.BROWSER_USER_AGENT, browser?.userAgent),
-      toAttribute(SemanticBrowserAttributes.BROWSER_LANGUAGE, browser?.language),
-      toAttribute(SemanticBrowserAttributes.BROWSER_BRANDS, browser?.brands),
-      toAttribute('browser.os', browser?.os),
+      toAttribute(ATTR_BROWSER_MOBILE, browser?.mobile),
+      toAttribute(ATTR_USER_AGENT_ORIGINAL, browser?.userAgent),
+      toAttribute(ATTR_BROWSER_LANGUAGE, browser?.language),
+      toAttribute(ATTR_BROWSER_BRANDS, browser?.brands),
+      toAttribute(ATTR_BROWSER_PLATFORM, browser?.os),
       toAttribute('browser.name', browser?.name),
       toAttribute('browser.version', browser?.version),
       toAttribute('browser.screen_width', browser?.viewportWidth),
@@ -264,6 +256,7 @@ function toResource(transportItem: TransportItem): Readonly<Resource> {
 
       toAttribute(ATTR_SERVICE_NAME, app?.name),
       toAttribute(ATTR_SERVICE_VERSION, app?.version),
+      toAttribute(ATTR_SERVICE_NAMESPACE, app?.namespace),
       toAttribute(ATTR_DEPLOYMENT_ENVIRONMENT_NAME, app?.environment),
     ].filter(isAttribute),
   };


### PR DESCRIPTION
## Why

**otlp-http-transport**

* Resource attribute `service.namespace` was missing.
* Some browser attributes were aligned to the current OTEL spec (still in experimental)
  - `browser.user_agent` is replaced by `user_agent.original`
  - `browser.os` is replaced by `browser.platform`

## What

See above

## Links

* [Spec: resource attributes browser](https://opentelemetry.io/docs/specs/semconv/resource/browser/)


## Checklist

- [x] Tests added/updated
- [x] Changelog updated
- [ ] Documentation updated
