### PR TITLE
fix: Check for undefined faro instancein isWebStorageAvailable catch block

### DIFF
--- a/packages/web-sdk/src/utils/webStorage.ts
+++ b/packages/web-sdk/src/utils/webStorage.ts
@@ -25,7 +25,8 @@ export function isWebStorageAvailable(type: StorageMechanism): boolean {
     return true;
   } catch (error) {
     // the above can throw
-    faro.internalLogger?.info(`Web storage of type ${type} is not available. Reason: ${error}`);
+    // this is called during module init, when the global instance may not be available
+    faro?.internalLogger?.info(`Web storage of type ${type} is not available. Reason: ${error}`);
     return false;
   }
 }


### PR DESCRIPTION
## Why

If storage throws an exception during the module init calls to isWebStorageAvailable, the global faro instance is not set and this crashes.

## What

Optional chain the faro instance itself in this catch block.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
