### PR TITLE
chore(demo): pin postgres version in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
   database:
     env_file:
       - './.env'
-    image: 'postgres:latest'
+    image: 'postgres:16.6'
     volumes:
       - 'db_data:/var/lib/postgresql/data'
     environment:


### PR DESCRIPTION
## Why

Because the Postgres verison wasn't fixed in the docker-compoise file a DB update was pulled which broke the demo.

## What
* Use fixed POstgres version instead of `:main`

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
