### PR TITLE
chore(pushError): automatically add error.cause to the extended error context

### DIFF
--- a/packages/core/src/api/exceptions/index.ts
+++ b/packages/core/src/api/exceptions/index.ts
@@ -10,4 +10,5 @@ export type {
   PushErrorOptions,
   Stacktrace,
   StacktraceParser,
+  ErrorWithIndexProperties,
 } from './types';

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -209,22 +209,29 @@ describe('api.exceptions', () => {
         // @ts-expect-error cause is missing in TS type Error
         const error3 = new Error('test3', { cause: { a: 'b' } });
         // @ts-expect-error cause is missing in TS type Error
-        const error4 = new Error('test4', { cause: undefined });
+        const error4 = new Error('test3', { cause: new Error('original error') });
         // @ts-expect-error cause is missing in TS type Error
-        const error5 = new Error('test5', { cause: null });
+        const error5 = new Error('test4', { cause: undefined });
         // @ts-expect-error cause is missing in TS type Error
-        const error6 = new Error('test6');
+        const error6 = new Error('test5', { cause: null });
+        const error7 = new Error('test6');
 
         api.pushError(error);
         api.pushError(error2);
         api.pushError(error3);
+        api.pushError(error4);
+        api.pushError(error5);
+        api.pushError(error6);
+        api.pushError(error7);
 
-        expect(transport.items).toHaveLength(3);
+        expect(transport.items).toHaveLength(7);
+
         expect((transport.items[0]?.payload as ExceptionEvent)?.context).toEqual({ cause: 'foo' });
         expect((transport.items[1]?.payload as ExceptionEvent)?.context).toEqual({ cause: '[1,3]' });
         expect((transport.items[2]?.payload as ExceptionEvent)?.context).toEqual({ cause: '{"a":"b"}' });
-        expect((transport.items[3]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[3]?.payload as ExceptionEvent)?.context).toEqual({ cause: 'Error: original error' });
         expect((transport.items[4]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
         expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
       });
     });

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -200,6 +200,33 @@ describe('api.exceptions', () => {
         expect(transport.items).toHaveLength(1);
         expect((transport.items[0]?.payload as ExceptionEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
       });
+
+      it('Adds error cause to error context', () => {
+        // @ts-expect-error cause is missing in TS type Error
+        const error = new Error('test', { cause: 'foo' });
+        // @ts-expect-error cause is missing in TS type Error
+        const error2 = new Error('test2', { cause: [1, 3] });
+        // @ts-expect-error cause is missing in TS type Error
+        const error3 = new Error('test3', { cause: { a: 'b' } });
+        // @ts-expect-error cause is missing in TS type Error
+        const error4 = new Error('test4', { cause: undefined });
+        // @ts-expect-error cause is missing in TS type Error
+        const error5 = new Error('test5', { cause: null });
+        // @ts-expect-error cause is missing in TS type Error
+        const error6 = new Error('test6');
+
+        api.pushError(error);
+        api.pushError(error2);
+        api.pushError(error3);
+
+        expect(transport.items).toHaveLength(3);
+        expect((transport.items[0]?.payload as ExceptionEvent)?.context).toEqual({ cause: 'foo' });
+        expect((transport.items[1]?.payload as ExceptionEvent)?.context).toEqual({ cause: '[1,3]' });
+        expect((transport.items[2]?.payload as ExceptionEvent)?.context).toEqual({ cause: '{"a":"b"}' });
+        expect((transport.items[3]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[4]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -209,11 +209,11 @@ describe('api.exceptions', () => {
         // @ts-expect-error cause is missing in TS type Error
         const error3 = new Error('test3', { cause: { a: 'b' } });
         // @ts-expect-error cause is missing in TS type Error
-        const error4 = new Error('test3', { cause: new Error('original error') });
+        const error4 = new Error('test4', { cause: new Error('original error') });
         // @ts-expect-error cause is missing in TS type Error
-        const error5 = new Error('test4', { cause: undefined });
+        const error5 = new Error('test5', { cause: null });
         // @ts-expect-error cause is missing in TS type Error
-        const error6 = new Error('test5', { cause: null });
+        const error6 = new Error('test6', { cause: undefined });
         const error7 = new Error('test6');
 
         api.pushError(error);
@@ -230,9 +230,9 @@ describe('api.exceptions', () => {
         expect((transport.items[1]?.payload as ExceptionEvent)?.context).toEqual({ cause: '[1,3]' });
         expect((transport.items[2]?.payload as ExceptionEvent)?.context).toEqual({ cause: '{"a":"b"}' });
         expect((transport.items[3]?.payload as ExceptionEvent)?.context).toEqual({ cause: 'Error: original error' });
-        expect((transport.items[4]?.payload as ExceptionEvent)?.context).toBeUndefined();
-        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
-        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[4]?.payload as ExceptionEvent)?.context).toEqual({});
+        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
+        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
       });
     });
   });

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -102,7 +102,9 @@ function parseCause(error: ErrorWithIndexProperties): {} | { cause: string } {
 
   if (isError(cause)) {
     cause = error.cause.toString();
-  } else if (isObject(error.cause) || isArray(error.cause)) {
+    // typeof operator on null returns "object". This is a well-known quirk in JavaScript and is considered a bug that cannot be fixed due to backward compatibility issues.
+    // MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
+  } else if (cause !== null && (isObject(error.cause) || isArray(error.cause))) {
     cause = JSON.stringify(error.cause);
   } else if (cause != null) {
     cause = error.cause.toString();

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -44,8 +44,13 @@ export interface PushErrorOptions {
   timestampOverwriteMs?: number;
 }
 
+// ts type is missing the cause property
+export type ErrorWithIndexProperties = Error & {
+  cause?: any;
+};
+
 export interface ExceptionsAPI {
   changeStacktraceParser: (stacktraceParser: StacktraceParser) => void;
   getStacktraceParser: () => StacktraceParser | undefined;
-  pushError: (value: Error, options?: PushErrorOptions) => void;
+  pushError: (value: ErrorWithIndexProperties, options?: PushErrorOptions) => void;
 }


### PR DESCRIPTION
## Why

JS allows to add a cause to errors. 
For example when re-throwing an error with a more specific  error message but to still have access to the original error.

Currently users need to do this manually by adding the cause to the extended error context.

Since this is a standard prop of the Error object Faro should take care of extarcting and adding it. 

## What

* Extract `error.cause`  and attach it to the extended Faro error context 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
