### PR TITLE
chore(deps-dev): bump eslint-config-prettier from 8.8.0 to 9.1.0 (#831)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   },
   "packageManager": "yarn@1.22.19",
   "resolutions": {
-    "tough-cookie": "^4.1.3"
+    "tough-cookie": "^4.1.3",
+    "cross-spawn": "^7.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
## Why

Pin cross-spawn to non vulnerbale version.
The `npm-run-all` package pulls and old version of the package. 


## What

* Add cross-spawn > = 7.x to resolutions object

## Links

[Dependabot alert](https://github.com/grafana/faro-web-sdk/security/dependabot/80)

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
