### PR TITLE
fix(console instrumentation): handle circular object references in json parser for console.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Next
 
-- Improvement (`@grafana/faro-web-sdk`): Guards user session stringifier against circular object
-  references (#715)
+- Fix (`@grafana/faro-web-sdk`): Guard user session stringifier against circular object references (#715)
+- Fix (`@grafana/faro-web-sdk`): Prevents circular references in objects sent via `console.error`
+  messages (#730)
 
 - Feat (`@grafana/faro-web-sdk`): Provide a `getIgnoreUrls()` function to easily retrieve the
   configured ignoreUrls (#732)

--- a/cypress/e2e/demo/errors.cy.ts
+++ b/cypress/e2e/demo/errors.cy.ts
@@ -32,8 +32,6 @@ context('Errors', () => {
   ].forEach(({ title, btnName, type = 'Error', value, expectStacktrace = true }) => {
     it(`will capture ${title}`, () => {
       cy.interceptCollector((body) => {
-        console.log('body :>> ', body);
-
         const item = body.exceptions?.find(
           (item: ExceptionEvent) =>
             item?.type === type &&

--- a/cypress/e2e/demo/logs.cy.ts
+++ b/cypress/e2e/demo/logs.cy.ts
@@ -6,7 +6,9 @@ context('Console logs', () => {
       cy.interceptCollector((body) => {
         let item =
           level === 'error'
-            ? body.exceptions?.find((item: ExceptionEvent) => item?.value === `This is a console ${level} message`)
+            ? body.exceptions?.find(
+                (item: ExceptionEvent) => item?.value === `console.error: This is a console ${level} message`
+              )
             : body.logs?.find(
                 (item: LogEvent) => item?.level === level && item?.message === `This is a console ${level} message`
               );

--- a/cypress/e2e/demo/logs.cy.ts
+++ b/cypress/e2e/demo/logs.cy.ts
@@ -13,8 +13,6 @@ context('Console logs', () => {
                 (item: LogEvent) => item?.level === level && item?.message === `This is a console ${level} message`
               );
 
-        console.log('item :>> ', item);
-
         return item != null ? 'log' : undefined;
       });
 

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -38,4 +38,29 @@ describe('ConsoleInstrumentation', () => {
       'with object {"foo":"bar","baz":"bam"}'
     );
   });
+
+  it('Handles objects with circular references', () => {
+    const mockTransport = new MockTransport();
+
+    initializeFaro(
+      makeCoreConfig(
+        mockConfig({
+          transports: [mockTransport],
+          instrumentations: [new ConsoleInstrumentation()],
+          unpatchedConsole: {
+            error: jest.fn(),
+          } as unknown as Console,
+        })
+      )!
+    );
+
+    const objWithCircularRef = { foo: 'bar', baz: 'bam' };
+    (objWithCircularRef as any).circular = objWithCircularRef;
+
+    console.error('with circular refs object', objWithCircularRef);
+
+    expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
+      'with circular refs object {"foo":"bar","baz":"bam","circular":null}'
+    );
+  });
 });

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -32,10 +32,12 @@ describe('ConsoleInstrumentation', () => {
     expect(mockTransport.items).toHaveLength(2);
 
     expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.type).toBe('Error');
-    expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe('console.error no 1');
+    expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
+      'console.error: console.error no 1'
+    );
     expect((mockTransport.items[1] as TransportItem<ExceptionEvent>)?.payload.type).toBe('Error');
     expect((mockTransport.items[1] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
-      'with object {"foo":"bar","baz":"bam"}'
+      'console.error: with object {"foo":"bar","baz":"bam"}'
     );
   });
 
@@ -60,7 +62,7 @@ describe('ConsoleInstrumentation', () => {
     console.error('with circular refs object', objWithCircularRef);
 
     expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
-      'with circular refs object {"foo":"bar","baz":"bam","circular":null}'
+      'console.error: with circular refs object {"foo":"bar","baz":"bam","circular":null}'
     );
   });
 });

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -1,5 +1,7 @@
 import { allLogLevels, BaseInstrumentation, isArray, isObject, LogLevel, VERSION } from '@grafana/faro-core';
 
+import { stringifyExternalJson } from '../../utils';
+
 import type { ConsoleInstrumentationOptions } from './types';
 
 export class ConsoleInstrumentation extends BaseInstrumentation {
@@ -23,7 +25,9 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
           try {
             if (level === LogLevel.ERROR) {
               this.api.pushError(
-                new Error(args.map((arg) => (isObject(arg) || isArray(arg) ? JSON.stringify(arg) : arg)).join(' '))
+                new Error(
+                  args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ')
+                )
               );
             } else {
               this.api.pushLog(args, { level });

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -26,7 +26,8 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
             if (level === LogLevel.ERROR) {
               this.api.pushError(
                 new Error(
-                  args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ')
+                  'console.error: ' +
+                    args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ')
                 )
               );
             } else {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -1,8 +1,7 @@
 import { faro } from '@grafana/faro-core';
 import type { Meta } from '@grafana/faro-core';
 
-import { throttle } from '../../../utils';
-import { getCircularDependencyReplacer } from '../../../utils/json';
+import { stringifyExternalJson, throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
 import { isSampled } from './sampling';
@@ -28,11 +27,7 @@ export class PersistentSessionsManager {
   }
 
   static storeUserSession(session: FaroUserSession): void {
-    setItem(
-      STORAGE_KEY,
-      JSON.stringify(session, getCircularDependencyReplacer()),
-      PersistentSessionsManager.storageTypeLocal
-    );
+    setItem(STORAGE_KEY, stringifyExternalJson(session), PersistentSessionsManager.storageTypeLocal);
   }
 
   static fetchUserSession(): FaroUserSession | null {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -2,7 +2,7 @@ import { faro } from '@grafana/faro-core';
 import type { Meta } from '@grafana/faro-core';
 
 import { throttle } from '../../../utils';
-import { getCircularDependencyReplacer } from '../../../utils/json';
+import { stringifyExternalJson } from '../../../utils/json';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
 import { isSampled } from './sampling';
@@ -28,11 +28,7 @@ export class VolatileSessionsManager {
   }
 
   static storeUserSession(session: FaroUserSession): void {
-    setItem(
-      STORAGE_KEY,
-      JSON.stringify(session, getCircularDependencyReplacer()),
-      VolatileSessionsManager.storageTypeSession
-    );
+    setItem(STORAGE_KEY, stringifyExternalJson(session), VolatileSessionsManager.storageTypeSession);
   }
 
   static fetchUserSession(): FaroUserSession | null {

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -10,4 +10,6 @@ export {
 
 export { throttle } from './throttle';
 
+export { getCircularDependencyReplacer, stringifyExternalJson } from './json';
+
 export { getIgnoreUrls } from './url';

--- a/packages/web-sdk/src/utils/json.test.ts
+++ b/packages/web-sdk/src/utils/json.test.ts
@@ -1,4 +1,4 @@
-import { getCircularDependencyReplacer } from './json';
+import { getCircularDependencyReplacer, stringifyExternalJson } from './json';
 
 describe('json', () => {
   it('replace circular references with null value', () => {
@@ -8,5 +8,12 @@ describe('json', () => {
     (obj as any).circular = obj;
 
     expect(JSON.stringify(obj, replacer)).toBe('{"a":1,"circular":null}');
+  });
+
+  it('stringifyExternalJson function replaces circular references with null value', () => {
+    const obj = { a: 1 };
+    (obj as any).circular = obj;
+
+    expect(stringifyExternalJson(obj)).toBe('{"a":1,"circular":null}');
   });
 });

--- a/packages/web-sdk/src/utils/json.ts
+++ b/packages/web-sdk/src/utils/json.ts
@@ -10,3 +10,13 @@ export function getCircularDependencyReplacer() {
     return value;
   };
 }
+
+type JSONObject = {
+  [key: string]: JSONValue;
+};
+type JSONArray = JSONValue[] & {};
+type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
+
+export function stringifyExternalJson(json: any = {}) {
+  return JSON.stringify(json ?? {}, getCircularDependencyReplacer());
+}


### PR DESCRIPTION
## Why

The console instrumentation for console.error logs stringifies objects provided from outside faro.
Those object can contain circular references which will cause `JSON.stringify()` to fail

## What
* Provide a new convenience function to stringify external objects 
* Use that function where appropriate
* Prefix errors send for console.error with `console.error: `


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
