### PR TITLE
chore(globalWindow): revert using Faro's globalObject

### DIFF
--- a/experimental/instrumentation-fetch/src/instrumentation.test.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { globalObject, initializeFaro } from '@grafana/faro-core';
+import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 import { FetchTransport, makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
@@ -135,7 +135,7 @@ describe('FetchInstrumentation', () => {
       };
     };
 
-    const requestUrl = globalObject.location.origin + '/test';
+    const requestUrl = window.location.origin + '/test';
 
     const actualResult = parseActualResult(
       instrumentation.buildRequestAndInit(new Request(requestUrl), {
@@ -257,7 +257,7 @@ describe('FetchInstrumentation', () => {
     const mockFetch = jest.fn();
     jest.spyOn(global, 'fetch').mockImplementationOnce(mockFetch);
 
-    globalObject.fetch('https://grafana.com');
+    window.fetch('https://grafana.com');
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
@@ -279,7 +279,7 @@ describe('FetchInstrumentation', () => {
     const mockPushEventApi = jest.fn();
     jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEventApi);
 
-    globalObject.fetch('https://example.com');
+    window.fetch('https://example.com');
 
     expect(mockPushEventApi).toHaveBeenCalledTimes(0);
   });

--- a/experimental/instrumentation-fetch/src/instrumentation.ts
+++ b/experimental/instrumentation-fetch/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import { BaseInstrumentation, faro, globalObject, isString, VERSION } from '@grafana/faro-core';
+import { BaseInstrumentation, faro, isString, VERSION } from '@grafana/faro-core';
 import type { Patterns } from '@grafana/faro-core';
 
 import {
@@ -22,7 +22,7 @@ function isRequest(input: any): input is Request {
 export class FetchInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-fetch';
   readonly version = VERSION;
-  readonly originalFetch: WindowFetch = globalObject.fetch.bind(globalObject);
+  readonly originalFetch: WindowFetch = window.fetch.bind(window);
   private ignoredUrls: FetchInstrumentationOptions['ignoredUrls'];
 
   constructor(private options?: FetchInstrumentationOptions) {
@@ -30,13 +30,13 @@ export class FetchInstrumentation extends BaseInstrumentation {
   }
 
   /**
-   * Initialize fetch instrumentation - globalObject.fetch becomes instrumented fetch, assign original fetch to globalObject.originalFetch
+   * Initialize fetch instrumentation - window.fetch becomes instrumented fetch, assign original fetch to window.originalFetch
    */
   initialize(): void {
     this.internalLogger.info('Initializing fetch instrumentation');
     this.ignoredUrls = [...(this.options?.ignoredUrls ?? []), ...(this.getTransportIgnoreUrls() ?? [])];
 
-    Object.defineProperty(globalObject, fetchGlobalObjectKey, {
+    Object.defineProperty(window, fetchGlobalObjectKey, {
       configurable: true,
       writable: this.options?.testing ? true : false, // necessary for testing, instrumented fetch should not be writeable by default
       value: this.instrumentFetch().bind(this),
@@ -88,7 +88,7 @@ export class FetchInstrumentation extends BaseInstrumentation {
     }
 
     // add Faro RUM header to the request headers
-    const windowOrigin = globalObject.location.origin;
+    const windowOrigin = window.location.origin;
     const shouldAddRumHeaderToUrl = shouldPropagateRumHeaders(this.getRequestUrl(input), [
       ...(this.options?.propagateRumHeaderCorsUrls ?? []),
       windowOrigin,

--- a/experimental/instrumentation-xhr/src/instrumentation.test.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { globalObject, initializeFaro } from '@grafana/faro-core';
+import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 import { FetchTransport, makeCoreConfig, SessionInstrumentation } from '@grafana/faro-web-sdk';
 
@@ -54,7 +54,7 @@ describe('XHRInstrumentation', () => {
 
     const xhr = new XMLHttpRequest();
     // auto adds rum headers to requests sent to the same origin
-    xhr.open('GET', globalObject.location.origin + '/test');
+    xhr.open('GET', window.location.origin + '/test');
     expect(mockFetchSpyOpen).toHaveBeenCalledTimes(1);
 
     xhr.send();

--- a/experimental/instrumentation-xhr/src/instrumentation.ts
+++ b/experimental/instrumentation-xhr/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import { BaseInstrumentation, faro, globalObject, VERSION } from '@grafana/faro-core';
+import { BaseInstrumentation, faro, VERSION } from '@grafana/faro-core';
 
 import { faroRumHeader, makeFaroRumHeaderValue, XHREventType, XHRInstrumentationOptions } from './types';
 import { parseXHREvent, parseXHRHeaders, shouldPropagateRumHeaders } from './utils';
@@ -70,7 +70,7 @@ export class XHRInstrumentation extends BaseInstrumentation {
         }
 
         // add Faro RUM header to the request headers
-        const windowOrigin = globalObject.location.origin;
+        const windowOrigin = window.location.origin;
         const shouldAddRumHeaderToUrl = shouldPropagateRumHeaders(requestUrl, [
           ...(instrumentation?.options?.propagateRumHeaderCorsUrls ?? []),
           windowOrigin,

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
@@ -1,4 +1,3 @@
-import { globalObject } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { initializeFaro } from '../../initialize';
@@ -9,7 +8,7 @@ describe('registerOnerror', () => {
   it('will preserve the old callback', () => {
     let called = false;
 
-    globalObject.onerror = () => {
+    window.onerror = () => {
       called = true;
     };
 
@@ -22,7 +21,7 @@ describe('registerOnerror', () => {
 
     registerOnerror(api);
 
-    globalObject.onerror('boo', 'some file', 10, 10, new Error('boo'));
+    window.onerror('boo', 'some file', 10, 10, new Error('boo'));
     expect(called).toBe(true);
     expect(transport.items).toHaveLength(1);
   });

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
@@ -1,4 +1,4 @@
-import { globalObject, isString } from '@grafana/faro-core';
+import { isString } from '@grafana/faro-core';
 import type { API, ExceptionStackFrame } from '@grafana/faro-core';
 
 import { unknownSymbolString } from './const';
@@ -7,9 +7,9 @@ import { getValueAndTypeFromMessage } from './getValueAndTypeFromMessage';
 import { buildStackFrame } from './stackFrames';
 
 export function registerOnerror(api: API): void {
-  const oldOnerror = globalObject.onerror;
+  const oldOnerror = window.onerror;
 
-  globalObject.onerror = (...args) => {
+  window.onerror = (...args) => {
     try {
       const [evt, source, lineno, colno, error] = args;
       let value: string | undefined;

--- a/packages/web-sdk/src/instrumentations/errors/registerOnunhandledrejection.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnunhandledrejection.ts
@@ -1,4 +1,4 @@
-import { ExceptionStackFrame, globalObject, isPrimitive } from '@grafana/faro-core';
+import { ExceptionStackFrame, isPrimitive } from '@grafana/faro-core';
 import type { API } from '@grafana/faro-core';
 
 import { primitiveUnhandledType, primitiveUnhandledValue } from './const';
@@ -6,7 +6,7 @@ import { getErrorDetails } from './getErrorDetails';
 import type { ExtendedPromiseRejectionEvent } from './types';
 
 export function registerOnunhandledrejection(api: API): void {
-  globalObject.addEventListener('unhandledrejection', (evt: ExtendedPromiseRejectionEvent) => {
+  window.addEventListener('unhandledrejection', (evt: ExtendedPromiseRejectionEvent) => {
     let error = evt;
 
     if (error.reason) {

--- a/packages/web-sdk/src/metas/browser/meta.ts
+++ b/packages/web-sdk/src/metas/browser/meta.ts
@@ -1,6 +1,6 @@
 import { UAParser } from 'ua-parser-js';
 
-import { globalObject, unknownString } from '@grafana/faro-core';
+import { unknownString } from '@grafana/faro-core';
 import type { Meta, MetaBrowser, MetaItem } from '@grafana/faro-core';
 
 export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
@@ -21,8 +21,8 @@ export const browserMeta: MetaItem<Pick<Meta, 'browser'>> = () => {
       language: language ?? unknownString,
       mobile,
       brands: brands ?? unknownString,
-      viewportWidth: `${globalObject.innerWidth}`,
-      viewportHeight: `${globalObject.innerHeight}`,
+      viewportWidth: `${window.innerWidth}`,
+      viewportHeight: `${window.innerHeight}`,
     },
   };
 


### PR DESCRIPTION
## Why

Revert the [former change](https://github.com/grafana/faro-web-sdk/pull/914/files) to use Faro's globalObject

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
