### PR TITLE
chore: use Faro globalObject  instead of window object

### DIFF
--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { initializeFaro } from '@grafana/faro-core';
+import { globalObject, initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 import { FetchTransport, makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
@@ -135,7 +135,7 @@ describe('FetchInstrumentation', () => {
       };
     };
 
-    const requestUrl = window.location.origin + '/test';
+    const requestUrl = globalObject.location.origin + '/test';
 
     const actualResult = parseActualResult(
       instrumentation.buildRequestAndInit(new Request(requestUrl), {
@@ -257,7 +257,7 @@ describe('FetchInstrumentation', () => {
     const mockFetch = jest.fn();
     jest.spyOn(global, 'fetch').mockImplementationOnce(mockFetch);
 
-    window.fetch('https://grafana.com');
+    globalObject.fetch('https://grafana.com');
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
@@ -279,7 +279,7 @@ describe('FetchInstrumentation', () => {
     const mockPushEventApi = jest.fn();
     jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEventApi);
 
-    window.fetch('https://example.com');
+    globalObject.fetch('https://example.com');
 
     expect(mockPushEventApi).toHaveBeenCalledTimes(0);
   });

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -22,7 +22,7 @@ function isRequest(input: any): input is Request {
 export class FetchInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-fetch';
   readonly version = VERSION;
-  readonly originalFetch: WindowFetch = window.fetch.bind(globalObject);
+  readonly originalFetch: WindowFetch = globalObject.fetch.bind(globalObject);
   private ignoredUrls: FetchInstrumentationOptions['ignoredUrls'];
 
   constructor(private options?: FetchInstrumentationOptions) {
@@ -88,7 +88,7 @@ export class FetchInstrumentation extends BaseInstrumentation {
     }
 
     // add Faro RUM header to the request headers
-    const windowOrigin = window.location.origin;
+    const windowOrigin = globalObject.location.origin;
     const shouldAddRumHeaderToUrl = shouldPropagateRumHeaders(this.getRequestUrl(input), [
       ...(this.options?.propagateRumHeaderCorsUrls ?? []),
       windowOrigin,

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { initializeFaro } from '@grafana/faro-core';
+import { globalObject, initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 import { FetchTransport, makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
@@ -54,7 +54,7 @@ describe('XHRInstrumentation', () => {
 
     const xhr = new XMLHttpRequest();
     // auto adds rum headers to requests sent to the same origin
-    xhr.open('GET', window.location.origin + '/test');
+    xhr.open('GET', globalObject.location.origin + '/test');
     expect(mockFetchSpyOpen).toHaveBeenCalledTimes(1);
 
     xhr.send();

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import { BaseInstrumentation, faro, VERSION } from '@grafana/faro-core';
+import { BaseInstrumentation, faro, globalObject, VERSION } from '@grafana/faro-core';
 
 import { faroRumHeader, makeFaroRumHeaderValue, XHREventType, XHRInstrumentationOptions } from './types';
 import { parseXHREvent, parseXHRHeaders, shouldPropagateRumHeaders } from './utils';
@@ -70,7 +70,7 @@ export class XHRInstrumentation extends BaseInstrumentation {
         }
 
         // add Faro RUM header to the request headers
-        const windowOrigin = window.location.origin;
+        const windowOrigin = globalObject.location.origin;
         const shouldAddRumHeaderToUrl = shouldPropagateRumHeaders(requestUrl, [
           ...(instrumentation?.options?.propagateRumHeaderCorsUrls ?? []),
           windowOrigin,

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
@@ -1,3 +1,4 @@
+import { globalObject } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { initializeFaro } from '../../initialize';
@@ -8,7 +9,7 @@ describe('registerOnerror', () => {
   it('will preserve the old callback', () => {
     let called = false;
 
-    window.onerror = () => {
+    globalObject.onerror = () => {
       called = true;
     };
 
@@ -21,7 +22,7 @@ describe('registerOnerror', () => {
 
     registerOnerror(api);
 
-    window.onerror('boo', 'some file', 10, 10, new Error('boo'));
+    globalObject.onerror('boo', 'some file', 10, 10, new Error('boo'));
     expect(called).toBe(true);
     expect(transport.items).toHaveLength(1);
   });

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
@@ -1,4 +1,4 @@
-import { isString } from '@grafana/faro-core';
+import { globalObject, isString } from '@grafana/faro-core';
 import type { API, ExceptionStackFrame } from '@grafana/faro-core';
 
 import { unknownSymbolString } from './const';
@@ -7,9 +7,9 @@ import { getValueAndTypeFromMessage } from './getValueAndTypeFromMessage';
 import { buildStackFrame } from './stackFrames';
 
 export function registerOnerror(api: API): void {
-  const oldOnerror = window.onerror;
+  const oldOnerror = globalObject.onerror;
 
-  window.onerror = (...args) => {
+  globalObject.onerror = (...args) => {
     try {
       const [evt, source, lineno, colno, error] = args;
       let value: string | undefined;

--- a/packages/web-sdk/src/instrumentations/errors/registerOnunhandledrejection.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnunhandledrejection.ts
@@ -1,4 +1,4 @@
-import { ExceptionStackFrame, isPrimitive } from '@grafana/faro-core';
+import { ExceptionStackFrame, globalObject, isPrimitive } from '@grafana/faro-core';
 import type { API } from '@grafana/faro-core';
 
 import { primitiveUnhandledType, primitiveUnhandledValue } from './const';
@@ -6,7 +6,7 @@ import { getErrorDetails } from './getErrorDetails';
 import type { ExtendedPromiseRejectionEvent } from './types';
 
 export function registerOnunhandledrejection(api: API): void {
-  window.addEventListener('unhandledrejection', (evt: ExtendedPromiseRejectionEvent) => {
+  globalObject.addEventListener('unhandledrejection', (evt: ExtendedPromiseRejectionEvent) => {
     let error = evt;
 
     if (error.reason) {

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -1,6 +1,6 @@
 import { UAParser } from 'ua-parser-js';
 
-import { unknownString } from '@grafana/faro-core';
+import { globalObject, unknownString } from '@grafana/faro-core';
 import type { Meta, MetaBrowser, MetaItem } from '@grafana/faro-core';
 
 export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
@@ -21,8 +21,8 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       language: language ?? unknownString,
       mobile,
       brands: brands ?? unknownString,
-      viewportWidth: `${window.innerWidth}`,
-      viewportHeight: `${window.innerHeight}`,
+      viewportWidth: `${globalObject.innerWidth}`,
+      viewportHeight: `${globalObject.innerHeight}`,
     },
   };
 


### PR DESCRIPTION
## Why

Faro uses the window object in many places which can lead to issues if used in environments which don't provide a window object.

Faro's globalObject covers this and should be used instead of window.

## What

Replace usage of window.* with  globalObject.*

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests updated
- [x] Changelog updated
- [ ] Documentation updated
