### PR TITLE
chore(release): prepare 1.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ## 1.12.3
 
 - Feat (`@grafana/faro-web-tracing`): add duration to events from traces (#861)
-
 - Fix (`@grafana/faro-transport-otlp-http [experimental]`): Prevent sending requests when the
   endpoint URL is not configured (#827).
+- Dependencies (`@grafana/faro-web-tracing`): upgrade otel deps (#763)
 
 ## 1.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.12.3
 
+- Feat (`@grafana/faro-web-tracing`): add duration to events from traces (#861)
+
 - Fix (`@grafana/faro-transport-otlp-http [experimental]`): Prevent sending requests when the
   endpoint URL is not configured (#827).
 


### PR DESCRIPTION
## Why

- Feat (`@grafana/faro-web-tracing`): add duration to events from traces (#861)

- Fix (`@grafana/faro-transport-otlp-http [experimental]`): Prevent sending requests when the
  endpoint URL is not configured (#827).

A bunch of dependency updates which are closing CSVEs as well.


## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
