### PR TITLE
fix(ConsoleInstrumentation): guard json stringifier for non-error logs agains circular references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): Remove args.mapper form logs parser for standard logs in console instrumentation (#742)
+
 ## 1.12.0
 
 - Fix (`@grafana/faro-web-sdk`): Guard user session stringifier against circular object references (#715)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- Fix (`@grafana/faro-web-sdk`): Remove args.mapper form logs parser for standard logs in console instrumentation (#742)
+- Fix (`@grafana/faro-web-sdk`): Guard console instrumentation stringifier against circular object
+  references for non-error logs (#742)
 
 ## 1.12.0
 

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -34,10 +34,7 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
                 )
               );
             } else {
-              this.api.pushLog(
-                [args.map((arg) => (isObject(arg) || isArray(arg) ? JSON.stringify(arg) : arg)).join(' ')],
-                { level }
-              );
+              this.api.pushLog(args, { level });
             }
           } catch (err) {
             this.logError(err);

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -27,14 +27,9 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         console[level] = (...args) => {
           try {
             if (level === LogLevel.ERROR && !this.options?.consoleErrorAsLog) {
-              this.api.pushError(
-                new Error(
-                  'console.error: ' +
-                    args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ')
-                )
-              );
+              this.api.pushError(new Error('console.error: ' + formatConsoleArgs(args)));
             } else {
-              this.api.pushLog(args, { level });
+              this.api.pushLog([formatConsoleArgs(args)], { level });
             }
           } catch (err) {
             this.logError(err);
@@ -44,4 +39,8 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         };
       });
   }
+}
+
+function formatConsoleArgs(args: [any?, ...any[]]) {
+  return args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ');
 }


### PR DESCRIPTION
## Why

When sending standard log message for console logs we don't need an args mapper. 

Additionally the args mapper used there wasn't protected agains circular object references.


## What

* Revert args mapper form pushLog for standard logs 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
