### PR TITLE
chore: define supported Node engines 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 23]
+        node: [18.x, 20.x, 22.x, 23.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 23]
+        node: [18, 20, 22, 23]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature (`@grafana/faro-web-sdk`): Provide APIs to send `service.name` override instructions to the
   receiver (#893)
 - Improvement (`@grafana/faro-web-sdk`): Send an event for `service.name` overrides (#903)
+- Improvement (`@grafana/faro-*`) Add required Node engines to package.json ()
 
 ## 1.12.3
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-demo",
   "version": "1.12.3",
   "description": "Demo of Faro",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "license": "Apache-2.0",
   "author": "Grafana Labs",
   "homepage": "https://github.com/grafana/faro-web-sdk",

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Demo of Faro",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "license": "Apache-2.0",
   "author": "Grafana Labs",

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Improvement (`@grafana/faro-*`) Add required Node engines to package.json ()
+
 ## 1.12.3
 
 - Fix (`@grafana/faro-transport-otlp-http`): Prevent sending requests when the

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro fetch auto-instrumentation package",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-instrumentation-fetch",
   "version": "1.12.3",
   "description": "Faro fetch auto-instrumentation package",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro instrumentation to capture Browser Performance Timeline data.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-instrumentation-performance-timeline",
   "version": "1.12.3",
   "description": "Faro instrumentation to capture Browser Performance Timeline data.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/instrumentation-xhr/package.json
+++ b/experimental/instrumentation-xhr/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-instrumentation-xhr",
   "version": "1.12.3",
   "description": "Faro XHR auto-instrumentation package",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/instrumentation-xhr/package.json
+++ b/experimental/instrumentation-xhr/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro XHR auto-instrumentation package",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-transport-otlp-http",
   "version": "1.12.3",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "os-browserify": "^0.3.0",
     "prettier": "^3.0.3",
     "process": "^0.11.10",
-    "rimraf": "^6.0.1",
+    "rimraf": "^5.0.10",
     "rollup": "^4.0.2",
     "start-server-and-test": "^2.0.1",
     "ts-jest": "^29.0.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "faro-web-sdk",
   "version": "0.0.0",
   "description": "Monorepo for Faro Web SDK",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "license": "Apache-2.0",
   "author": "Grafana Labs",
   "homepage": "https://github.com/grafana/faro-web-sdk#readme",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Monorepo for Faro Web SDK",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "license": "Apache-2.0",
   "author": "Grafana Labs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-core",
   "version": "1.12.3",
   "description": "Core package of Faro.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Core package of Faro.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro package that enables easier integration in projects built with React.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-react",
   "version": "1.12.3",
   "description": "Faro package that enables easier integration in projects built with React.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro instrumentations, metas, transports for web.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-web-sdk",
   "version": "1.12.3",
   "description": "Faro instrumentations, metas, transports for web.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -2,6 +2,9 @@
   "name": "@grafana/faro-web-tracing",
   "version": "1.12.3",
   "description": "Faro web tracing implementation.",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.3",
   "description": "Faro web tracing implementation.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "observability",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6114,7 +6114,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^10.2.2, glob@^10.3.10, glob@~10.4.5:
+glob@^10.2.2, glob@^10.3.10, glob@^10.3.7, glob@~10.4.5:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
@@ -6125,18 +6125,6 @@ glob@^10.2.2, glob@^10.3.10, glob@~10.4.5:
     minipass "^7.1.2"
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
-
-glob@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.0.tgz#6031df0d7b65eaa1ccb9b29b5ced16cea658e77e"
-  integrity sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^4.0.1"
-    minimatch "^10.0.0"
-    minipass "^7.1.2"
-    package-json-from-dist "^1.0.0"
-    path-scurry "^2.0.0"
 
 glob@^7.1.3, glob@^7.1.4, glob@^7.2.3:
   version "7.2.3"
@@ -7200,13 +7188,6 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
-jackspeak@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.0.2.tgz#11f9468a3730c6ff6f56823a820d7e3be9bef015"
-  integrity sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -8195,11 +8176,6 @@ lru-cache@^10.0.1, lru-cache@^10.2.0, lru-cache@^10.2.2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lru-cache@^11.0.0:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.0.2.tgz#fbd8e7cf8211f5e7e5d91905c415a3f55755ca39"
-  integrity sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==
-
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -8714,13 +8690,6 @@ minimatch@9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
-  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -9706,14 +9675,6 @@ path-scurry@^1.11.1, path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-scurry@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.0.tgz#9f052289f23ad8bf9397a2a0425e7b8615c58580"
-  integrity sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==
-  dependencies:
-    lru-cache "^11.0.0"
-    minipass "^7.1.2"
-
 path-to-regexp@0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
@@ -10633,13 +10594,12 @@ rimraf@^4.4.1:
   dependencies:
     glob "^9.2.0"
 
-rimraf@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
-  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
+rimraf@^5.0.10:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.10.tgz#23b9843d3dc92db71f96e1a2ce92e39fd2a8221c"
+  integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
   dependencies:
-    glob "^11.0.0"
-    package-json-from-dist "^1.0.0"
+    glob "^10.3.7"
 
 rollup@^4.0.2, rollup@^4.23.0:
   version "4.32.0"
@@ -11321,16 +11281,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11466,14 +11417,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12510,7 +12454,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12523,15 +12467,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Why

Define supported Node engines.

## What
* Define Node engines in package.json engines object
* Update Github action to  build/test against Node 18 as well. 
* Update Github action to  build/test against Node version ranges instead of a fixed version number
* Downgrade rimraf to V5 because starting [with V6 rimraf needs Node version >= 20](https://www.npmjs.com/package/rimraf). 
   - [This rimraf version has no known CVEs](https://security.snyk.io/package/npm/rimraf/5.0.10)

## Links

- [Node EOL table](https://endoflife.date/nodejs) 

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
