### PR TITLE
fix(transport-otlp-http): don't send payload if endpoint URL is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+## 1.12.3
+
+- Fix (`@grafana/faro-transport-otlp-http [experimental]`): Prevent sending requests when the
+  endpoint URL is not configured (#827).
+
 ## 1.12.2
 
 - Fix (`@grafana/faro-web-sdk`): Update Faro log parsing in console instrumentation to use Faro's

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,14 +2,19 @@
 
 ## Next
 
+## 1.12.3
+
+- Fix (`@grafana/faro-transport-otlp-http`): Prevent sending requests when the
+  endpoint URL is not configured (#827).
+
 ## 1.10.1
 
-- Fix (`@grafana/faro-transport-otlp-http [experimental]`): add `service.namespace` attribute if set
+- Fix (`@grafana/faro-transport-otlp-http`): add `service.namespace` attribute if set
   (#684).
 
 ### Breaking
 
-- Change (`@grafana/faro-transport-otlp-http [experimental]`): update semantic attributes
+- Change (`@grafana/faro-transport-otlp-http`): update semantic attributes
   for browser (#687).
   - `browser.user_agent` is replaced by `user_agent.original`
   - `browser.os` is replaced by `browser.platform`

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -175,15 +175,16 @@ describe('OtlpHttpTransport', () => {
 
   // TODO: add case for resourceSpans once the respective transform is implemented
   it.each([
-    { v: logTransportItem, type: 'resourceLogs' },
-    { v: traceTransportItem, type: 'resourceSpans' },
+    { v: logTransportItem, type: 'resourceLogs', otelEndpointUrl: 'www.example.com/v1/logs' },
+    { v: traceTransportItem, type: 'resourceSpans', otelEndpointUrl: 'www.example.com/v1/traces' },
   ])(
     'will back off on 429 for default interval if retry-after header present, with delay while sending $type',
-    async ({ v }) => {
+    async ({ v, otelEndpointUrl }) => {
       jest.useFakeTimers();
 
       const transport = new OtlpHttpTransport({
-        logsURL: 'www.example.com/v1/logs',
+        logsURL: otelEndpointUrl,
+        tracesURL: otelEndpointUrl,
         defaultRateLimitBackoffMs: 1000,
       });
 
@@ -213,15 +214,16 @@ describe('OtlpHttpTransport', () => {
   );
 
   it.each([
-    { v: logTransportItem, type: 'resourceLogs' },
-    { v: traceTransportItem, type: 'resourceSpans' },
+    { v: logTransportItem, type: 'resourceLogs', otelEndpointUrl: 'www.example.com/v1/logs' },
+    { v: traceTransportItem, type: 'resourceSpans', otelEndpointUrl: 'www.example.com/v1/traces' },
   ])(
     'will back off on 429 for default interval if retry-after header present, with date while sending $type',
-    async ({ v }) => {
+    async ({ v, otelEndpointUrl }) => {
       jest.useFakeTimers();
 
       const transport = new OtlpHttpTransport({
-        logsURL: 'www.example.com/v1/logs',
+        logsURL: otelEndpointUrl,
+        tracesURL: otelEndpointUrl,
         defaultRateLimitBackoffMs: 1000,
       });
 
@@ -417,5 +419,31 @@ describe('OtlpHttpTransport', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(mockResponseTextFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not send traces data if traces URL is not set', () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'www.example.com/v1/logs',
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    transport.send([traceTransportItem]);
+    transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not send logs data if logs URL is not set', () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'www.example.com/v1/traces',
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    transport.send([traceTransportItem]);
+    transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -98,6 +98,10 @@ export class OtlpHttpTransport extends BaseTransport {
         const { requestOptions, apiKey } = this.options;
         const { headers, ...restOfRequestOptions } = requestOptions ?? {};
 
+        if (!url) {
+          continue;
+        }
+
         this.promiseBuffer.add(() => {
           return fetch(url, {
             method: 'POST',


### PR DESCRIPTION
## Why

Don't send a requests if the respective traces or logs endpoint  URL is not set.

## What

See above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
