### PR TITLE
feat: provide dynamic service name overrides

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -21,20 +21,7 @@ export function initializeFaro(): Faro {
         captureConsole: true,
       }),
 
-      new TracingInstrumentation({
-        instrumentationOptions: {
-          fetchInstrumentationOptions: {
-            applyCustomAttributesOnSpan: () => {
-              console.log('fetchInstrumentationOptions: applyCustomAttributesOnSpan');
-            },
-          },
-          xhrInstrumentationOptions: {
-            applyCustomAttributesOnSpan: () => {
-              console.log('xhrInstrumentationOptions: applyCustomAttributesOnSpan');
-            },
-          },
-        },
-      }),
+      new TracingInstrumentation(),
       new ReactIntegration({
         router: {
           version: ReactRouterVersion.V6,

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -173,7 +173,6 @@ describe('OtlpHttpTransport', () => {
     }
   );
 
-  // TODO: add case for resourceSpans once the respective transform is implemented
   it.each([
     { v: logTransportItem, type: 'resourceLogs', otelEndpointUrl: 'www.example.com/v1/logs' },
     { v: traceTransportItem, type: 'resourceSpans', otelEndpointUrl: 'www.example.com/v1/traces' },

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -54,7 +54,7 @@ export function initializeMetaAPI(
 
   const setView: MetaAPI['setView'] = (view, options) => {
     if (options?.overrides) {
-      setSession(undefined, { overrides: options.overrides });
+      setSession(getSession(), { overrides: options.overrides });
     }
 
     if (metaView?.view?.name === view?.name) {

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -45,8 +45,13 @@ export function initializeMetaAPI(
     const previousSession = metaSession;
 
     metaSession = {
+      session,
+    };
+
+    metaSession = {
       session: {
         ...session,
+        id: session?.id ?? previousSession?.session?.id,
         ...(overrides ?? {}),
       },
     };

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -1,10 +1,9 @@
-import { deepEqual, Meta } from '@grafana/faro-core';
-
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
-import type { Metas } from '../../metas';
+import type { Meta, Metas } from '../../metas';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
+import { deepEqual } from '../../utils/deepEqual';
 
 import type { MetaAPI } from './types';
 

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -3,7 +3,7 @@ import type { InternalLogger } from '../../internalLogger';
 import type { Meta, Metas } from '../../metas';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-// import { deepEqual } from '../../utils/deepEqual';
+import { isEmpty } from '../../utils/is';
 
 import type { MetaAPI } from './types';
 
@@ -35,39 +35,27 @@ export function initializeMetaAPI(
   const setSession: MetaAPI['setSession'] = (session, options) => {
     const overrides = options?.overrides;
 
-    // const noNewOverrides = overrides && deepEqual(metaSession?.session?.overrides, overrides);
-    // const oldAndNewSessionIdentical = deepEqual(metaSession?.session, session);
+    const newSession = isEmpty(session) ? metaSession?.session : session;
 
-    // if (oldAndNewSessionIdentical && noNewOverrides) {
-    //   return;
-    // }
-
-    const previousSession = metaSession;
-
-    metaSession = {
-      session,
-    };
+    if (metaSession) {
+      metas.remove(metaSession);
+    }
 
     metaSession = {
       session: {
-        ...session,
-        id: session?.id ?? previousSession?.session?.id,
-        ...(overrides ?? {}),
+        ...newSession,
+        overrides,
       },
     };
 
     metas.add(metaSession);
-
-    if (previousSession) {
-      metas.remove(previousSession);
-    }
   };
 
   const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
   const setView: MetaAPI['setView'] = (view, options) => {
     if (options?.overrides) {
-      setSession({ overrides: options.overrides });
+      setSession(undefined, { overrides: options.overrides });
     }
 
     if (metaView?.view?.name === view?.name) {

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -3,7 +3,7 @@ import type { InternalLogger } from '../../internalLogger';
 import type { Meta, Metas } from '../../metas';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual } from '../../utils/deepEqual';
+// import { deepEqual } from '../../utils/deepEqual';
 
 import type { MetaAPI } from './types';
 
@@ -35,14 +35,20 @@ export function initializeMetaAPI(
   const setSession: MetaAPI['setSession'] = (session, options) => {
     const overrides = options?.overrides;
 
-    if (deepEqual(metaSession?.session, session) && deepEqual(metaSession?.session?.overrides, overrides)) {
-      return;
-    }
+    // const noNewOverrides = overrides && deepEqual(metaSession?.session?.overrides, overrides);
+    // const oldAndNewSessionIdentical = deepEqual(metaSession?.session, session);
+
+    // if (oldAndNewSessionIdentical && noNewOverrides) {
+    //   return;
+    // }
 
     const previousSession = metaSession;
 
     metaSession = {
-      session,
+      session: {
+        ...session,
+        ...(overrides ?? {}),
+      },
     };
 
     metas.add(metaSession);

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -35,16 +35,15 @@ export function initializeMetaAPI(
   const setSession: MetaAPI['setSession'] = (session, options) => {
     const overrides = options?.overrides;
 
-    const newSession = isEmpty(session) ? metaSession?.session : session;
-
     if (metaSession) {
       metas.remove(metaSession);
     }
 
     metaSession = {
       session: {
-        ...newSession,
-        overrides,
+        // if session is empty, session manager force creates a new session
+        ...(isEmpty(session) ? undefined : session),
+        ...(overrides ? { overrides } : {}),
       },
     };
 

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -33,8 +33,10 @@ export function initializeMetaAPI(
     metas.add(metaUser);
   };
 
-  const setSession: MetaAPI['setSession'] = (session) => {
-    if (deepEqual(metaSession, session)) {
+  const setSession: MetaAPI['setSession'] = (session, options) => {
+    const overrides = options?.overrides;
+
+    if (deepEqual(metaSession?.session, session) && deepEqual(metaSession?.session?.overrides, overrides)) {
       return;
     }
 
@@ -53,9 +55,9 @@ export function initializeMetaAPI(
 
   const getSession: MetaAPI['getSession'] = () => metas.value.session;
 
-  const setView: MetaAPI['setView'] = (view, context) => {
-    if (context?.overrides) {
-      setSession({ overrides: context.overrides });
+  const setView: MetaAPI['setView'] = (view, options) => {
+    if (options?.overrides) {
+      setSession({ overrides: options.overrides });
     }
 
     if (metaView?.view?.name === view?.name) {

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -2,6 +2,11 @@ import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 describe('Meta API', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
   describe('setView', () => {
     it('updates the view meta if the new view meta is different to the previous one', () => {
       const { api } = initializeFaro(mockConfig());
@@ -33,36 +38,26 @@ describe('Meta API', () => {
   });
 
   describe('setSession', () => {
-    // it('updates the session meta if the new session meta is different to the previous one', () => {
-    //   const initialSession = { id: 'my-session' };
-    //   const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
-
-    //   const newSession = { id: 'my-new-session' };
-    //   api.setSession(newSession);
-
-    //   const previousSession = api.getSession();
-    //   expect(previousSession).toEqual(newSession);
-    // });
-
-    // it('does not update the session meta if the new session meta is identical to the previous one', () => {
-    //   const initialSession = { id: 'my-session' };
-    //   const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
-
-    //   const newSession = { id: 'my-session' };
-    //   api.setSession(newSession);
-    //   const previousSession = api.getSession();
-    //   expect(previousSession).toEqual(initialSession);
-    // });
-
     it('adds overrides to the session meta if provided via the setView() function call', () => {
       const initialSession = { id: 'my-session' };
-      const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
 
-      const newSession = { id: 'my-new-session' };
-      api.setSession(newSession, { overrides: { serviceName: 'foo' } });
+      const { api } = initializeFaro(mockConfig({ sessionTracking: { enabled: false, session: initialSession } }));
 
-      const previousSession = api.getSession();
-      expect(previousSession).toEqual({ ...newSession, overrides: { serviceName: 'foo' } });
+      expect(api.getSession()).toEqual(initialSession);
+
+      let overrides = { serviceName: 'service-1' };
+
+      const newSession = { id: 'my-new-session', attributes: { hello: 'world' } };
+      api.setSession(newSession, { overrides });
+      expect(api.getSession()).toEqual({ ...newSession, overrides });
+
+      overrides = { serviceName: 'service-2' };
+      api.setSession({}, { overrides });
+      expect(api.getSession()).toEqual({ ...newSession, overrides });
+
+      overrides = { serviceName: 'service-3' };
+      api.setSession(undefined, { overrides });
+      expect(api.getSession()).toEqual({ ...newSession, overrides });
     });
   });
 });

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -57,7 +57,7 @@ describe('Meta API', () => {
 
       overrides = { serviceName: 'service-3' };
       api.setSession(undefined, { overrides });
-      expect(api.getSession()).toEqual({ ...newSession, overrides });
+      expect(api.getSession()).toEqual({ overrides });
     });
   });
 });

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -53,7 +53,7 @@ describe('Meta API', () => {
 
       overrides = { serviceName: 'service-2' };
       api.setSession({}, { overrides });
-      expect(api.getSession()).toEqual({ ...newSession, overrides });
+      expect(api.getSession()).toEqual({ overrides });
 
       overrides = { serviceName: 'service-3' };
       api.setSession(undefined, { overrides });

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -33,25 +33,36 @@ describe('Meta API', () => {
   });
 
   describe('setSession', () => {
-    it('updates the session meta if the new session meta is different to the previous one', () => {
+    // it('updates the session meta if the new session meta is different to the previous one', () => {
+    //   const initialSession = { id: 'my-session' };
+    //   const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
+
+    //   const newSession = { id: 'my-new-session' };
+    //   api.setSession(newSession);
+
+    //   const previousSession = api.getSession();
+    //   expect(previousSession).toEqual(newSession);
+    // });
+
+    // it('does not update the session meta if the new session meta is identical to the previous one', () => {
+    //   const initialSession = { id: 'my-session' };
+    //   const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
+
+    //   const newSession = { id: 'my-session' };
+    //   api.setSession(newSession);
+    //   const previousSession = api.getSession();
+    //   expect(previousSession).toEqual(initialSession);
+    // });
+
+    it('adds overrides to the session meta if provided via the setView() function call', () => {
       const initialSession = { id: 'my-session' };
       const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
 
       const newSession = { id: 'my-new-session' };
-      api.setSession(newSession);
+      api.setSession(newSession, { overrides: { serviceName: 'foo' } });
 
       const previousSession = api.getSession();
-      expect(previousSession).toEqual(newSession);
-    });
-
-    it('does not update the session meta if the new session meta is identical to the previous one', () => {
-      const initialSession = { id: 'my-session' };
-      const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
-
-      const newSession = { id: 'my-session' };
-      api.setSession(newSession);
-      const previousSession = api.getSession();
-      expect(previousSession).toEqual(initialSession);
+      expect(previousSession).toEqual({ ...newSession, overrides: { serviceName: 'foo' } });
     });
   });
 });

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -1,0 +1,57 @@
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+describe('Meta API', () => {
+  describe('setView', () => {
+    it('updates the view meta if the new view meta is different to the previous one', () => {
+      const { api } = initializeFaro(mockConfig());
+
+      const view = { name: 'my-view' };
+      api.setView(view);
+      let previousView = api.getView();
+      expect(previousView).toEqual(view);
+
+      const newView = { name: 'my-new-view' };
+      api.setView(newView);
+      previousView = api.getView();
+      expect(previousView).toEqual(newView);
+    });
+
+    it('does not update the view meta if the new view meta is identical to the previous one', () => {
+      const { api } = initializeFaro(mockConfig());
+
+      const view = { name: 'my-view' };
+      api.setView(view);
+      let previousView = api.getView();
+      expect(previousView).toEqual(view);
+
+      const newView = { name: 'my-view' };
+      api.setView(newView);
+      previousView = api.getView();
+      expect(previousView).toEqual(view);
+    });
+  });
+
+  describe('setSession', () => {
+    it('updates the session meta if the new session meta is different to the previous one', () => {
+      const initialSession = { id: 'my-session' };
+      const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
+
+      const newSession = { id: 'my-new-session' };
+      api.setSession(newSession);
+
+      const previousSession = api.getSession();
+      expect(previousSession).toEqual(newSession);
+    });
+
+    it('does not update the session meta if the new session meta is identical to the previous one', () => {
+      const initialSession = { id: 'my-session' };
+      const { api } = initializeFaro(mockConfig({ sessionTracking: { session: initialSession } }));
+
+      const newSession = { id: 'my-session' };
+      api.setSession(newSession);
+      const previousSession = api.getSession();
+      expect(previousSession).toEqual(initialSession);
+    });
+  });
+});

--- a/packages/core/src/api/meta/types.ts
+++ b/packages/core/src/api/meta/types.ts
@@ -1,4 +1,4 @@
-import type { MetaSession, MetaUser, MetaView } from '../../metas';
+import type { MetaOverrides, MetaSession, MetaUser, MetaView } from '../../metas';
 
 export interface MetaAPI {
   setUser: (user?: MetaUser | undefined) => void;
@@ -6,6 +6,11 @@ export interface MetaAPI {
   setSession: (session?: MetaSession | undefined) => void;
   resetSession: () => void;
   getSession: () => MetaSession | undefined;
-  setView: (view?: MetaView | undefined) => void;
+  setView: (
+    view?: MetaView | undefined,
+    options?: {
+      overrides: MetaOverrides;
+    }
+  ) => void;
   getView: () => MetaView | undefined;
 }

--- a/packages/core/src/api/meta/types.ts
+++ b/packages/core/src/api/meta/types.ts
@@ -3,7 +3,12 @@ import type { MetaOverrides, MetaSession, MetaUser, MetaView } from '../../metas
 export interface MetaAPI {
   setUser: (user?: MetaUser | undefined) => void;
   resetUser: () => void;
-  setSession: (session?: MetaSession | undefined) => void;
+  setSession: (
+    session?: MetaSession | undefined,
+    options?: {
+      overrides: MetaOverrides;
+    }
+  ) => void;
   resetSession: () => void;
   getSession: () => MetaSession | undefined;
   setView: (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,7 @@ export {
   LogLevel,
   noop,
   dateNow,
+  isEmpty,
 } from './utils';
 export type {
   BaseObject,

--- a/packages/core/src/metas/index.ts
+++ b/packages/core/src/metas/index.ts
@@ -17,4 +17,5 @@ export type {
   MetaUser,
   MetaView,
   Metas,
+  MetaOverrides,
 } from './types';

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -44,6 +44,7 @@ export interface MetaUser {
 export interface MetaSession {
   id?: string;
   attributes?: MetaAttributes;
+  overrides?: MetaOverrides;
 }
 
 export interface MetaPage {
@@ -88,3 +89,10 @@ export interface Meta {
   view?: MetaView;
   k6?: MetaK6;
 }
+
+/**
+ * Overrides are instructions that allow the receiver to override certain properties.
+ */
+export type MetaOverrides = {
+  serviceName?: string;
+};

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -33,6 +33,7 @@ export {
   isToString,
   isTypeof,
   isUndefined,
+  isEmpty,
 } from './is';
 export type { IsFnHelper } from './is';
 

--- a/packages/core/src/utils/is.test.ts
+++ b/packages/core/src/utils/is.test.ts
@@ -1,0 +1,21 @@
+import { isEmpty } from './is';
+
+describe('Meta API', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('isEmpty() determines the empty state of a given  value', () => {
+    expect(isEmpty(null)).toBe(true);
+    expect(isEmpty(undefined)).toBe(true);
+    expect(isEmpty('')).toBe(true);
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty({})).toBe(true);
+
+    expect(isEmpty(0)).toBe(false);
+    expect(isEmpty('0')).toBe(false);
+    expect(isEmpty([0])).toBe(false);
+    expect(isEmpty({ key: 'value' })).toBe(false);
+  });
+});

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -73,12 +73,12 @@ export const isSyntheticEvent = ((value) =>
   'preventDefault' in value &&
   'stopPropagation' in value) as IsFnHelper<Event>;
 
-export function isEmpty(value: unknown): boolean {
-  if (!value) {
+export function isEmpty(value: any): boolean {
+  if (value == null) {
     return true;
   }
 
-  if (isArray(value)) {
+  if (isArray(value) || isString(value)) {
     return value.length === 0;
   }
 

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -72,3 +72,19 @@ export const isSyntheticEvent = ((value) =>
   'nativeEvent' in value &&
   'preventDefault' in value &&
   'stopPropagation' in value) as IsFnHelper<Event>;
+
+export function isEmpty(value: unknown): boolean {
+  if (!value) {
+    return true;
+  }
+
+  if (isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (isObject(value)) {
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+}

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -131,6 +131,10 @@ describe('ConsoleInstrumentation', () => {
       )!
     );
 
+    console.error('error logs are enabled');
+    console.info('info logs are enabled');
+    console.log('log logs are disabled');
+
     expect(mockTransport.items).toHaveLength(2);
     expect((mockTransport.items[0] as TransportItem<LogEvent>)?.payload.message).toBe('error logs are enabled');
     expect((mockTransport.items[1] as TransportItem<LogEvent>)?.payload.message).toBe('info logs are enabled');

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -131,10 +131,6 @@ describe('ConsoleInstrumentation', () => {
       )!
     );
 
-    console.error('error logs are enabled');
-    console.info('info logs are enabled');
-    console.log('log logs are disabled');
-
     expect(mockTransport.items).toHaveLength(2);
     expect((mockTransport.items[0] as TransportItem<LogEvent>)?.payload.message).toBe('error logs are enabled');
     expect((mockTransport.items[1] as TransportItem<LogEvent>)?.payload.message).toBe('info logs are enabled');

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -1,17 +1,10 @@
 import { faro } from '@grafana/faro-core';
-import type { Meta } from '@grafana/faro-core';
 
 import { stringifyExternalJson, throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
-import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
-import {
-  addSessionMetadataToNextSession,
-  createUserSessionObject,
-  getSessionMetaUpdateHandler,
-  getUserSessionUpdater,
-} from './sessionManagerUtils';
+import { getSessionMetaUpdateHandler, getUserSessionUpdater } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 
 export class PersistentSessionsManager {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -1,13 +1,11 @@
 import { faro } from '@grafana/faro-core';
-import type { Meta } from '@grafana/faro-core';
 
 import { throttle } from '../../../utils';
 import { stringifyExternalJson } from '../../../utils/json';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
-import { isSampled } from './sampling';
 import { STORAGE_KEY, STORAGE_UPDATE_DELAY } from './sessionConstants';
-import { addSessionMetadataToNextSession, createUserSessionObject, getUserSessionUpdater } from './sessionManagerUtils';
+import { getSessionMetaUpdateHandler, getUserSessionUpdater } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 
 export class VolatileSessionsManager {
@@ -51,19 +49,11 @@ export class VolatileSessionsManager {
     });
 
     // Users can call the setSession() method, so we need to sync this with the local storage session
-    faro.metas.addListener(function syncSessionIfChangedExternally(meta: Meta) {
-      const session = meta.session;
-      const sessionFromSessionStorage = VolatileSessionsManager.fetchUserSession();
-
-      if (session && session.id !== sessionFromSessionStorage?.sessionId) {
-        const userSession = addSessionMetadataToNextSession(
-          createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
-          sessionFromSessionStorage
-        );
-
-        VolatileSessionsManager.storeUserSession(userSession);
-        faro.api.setSession(userSession.sessionMeta);
-      }
-    });
+    faro.metas.addListener(
+      getSessionMetaUpdateHandler({
+        fetchUserSession: VolatileSessionsManager.fetchUserSession,
+        storeUserSession: VolatileSessionsManager.storeUserSession,
+      })
+    );
   }
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionsManager.test.ts
@@ -1,5 +1,5 @@
 import * as faroCore from '@grafana/faro-core';
-import { faro, initializeFaro } from '@grafana/faro-core';
+import { dateNow, faro, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import * as samplingModule from './sampling';
@@ -222,5 +222,92 @@ describe('Volatile Sessions Manager.', () => {
     expect(() => {
       VolatileSessionsManager.storeUserSession(storedSession);
     }).not.toThrow();
+  });
+
+  describe('setSession().', () => {
+    it('Creates a new Faro user session if new sessionId is set.', () => {
+      const mockIsSampled = jest.fn();
+      jest.spyOn(samplingModule, 'isSampled').mockImplementationOnce(mockIsSampled);
+
+      const storedSession: FaroUserSession = {
+        sessionId: mockInitialSessionId,
+        isSampled: true,
+        lastActivity: dateNow(),
+        started: dateNow(),
+      };
+
+      mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+
+      new VolatileSessionsManager();
+
+      const initialSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+      expect(initialSession.sessionId).toBe(mockInitialSessionId);
+
+      const manualSetSessionId = 'xyz';
+      faro.api.setSession({ id: manualSetSessionId });
+      expect(mockIsSampled).toHaveBeenCalledTimes(1);
+
+      const newSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+      expect(newSession.sessionId).toBe(manualSetSessionId);
+    });
+
+    it('Does not update Faro user session if "sessionId" and "attributes" in the meta session object and stored session meta are identical.', () => {
+      const storedSession: FaroUserSession = {
+        sessionId: mockInitialSessionId,
+        isSampled: true,
+        lastActivity: dateNow(),
+        started: dateNow(),
+        sessionMeta: {
+          id: mockInitialSessionId,
+          attributes: {
+            previousSession: 'none',
+            isSampled: 'true',
+          },
+        },
+      };
+
+      mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+      new VolatileSessionsManager();
+
+      faro.api.setSession(storedSession.sessionMeta);
+
+      expect(setItemSpy).not.toHaveBeenCalled();
+      expect(mockOnNewSessionCreated).not.toHaveBeenCalled();
+      expect(JSON.parse(mockStorage[STORAGE_KEY]!)).toStrictEqual(storedSession);
+    });
+
+    it('Creates a new Faro user session if new meta attributes are added.', () => {
+      const storedSession: FaroUserSession = {
+        sessionId: mockInitialSessionId,
+        isSampled: true,
+        lastActivity: dateNow(),
+        started: dateNow(),
+        sessionMeta: {
+          id: mockInitialSessionId,
+          attributes: {
+            isSampled: 'true',
+          },
+        },
+      };
+
+      mockStorage[STORAGE_KEY] = JSON.stringify(storedSession);
+      new VolatileSessionsManager();
+
+      const newMetaAttributes = {
+        id: mockInitialSessionId,
+        attributes: {
+          previousSession: mockInitialSessionId,
+          isSampled: 'true',
+          newAttribute: 'newValue',
+        },
+      };
+
+      faro.api.setSession(newMetaAttributes);
+
+      expect(setItemSpy).toHaveBeenCalledTimes(1);
+
+      const updatedSession: FaroUserSession = JSON.parse(mockStorage[STORAGE_KEY]!);
+      expect(updatedSession.sessionMeta).toStrictEqual(newMetaAttributes);
+    });
   });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -487,6 +487,98 @@ describe('sessionManagerUtils', () => {
     });
   });
 
-  // TODO: Add for newAttributes faroUserSession updates
-  // TODO: Add for newOverrides faroUserSession updates
+  it('Updates session attributes without creating a new Faro user session if only attributes have changed.', () => {
+    const mockStoreUserSession = jest.fn();
+    jest.spyOn(VolatileSessionsManager, 'storeUserSession').mockImplementationOnce(mockStoreUserSession);
+
+    const storedSession: FaroUserSession = {
+      sessionId: mockSessionId,
+      isSampled: true,
+      lastActivity: fakeSystemTime,
+      started: fakeSystemTime,
+      sessionMeta: {
+        id: mockSessionId,
+        attributes: {
+          isSampled: 'true',
+        },
+      },
+    };
+
+    jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValueOnce(storedSession);
+
+    const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
+      fetchUserSession: VolatileSessionsManager.fetchUserSession,
+      storeUserSession: VolatileSessionsManager.storeUserSession,
+    });
+
+    const updatedAttributes = {
+      isSampled: 'true',
+      foo: 'bar',
+    };
+
+    handler({
+      session: {
+        id: mockSessionId,
+        attributes: updatedAttributes,
+      },
+    });
+
+    expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
+    expect(mockStoreUserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: mockSessionId,
+        isSampled: true,
+        sessionMeta: expect.objectContaining({
+          attributes: expect.objectContaining(updatedAttributes),
+        }),
+      })
+    );
+  });
+
+  // it('Updates session overrides without creating a new Faro user session if only overrides have changed.', () => {
+  //   const mockStoreUserSession = jest.fn();
+  //   jest.spyOn(VolatileSessionsManager, 'storeUserSession').mockImplementationOnce(mockStoreUserSession);
+
+  //   const storedSession: FaroUserSession = {
+  //     sessionId: mockSessionId,
+  //     isSampled: true,
+  //     lastActivity: fakeSystemTime,
+  //     started: fakeSystemTime,
+  //     sessionMeta: {
+  //       id: mockSessionId,
+  //       attributes: {
+  //         isSampled: 'true',
+  //       },
+  //     },
+  //   };
+
+  //   jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValueOnce(storedSession);
+
+  //   const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
+  //     fetchUserSession: VolatileSessionsManager.fetchUserSession,
+  //     storeUserSession: VolatileSessionsManager.storeUserSession,
+  //   });
+
+  //   const updatedAttributes: MetaSession['overrides'] = {
+  //     serviceName: 'new-service-name',
+  //   };
+
+  //   handler({
+  //     session: {
+  //       id: mockSessionId,
+  //       overrides: updatedAttributes,
+  //     },
+  //   });
+
+  //   expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
+  //   expect(mockStoreUserSession).toHaveBeenCalledWith(
+  //     expect.objectContaining({
+  //       sessionId: mockSessionId,
+  //       isSampled: true,
+  //       sessionMeta: expect.objectContaining({
+  //         overrides: updatedAttributes,
+  //       }),
+  //     })
+  //   );
+  // });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -37,7 +37,7 @@ describe('sessionManagerUtils', () => {
   });
 
   it('creates new user session object.', () => {
-    jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockSessionId);
+    jest.spyOn(faroCore, 'genShortID').mockReturnValueOnce(mockSessionId);
 
     // create new id
     const newSession = createUserSessionObject();
@@ -86,7 +86,7 @@ describe('sessionManagerUtils', () => {
   });
 
   it('checks if user session is valid.', () => {
-    jest.spyOn(faroCore, 'genShortID').mockReturnValue(mockSessionId);
+    jest.spyOn(faroCore, 'genShortID').mockReturnValueOnce(mockSessionId);
 
     // return false if session is null
     const isNullSessionInvalid = isUserSessionValid(null);
@@ -455,7 +455,7 @@ describe('sessionManagerUtils', () => {
         },
       };
 
-      jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValue(storedSession);
+      jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValueOnce(storedSession);
 
       const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
         fetchUserSession: VolatileSessionsManager.fetchUserSession,
@@ -508,7 +508,7 @@ describe('sessionManagerUtils', () => {
         },
       };
 
-      jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValue(storedSession);
+      jest.spyOn(VolatileSessionsManager, 'fetchUserSession').mockReturnValueOnce(storedSession);
 
       const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
         fetchUserSession: VolatileSessionsManager.fetchUserSession,

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -1,6 +1,5 @@
-import { initializeFaro } from '@grafana/faro-core';
 import * as faroCore from '@grafana/faro-core';
-import type { MetaSession } from '@grafana/faro-core';
+import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import { getSessionManagerByConfig } from './getSessionManagerByConfig';
@@ -341,9 +340,7 @@ describe('sessionManagerUtils', () => {
       serviceName: 'my-service',
     };
 
-    const sessionMeta: MetaSession = { overrides };
-
-    api.setSession(sessionMeta);
+    api.setSession(undefined, { overrides });
 
     const sessionWithOverrides = addSessionMetadataToNextSession(newSession, previousSession);
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -539,5 +539,35 @@ describe('sessionManagerUtils', () => {
         })
       );
     });
+
+    it('creates a new session with overrides if the session is empty and only overrides are available.', () => {
+      const mockStoreUserSession = jest.fn();
+      jest.spyOn(VolatileSessionsManager, 'storeUserSession').mockImplementationOnce(mockStoreUserSession);
+
+      const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
+        fetchUserSession: VolatileSessionsManager.fetchUserSession,
+        storeUserSession: VolatileSessionsManager.storeUserSession,
+      });
+
+      const faro = initializeFaro(mockConfig({}));
+
+      const newOverrides = { serviceName: 'my-service' };
+
+      // Simulate setting session with only overrides
+      faro.api.setSession(undefined, { overrides: newOverrides });
+
+      handler(faro.metas.value);
+
+      expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
+      expect(mockStoreUserSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: expect.any(String),
+          isSampled: true,
+          sessionMeta: expect.objectContaining({
+            overrides: newOverrides,
+          }),
+        })
+      );
+    });
   });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -486,4 +486,7 @@ describe('sessionManagerUtils', () => {
       );
     });
   });
+
+  // TODO: Add for newAttributes faroUserSession updates
+  // TODO: Add for newOverrides faroUserSession updates
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,4 +1,4 @@
-import { dateNow, faro, genShortID } from '@grafana/faro-core';
+import { dateNow, faro, genShortID, Meta } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
@@ -107,4 +107,58 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
   };
 
   return sessionWithMeta;
+}
+
+type GetUserSessionMetaUpdateHandlerParams = {
+  storeUserSession: (session: FaroUserSession) => void;
+  fetchUserSession: () => FaroUserSession | null;
+};
+
+export function getSessionMetaUpdateHandler({
+  fetchUserSession,
+  storeUserSession,
+}: GetUserSessionMetaUpdateHandlerParams) {
+  return function syncSessionIfChangedExternally(meta: Meta) {
+    //   const session = meta.session;
+    //   const sessionFromSessionStorage = fetchUserSession();
+    //   const { id: metaSessionId, attributes: metaAttributes } = session ?? {};
+    //   const { sessionId: sessionFromStorageId, sessionMeta: sessionFromStorageMeta } = sessionFromSessionStorage ?? {};
+    //   const sessionFromStorageMetaAttributes = sessionFromStorageMeta?.attributes;
+    //   const sessionIdsIdentical = session?.id === sessionFromStorageId;
+    //   const attributesIdentical = deepEqual(metaAttributes, sessionFromStorageMetaAttributes);
+    //   const internalSessionAttributesIdentical = deepEqual(session?.internal, sessionFromStorageMeta?.internal);
+    //   if (sessionIdsIdentical && attributesIdentical && internalSessionAttributesIdentical) {
+    //     return;
+    //   }
+    //   const sessionIdManuallyUpdated = metaSessionId && metaSessionId !== sessionFromStorageId;
+    //   const attributesManuallyUpdated = Boolean(
+    //     metaAttributes && !deepEqual(metaAttributes, sessionFromStorageMetaAttributes)
+    //   );
+    //   if (sessionIdManuallyUpdated || attributesManuallyUpdated) {
+    //     let sessionId = metaSessionId;
+    //     if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
+    //       sessionId = sessionFromSessionStorage?.sessionId;
+    //     }
+    //     const userSession = addSessionMetadataToNextSession(
+    //       createUserSessionObject({ sessionId, isSampled: isSampled() }),
+    //       sessionFromSessionStorage
+    //     );
+    //     storeUserSession(userSession);
+    //     faro.api.setSession(userSession.sessionMeta);
+    //   }
+    // };
+
+    const session = meta.session;
+    const sessionFromSessionStorage = fetchUserSession();
+
+    if (session && session.id !== sessionFromSessionStorage?.sessionId) {
+      const userSession = addSessionMetadataToNextSession(
+        createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
+        sessionFromSessionStorage
+      );
+
+      storeUserSession(userSession);
+      faro.api.setSession(userSession.sessionMeta);
+    }
+  };
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,4 +1,4 @@
-import { dateNow, faro, genShortID, Meta } from '@grafana/faro-core';
+import { dateNow, deepEqual, faro, genShortID, Meta } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
@@ -153,13 +153,16 @@ export function getSessionMetaUpdateHandler({
 
     let sessionId = session?.id;
 
-    if (session && session.id !== sessionFromSessionStorage?.sessionId) {
+    if (
+      (session && session.id !== sessionFromSessionStorage?.sessionId) ||
+      !deepEqual(session?.attributes, sessionFromSessionStorage?.sessionMeta?.attributes)
+    ) {
       if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
         sessionId = sessionFromSessionStorage?.sessionId;
       }
 
       const userSession = addSessionMetadataToNextSession(
-        createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
+        createUserSessionObject({ sessionId, isSampled: isSampled() }),
         sessionFromSessionStorage
       );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -139,9 +139,7 @@ export function getSessionMetaUpdateHandler({
       // }
 
       const userSession = addSessionMetadataToNextSession(
-        {
-          ...createUserSessionObject({ sessionId, isSampled: isSampled() }),
-        },
+        createUserSessionObject({ sessionId, isSampled: isSampled() }),
         sessionFromSessionStorage
       );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -155,7 +155,7 @@ export function getSessionMetaUpdateHandler({
 
     if (
       (session && session.id !== sessionFromSessionStorage?.sessionId) ||
-      !deepEqual(session?.attributes, sessionFromSessionStorage?.sessionMeta?.attributes)
+      (session?.attributes && !deepEqual(session?.attributes, sessionFromSessionStorage?.sessionMeta?.attributes))
     ) {
       if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
         sessionId = sessionFromSessionStorage?.sessionId;

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -122,18 +122,25 @@ export function getSessionMetaUpdateHandler({
     const session = meta.session;
     const sessionFromSessionStorage = fetchUserSession();
 
+    const sessionMeta = sessionFromSessionStorage?.sessionMeta;
+    const previousSessionId = sessionFromSessionStorage?.sessionId;
+
+    const { attributes: newAttributes, overrides: newOverrides } = session ?? {};
     let sessionId = session?.id;
 
     if (
-      (session && session.id !== sessionFromSessionStorage?.sessionId) ||
-      (session?.attributes && !deepEqual(session?.attributes, sessionFromSessionStorage?.sessionMeta?.attributes))
+      (session && sessionId !== previousSessionId) || // session id changed
+      (newAttributes && !deepEqual(newAttributes, sessionMeta?.attributes)) || // session attributes changed
+      (newOverrides && !deepEqual(newOverrides, sessionMeta?.overrides)) // session overrides changed
     ) {
       if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
-        sessionId = sessionFromSessionStorage?.sessionId;
+        sessionId = previousSessionId;
       }
 
       const userSession = addSessionMetadataToNextSession(
-        createUserSessionObject({ sessionId, isSampled: isSampled() }),
+        {
+          ...createUserSessionObject({ sessionId, isSampled: isSampled() }),
+        },
         sessionFromSessionStorage
       );
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,4 +1,4 @@
-import { dateNow, deepEqual, faro, genShortID, Meta } from '@grafana/faro-core';
+import { dateNow, deepEqual, faro, genShortID, isEmpty, Meta } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
@@ -106,12 +106,12 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
   };
 
   const overrides = faro.metas.value.session?.overrides ?? previousSession?.sessionMeta?.overrides;
-  if (overrides) {
+  if (!isEmpty(overrides)) {
     sessionWithMeta.sessionMeta.overrides = overrides;
   }
 
   const previousSessionId = previousSession?.sessionId;
-  if (previousSessionId) {
+  if (previousSessionId != null) {
     sessionWithMeta.sessionMeta.attributes!['previousSession'] = previousSessionId;
   }
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -133,9 +133,10 @@ export function getSessionMetaUpdateHandler({
       (newAttributes && !deepEqual(newAttributes, sessionMeta?.attributes)) || // session attributes changed
       (newOverrides && !deepEqual(newOverrides, sessionMeta?.overrides)) // session overrides changed
     ) {
-      if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
-        sessionId = previousSessionId;
-      }
+      // TODO: should be handled by the setSession method
+      // if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
+      //   sessionId = previousSessionId;
+      // }
 
       const userSession = addSessionMetadataToNextSession(
         {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -133,11 +133,6 @@ export function getSessionMetaUpdateHandler({
       (newAttributes && !deepEqual(newAttributes, sessionMeta?.attributes)) || // session attributes changed
       (newOverrides && !deepEqual(newOverrides, sessionMeta?.overrides)) // session overrides changed
     ) {
-      // TODO: should be handled by the setSession method
-      // if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
-      //   sessionId = previousSessionId;
-      // }
-
       const userSession = addSessionMetadataToNextSession(
         createUserSessionObject({ sessionId, isSampled: isSampled() }),
         sessionFromSessionStorage

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -100,11 +100,20 @@ export function addSessionMetadataToNextSession(newSession: FaroUserSession, pre
       attributes: {
         ...faro.config.sessionTracking?.session?.attributes,
         ...(faro.metas.value.session?.attributes ?? {}),
-        ...(previousSession != null ? { previousSession: previousSession.sessionId } : {}),
         isSampled: newSession.isSampled.toString(),
       },
     },
   };
+
+  const overrides = faro.metas.value.session?.overrides ?? previousSession?.sessionMeta?.overrides;
+  if (overrides) {
+    sessionWithMeta.sessionMeta.overrides = overrides;
+  }
+
+  const previousSessionId = previousSession?.sessionId;
+  if (previousSessionId) {
+    sessionWithMeta.sessionMeta.attributes!['previousSession'] = previousSessionId;
+  }
 
   return sessionWithMeta;
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -119,35 +119,6 @@ export function getSessionMetaUpdateHandler({
   storeUserSession,
 }: GetUserSessionMetaUpdateHandlerParams) {
   return function syncSessionIfChangedExternally(meta: Meta) {
-    //   const session = meta.session;
-    //   const sessionFromSessionStorage = fetchUserSession();
-    //   const { id: metaSessionId, attributes: metaAttributes } = session ?? {};
-    //   const { sessionId: sessionFromStorageId, sessionMeta: sessionFromStorageMeta } = sessionFromSessionStorage ?? {};
-    //   const sessionFromStorageMetaAttributes = sessionFromStorageMeta?.attributes;
-    //   const sessionIdsIdentical = session?.id === sessionFromStorageId;
-    //   const attributesIdentical = deepEqual(metaAttributes, sessionFromStorageMetaAttributes);
-    //   const internalSessionAttributesIdentical = deepEqual(session?.internal, sessionFromStorageMeta?.internal);
-    //   if (sessionIdsIdentical && attributesIdentical && internalSessionAttributesIdentical) {
-    //     return;
-    //   }
-    //   const sessionIdManuallyUpdated = metaSessionId && metaSessionId !== sessionFromStorageId;
-    //   const attributesManuallyUpdated = Boolean(
-    //     metaAttributes && !deepEqual(metaAttributes, sessionFromStorageMetaAttributes)
-    //   );
-    //   if (sessionIdManuallyUpdated || attributesManuallyUpdated) {
-    //     let sessionId = metaSessionId;
-    //     if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
-    //       sessionId = sessionFromSessionStorage?.sessionId;
-    //     }
-    //     const userSession = addSessionMetadataToNextSession(
-    //       createUserSessionObject({ sessionId, isSampled: isSampled() }),
-    //       sessionFromSessionStorage
-    //     );
-    //     storeUserSession(userSession);
-    //     faro.api.setSession(userSession.sessionMeta);
-    //   }
-    // };
-
     const session = meta.session;
     const sessionFromSessionStorage = fetchUserSession();
 

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -151,7 +151,13 @@ export function getSessionMetaUpdateHandler({
     const session = meta.session;
     const sessionFromSessionStorage = fetchUserSession();
 
+    let sessionId = session?.id;
+
     if (session && session.id !== sessionFromSessionStorage?.sessionId) {
+      if (sessionId == null && isUserSessionValid(sessionFromSessionStorage)) {
+        sessionId = sessionFromSessionStorage?.sessionId;
+      }
+
       const userSession = addSessionMetadataToNextSession(
         createUserSessionObject({ sessionId: session.id, isSampled: isSampled() }),
         sessionFromSessionStorage

--- a/packages/web-sdk/src/utils/webStorage.test.ts
+++ b/packages/web-sdk/src/utils/webStorage.test.ts
@@ -2,7 +2,6 @@ import { isWebStorageAvailable } from './webStorage';
 
 let windowSpy: jest.SpyInstance;
 
-// TODO: adapt tests
 describe('webStorage', () => {
   beforeEach(() => {
     windowSpy = jest.spyOn(globalThis, 'window', 'get');

--- a/packages/web-sdk/src/utils/webStorage.ts
+++ b/packages/web-sdk/src/utils/webStorage.ts
@@ -7,8 +7,6 @@ export const webStorageType = {
 
 type StorageMechanism = (typeof webStorageType)[keyof typeof webStorageType];
 
-// TODO: remove default storage type from all function
-
 /**
  * Check if selected web storage mechanism is available.
  * @param type storage mechanism to test availability for.


### PR DESCRIPTION
## Why

As a user of Frontend O11y and Application O11y in Grafana Cloud, i would like to override the service name
for a subset of telemetry as the user progresses through the UX.

Example:
User lands on the login page, the telemetry should be mapped to the login service
User progresses through the app, goes to checkout, the associated telemetry should be associated with the checkout service
User manages their newsletter preferences, associated telemetry should be tagged with the profile service name
The override should be persisted in the user session to allow maximum flexibility.

TODO:
- [ ] update docs

## What

Faro provides two APIs to dynamically set overrides.
Under the hood it's nothing else as adding an overrides object to the session meta.
The receiver (for Grafana it's cloud only atm) reads the contents of the overrides object and triggers respective actions.
Currently it only provides a service name override.

The overrides can be set via the `setView(view, overrides)` and `setSession(session, overrides)` APIs.
When calling set session without a session object (falsy or empty)m the the session manager creates a new session.


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
