### PR TITLE
fix(readme): import for createBrowserRouter no pints to react-router-dom

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -99,7 +99,7 @@ In the file you create your data router, often the App.\* file pass your data ro
 function `withFaroRouterInstrumentation` to wrap all your routes and apply Faro auto instrumentation:
 
 ```ts
-import { createBrowserRouter } from '@grafana/faro-react';
+import { createBrowserRouter } from 'react-router-dom';
 
 const reactBrowserRouter = createBrowserRouter([
   // your routes...


### PR DESCRIPTION
## Why

The import for createBrowserRouter in the Faro react readme pointed to faro-react instead of 'react-router-dom'

## What
* Update import statement

## Links

* [PR cloud docs (private)](https://github.com/grafana/website/pull/22086)
* [PR  frontend-o11y app (private)](https://github.com/grafana/app-o11y-kwl/pull/1157)

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [x] Documentation updated
