### PR TITLE
chore: revert add custom error serializer to console instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Next
 
-- Feature (`@grafana/faro-web-sdk`): Add `errorSerializer` to the `consoleInstrumentation` property of the core
-  configuration object to provide custom ways to serialize data captured by the `ConsoleInstrumentation` (#902)
 - Feature (`@grafana/faro-web-sdk`): Provide APIs to send `service.name` override instructions to the
   receiver (#893)
 - Improvement (`@grafana/faro-web-sdk`): Send an event for `service.name` overrides (#903)

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -179,11 +179,6 @@ export interface Config<P = APIEvent> {
      * By default, Faro sends an error for console.error calls. If you want to send a log instead, set this to true.
      */
     consoleErrorAsLog?: boolean;
-
-    /**
-     * Custom function to serialize the contents of error messages
-     */
-    errorSerializer?: LogArgsSerializer;
   };
 }
 

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -168,4 +168,3 @@ export {
 } from './instrumentations/session';
 
 export { getIgnoreUrls } from './utils/url';
-export { stringifyExternalJson } from './utils/json';

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.test.ts
@@ -3,7 +3,6 @@ import type { ExceptionEvent, LogEvent } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { makeCoreConfig } from '../../config';
-import { stringifyExternalJson } from '../../utils';
 
 import { ConsoleInstrumentation } from './instrumentation';
 
@@ -79,37 +78,6 @@ describe('ConsoleInstrumentation', () => {
 
     expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
       'console.error: with circular refs object [object Object]'
-    );
-  });
-
-  it('Handles objects with circular references with custom serializer', () => {
-    const mockTransport = new MockTransport();
-
-    initializeFaro(
-      makeCoreConfig(
-        mockConfig({
-          transports: [mockTransport],
-          instrumentations: [
-            new ConsoleInstrumentation({
-              errorSerializer: (args: any[]) => {
-                return args.map((arg) => (typeof arg === 'string' ? arg : stringifyExternalJson(arg))).join(' ');
-              },
-            }),
-          ],
-          unpatchedConsole: {
-            error: jest.fn(),
-          } as unknown as Console,
-        })
-      )!
-    );
-
-    const objWithCircularRef = { foo: 'bar', baz: 'bam' };
-    (objWithCircularRef as any).circular = objWithCircularRef;
-
-    console.error('with circular refs object', objWithCircularRef);
-
-    expect((mockTransport.items[0] as TransportItem<ExceptionEvent>)?.payload.value).toBe(
-      `console.error: with circular refs object {\"foo\":\"bar\",\"baz\":\"bam\",\"circular\":null}`
     );
   });
 

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -1,11 +1,4 @@
-import {
-  allLogLevels,
-  BaseInstrumentation,
-  defaultLogArgsSerializer,
-  LogArgsSerializer,
-  LogLevel,
-  VERSION,
-} from '@grafana/faro-core';
+import { allLogLevels, BaseInstrumentation, defaultLogArgsSerializer, LogLevel, VERSION } from '@grafana/faro-core';
 
 import type { ConsoleInstrumentationOptions } from './types';
 
@@ -14,7 +7,6 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
 
   static defaultDisabledLevels: LogLevel[] = [LogLevel.DEBUG, LogLevel.TRACE, LogLevel.LOG];
-  private errorSerializer: LogArgsSerializer = defaultLogArgsSerializer;
 
   constructor(private options: ConsoleInstrumentationOptions = {}) {
     super();
@@ -23,7 +15,6 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
   initialize() {
     this.logDebug('Initializing\n', this.options);
     this.options = { ...this.options, ...this.config.consoleInstrumentation };
-    this.errorSerializer = this.options.errorSerializer ?? defaultLogArgsSerializer;
 
     allLogLevels
       .filter(
@@ -34,7 +25,7 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
         console[level] = (...args) => {
           try {
             if (level === LogLevel.ERROR && !this.options?.consoleErrorAsLog) {
-              this.api.pushError(new Error('console.error: ' + this.errorSerializer(args)));
+              this.api.pushError(new Error('console.error: ' + defaultLogArgsSerializer(args)));
             } else {
               this.api.pushLog(args, { level });
             }


### PR DESCRIPTION
Reverts grafana/faro-web-sdk#902

reverting this PR in favor of #904 - that PR accomplishes what this PR intended to do and is more in line with the correct functionality 