### PR TITLE
Allow additionalInstrumentations in TracingInstrumentation

### DIFF
--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -104,6 +104,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
           propagateTraceHeaderCorsUrls,
           fetchInstrumentationOptions,
           xhrInstrumentationOptions,
+          ...options.additionalInstrumentations ?? [],
         }),
     });
 

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -23,6 +23,7 @@ export interface TracingInstrumentationOptions {
   instrumentations?: InstrumentationOption[];
   spanProcessor?: SpanProcessor;
   instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
+  additionalInstrumentations?: Instrumentation[];
 }
 
 export type MatchUrlDefinitions = Patterns;


### PR DESCRIPTION
## Why

This PR adds a small feature to the `faro.initialize()` API  that was opened in #711 

## What

<!-- Add a clear and concise description of what you changed. -->
Allow `additionalInstrumentations` for non-default tracing instrumentations to be added via `faro.initialize()` instead of re-implementing in a subclass or being forced to re-implement `getIgnoreUrls`.

## Links

Fixes #711 

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
