### PR TITLE
feat: provide getIgnoreUrls function

### DIFF
--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -166,3 +166,5 @@ export {
   SESSION_INACTIVITY_TIME,
   STORAGE_KEY,
 } from './instrumentations/session';
+
+export { getIgnoreUrls } from './utils/url';

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -9,3 +9,5 @@ export {
 } from './webStorage';
 
 export { throttle } from './throttle';
+
+export { getIgnoreUrls } from './url';

--- a/packages/web-sdk/src/utils/url.ts
+++ b/packages/web-sdk/src/utils/url.ts
@@ -1,0 +1,9 @@
+import { faro } from '@grafana/faro-core';
+import type { Transport } from '@grafana/faro-core';
+
+/**
+ * Get all configured ignore URLs.
+ */
+export function getIgnoreUrls() {
+  return faro.transports.transports.flatMap((transport: Transport) => transport.getIgnoreUrls());
+}

--- a/packages/web-sdk/src/utils/urls.test.ts
+++ b/packages/web-sdk/src/utils/urls.test.ts
@@ -1,0 +1,45 @@
+import { BaseTransport, initializeFaro, VERSION } from '@grafana/faro-core';
+import type { Patterns, TransportItem } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { getIgnoreUrls } from './url';
+
+class MockTransport extends BaseTransport {
+  readonly name = '@grafana/transport-mock';
+  readonly version = VERSION;
+
+  items: TransportItem[] = [];
+
+  constructor(private ignoreURLs: Patterns = []) {
+    super();
+  }
+
+  send(items: TransportItem[]): void | Promise<void> {
+    this.items.push(...items);
+  }
+
+  override isBatched(): boolean {
+    return true;
+  }
+
+  override getIgnoreUrls(): Patterns {
+    return (this.ignoreURLs ?? ([] as Patterns[])).concat(this.config.ignoreUrls ?? []);
+  }
+}
+
+describe('Urls', () => {
+  it('should return the correct ignore urls for the given configuration', () => {
+    const transport = new MockTransport(['http://foo.com']);
+
+    initializeFaro(
+      mockConfig({
+        transports: [transport],
+        ignoreUrls: ['http://example.com', 'http://example2.com/test'],
+      })
+    );
+
+    const urls = getIgnoreUrls();
+
+    expect(urls).toEqual(['http://foo.com', 'http://example.com', 'http://example2.com/test']);
+  });
+});


### PR DESCRIPTION
## Why

Export a `getIgnoreUrls` function sp users can easily add ignoreUrls to custom instrumentations

## What

see above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
