### PR TITLE
fix(console instrumentation): revert to former log parsing behavior

### DIFF
--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -52,7 +52,7 @@ describe('ConsoleInstrumentation', () => {
     );
     expect((mockTransport.items[1] as TransportItem<ExceptionEvent>)?.payload.type).toBe('Error');
     expect((mockTransport.items[1] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
-      'console.error: with object {"foo":"bar","baz":"bam"}'
+      'console.error: with object [object Object]'
     );
   });
 
@@ -77,7 +77,7 @@ describe('ConsoleInstrumentation', () => {
     console.error('with circular refs object', objWithCircularRef);
 
     expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
-      'console.error: with circular refs object {"foo":"bar","baz":"bam","circular":null}'
+      'console.error: with circular refs object [object Object]'
     );
   });
 
@@ -106,7 +106,7 @@ describe('ConsoleInstrumentation', () => {
 
     expect((mockTransport.items[0] as TransportItem<LogEvent>)?.payload.message).toBe('console.error log no 1');
     expect((mockTransport.items[1] as TransportItem<LogEvent>)?.payload.message).toBe(
-      'console.error log with object {"foo":"bar","baz":"bam"}'
+      'console.error log with object [object Object]'
     );
   });
 

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -1,6 +1,4 @@
-import { allLogLevels, BaseInstrumentation, isArray, isObject, LogLevel, VERSION } from '@grafana/faro-core';
-
-import { stringifyExternalJson } from '../../utils';
+import { allLogLevels, BaseInstrumentation, defaultLogArgsSerializer, LogLevel, VERSION } from '@grafana/faro-core';
 
 import type { ConsoleInstrumentationOptions } from './types';
 
@@ -27,9 +25,9 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         console[level] = (...args) => {
           try {
             if (level === LogLevel.ERROR && !this.options?.consoleErrorAsLog) {
-              this.api.pushError(new Error('console.error: ' + formatConsoleArgs(args)));
+              this.api.pushError(new Error('console.error: ' + defaultLogArgsSerializer(args)));
             } else {
-              this.api.pushLog([formatConsoleArgs(args)], { level });
+              this.api.pushLog(args, { level });
             }
           } catch (err) {
             this.logError(err);
@@ -39,8 +37,4 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         };
       });
   }
-}
-
-function formatConsoleArgs(args: [any?, ...any[]]) {
-  return args.map((arg) => (isObject(arg) || isArray(arg) ? stringifyExternalJson(arg) : arg)).join(' ');
 }


### PR DESCRIPTION
## Why

We revert to the default log parser behaviour and do not stringify object by default.
Faro provides an option to inject a custom log parser which customers can leverage if custom parsing logic is needed.

## What
* use `defaultLogArgsSerializer` for errors
* use the former `this.api.pushLog(args, { level });` function which internally parses logs and applies the custom log parser if configured.

## Links

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
