### PR TITLE
fix(web-sdk): include pathname for page id

### DIFF
--- a/packages/web-sdk/src/metas/page/meta.ts
+++ b/packages/web-sdk/src/metas/page/meta.ts
@@ -2,6 +2,7 @@ import type { Meta, MetaItem } from '@grafana/faro-core';
 
 export const pageMeta: MetaItem<Pick<Meta, 'page'>> = () => ({
   page: {
+    id: location.pathname,
     url: location.href,
   },
 });


### PR DESCRIPTION
## Why

I found a potential fix for https://github.com/grafana/faro-web-sdk/issues/702

As I could not find the code that actually propagates the id in the first place (I assume it's done in Grafana?)

## What

I included a default value for the parameter id of the `page` meta object.
 
## Links

https://github.com/grafana/faro-web-sdk/issues/702

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
