### PR TITLE
chore(deps-dev): pin tough cookie version

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "typescript": "^4.9.4"
   },
   "packageManager": "yarn@1.22.19",
+  "resolutions": {
+    "tough-cookie": "^4.1.3"
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
## Why

The last open dependabot security alert depedns on cypress. 
We alreay updated cypress to the latest version, but it still pulls the vulnerable tough-cookie version.

For now we pin the version to the non-vulnerable one.

## What

* For now we pin the version via Yarn resolutions

## Links


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
