### PR TITLE
fix: demo build during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Improvement (`@grafana/faro-web-sdk`): Send an event for `service.name` overrides (#903)
 - Improvement (`@grafana/faro-*`) Add required Node engines to package.json ()
 - Feature (`@grafana/faro-web-sdk`) Adds the option to provide an serializer to serialize console error properties (#901)
+- Fix (`faro demo`): Add missing json files to Docker image (#925).
 
 ## 1.12.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN touch index.scss ${DEMO_DEMO_PATH}/src/client
 # Packages - Core
 COPY ${DEMO_PACKAGES_CORE_PATH}/package.json \
      ${DEMO_PACKAGES_CORE_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_CORE_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_CORE_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_CORE_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_CORE_PATH}/tsconfig.spec.json \
@@ -71,6 +72,7 @@ RUN cp index.ts ${DEMO_PACKAGES_CORE_PATH}/src
 # Packages - React
 COPY ${DEMO_PACKAGES_REACT_PATH}/package.json \
      ${DEMO_PACKAGES_REACT_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_REACT_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_REACT_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_REACT_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_REACT_PATH}/tsconfig.spec.json \
@@ -83,6 +85,7 @@ RUN cp index.ts ${DEMO_PACKAGES_REACT_PATH}/src
 # Packages - Web Sdk
 COPY ${DEMO_PACKAGES_WEB_SDK_PATH}/package.json \
      ${DEMO_PACKAGES_WEB_SDK_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_WEB_SDK_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_WEB_SDK_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_WEB_SDK_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_WEB_SDK_PATH}/tsconfig.spec.json \
@@ -95,6 +98,7 @@ RUN cp index.ts ${DEMO_PACKAGES_WEB_SDK_PATH}/src
 # Packages - Web Tracing
 COPY ${DEMO_PACKAGES_WEB_TRACING_PATH}/package.json \
      ${DEMO_PACKAGES_WEB_TRACING_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_WEB_TRACING_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_WEB_TRACING_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_WEB_TRACING_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_WEB_TRACING_PATH}/tsconfig.spec.json \
@@ -107,6 +111,7 @@ RUN cp index.ts ${DEMO_PACKAGES_WEB_TRACING_PATH}/src
 # Packages - Experimental Fetch Instrumentation
 COPY ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/package.json \
      ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/tsconfig.spec.json \
@@ -119,6 +124,7 @@ RUN cp index.ts ${DEMO_PACKAGES_FETCH_INSTRUMENTATION_PATH}/src
 # Packages - Experimental XHR Instrumentation
 COPY ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/package.json \
      ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/rollup.config.js \
+     ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/tsconfig.bundle.json \
      ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/tsconfig.cjs.json \
      ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/tsconfig.esm.json \
      ${DEMO_PACKAGES_XHR_INSTRUMENTATION_PATH}/tsconfig.spec.json \


### PR DESCRIPTION
## Why

When running `docker compose --profile demo up -d` the following error was encountered:
```
[!] Error: Could not find specified tsconfig.json at /usr/app/experimental/instrumentation-xhr/tsconfig.bundle.json
    at getTsConfigPath (/usr/app/node_modules/@rollup/plugin-typescript/dist/cjs/index.js:270:19)
    at parseTypescriptConfig (/usr/app/node_modules/@rollup/plugin-typescript/dist/cjs/index.js:344:26)
    at typescript (/usr/app/node_modules/@rollup/plugin-typescript/dist/cjs/index.js:800:27)
    at exports.getRollupConfigBase (/usr/app/rollup.config.base.js:86:7)
    at Object.<anonymous> (/usr/app/experimental/instrumentation-xhr/rollup.config.js:3:18)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1104:12)
    at cjsLoader (node:internal/modules/esm/translators:346:17)
```
## What

Add the missing `*.bundle.json` files to the Docker image.

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated