### PR TITLE
fix: add error context attributes stringifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): The optional context object in the `pushError` API now correctly
+  stringifies all provided values (#944)
+
 ## 1.13.1
 
 - Fix (`@grafana/faro-web-sdk`): Corrected the `setPage()` API to update the `page.id` properly and

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -234,6 +234,41 @@ describe('api.exceptions', () => {
         expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
         expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
       });
+
+      it('stringifies all values added to the context', () => {
+        api.pushError(new Error('Error with context'), {
+          context: {
+            // @ts-expect-error
+            a: 1,
+            b: 'foo',
+            // @ts-expect-error
+            c: true,
+            // @ts-expect-error
+            d: { e: 'bar' },
+            // @ts-expect-error
+            g: null,
+            // @ts-expect-error
+            h: undefined,
+            // @ts-expect-error
+            i: [1, 2, 3],
+          },
+        });
+
+        const context = (transport.items[0]?.payload as ExceptionEvent)?.context;
+        expect(context).toStrictEqual({
+          a: '1',
+          b: 'foo',
+          c: 'true',
+          d: '{"e":"bar"}',
+          g: 'null',
+          h: 'undefined',
+          i: '[1,2,3]',
+        });
+
+        Object.values(context ?? {}).forEach((value) => {
+          expect(typeof value).toBe('string');
+        });
+      });
     });
   });
 });

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -4,7 +4,16 @@ import type { Metas } from '../../metas';
 import { TransportItemType } from '../../transports';
 import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isArray, isError, isNull, isObject, stringifyObjectValues } from '../../utils';
+import {
+  deepEqual,
+  getCurrentTimestamp,
+  isArray,
+  isError,
+  isNull,
+  isObject,
+  stringifyExternalJson,
+  stringifyObjectValues,
+} from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -105,7 +114,7 @@ function parseCause(error: ErrorWithIndexProperties): {} | { cause: string } {
     // typeof operator on null returns "object". This is a well-known quirk in JavaScript and is considered a bug that cannot be fixed due to backward compatibility issues.
     // MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
   } else if (cause !== null && (isObject(error.cause) || isArray(error.cause))) {
-    cause = JSON.stringify(error.cause);
+    cause = stringifyExternalJson(error.cause);
   } else if (cause != null) {
     cause = error.cause.toString();
   }

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -4,7 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItemType } from '../../transports';
 import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isArray, isError, isNull, isObject } from '../../utils';
+import { deepEqual, getCurrentTimestamp, isArray, isError, isNull, isObject, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -53,10 +53,10 @@ export function initializeExceptionsAPI(
               span_id: spanContext.spanId,
             }
           : tracesApi.getTraceContext(),
-        context: {
+        context: stringifyObjectValues({
           ...parseCause(error),
           ...(context ?? {}),
-        },
+        }),
       },
       type: TransportItemType.EXCEPTION,
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,7 @@ export {
   isEmpty,
   getCircularDependencyReplacer,
   stringifyExternalJson,
+  stringifyObjectValues,
 } from './utils';
 export type {
   BaseObject,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -50,4 +50,4 @@ export { getBundleId } from './sourceMaps';
 
 export { dateNow } from './date';
 
-export { getCircularDependencyReplacer, stringifyExternalJson } from './json';
+export { getCircularDependencyReplacer, stringifyExternalJson, stringifyObjectValues } from './json';

--- a/packages/core/src/utils/json.test.ts
+++ b/packages/core/src/utils/json.test.ts
@@ -1,4 +1,4 @@
-import { getCircularDependencyReplacer, stringifyExternalJson } from './json';
+import { getCircularDependencyReplacer, stringifyExternalJson, stringifyObjectValues } from './json';
 
 describe('json', () => {
   it('replace circular references with null value', () => {
@@ -15,5 +15,22 @@ describe('json', () => {
     (obj as any).circular = obj;
 
     expect(stringifyExternalJson(obj)).toBe('{"a":1,"circular":null}');
+  });
+
+  it('stringifyObjectValues function stringifies object values', () => {
+    const obj = { a: 1, b: { c: 2 }, d: 'foo', e: true, f: [true, 'a', 1] };
+
+    const objectWithStringifiedValues = stringifyObjectValues(obj);
+    expect(objectWithStringifiedValues).toStrictEqual({
+      a: '1',
+      b: '{"c":2}',
+      d: 'foo',
+      e: 'true',
+      f: '[true,\"a\",1]',
+    });
+
+    Object.values(objectWithStringifiedValues).forEach((key) => {
+      expect(typeof key).toBe('string');
+    });
   });
 });

--- a/packages/core/src/utils/json.test.ts
+++ b/packages/core/src/utils/json.test.ts
@@ -18,7 +18,7 @@ describe('json', () => {
   });
 
   it('stringifyObjectValues function stringifies object values', () => {
-    const obj = { a: 1, b: { c: 2 }, d: 'foo', e: true, f: [true, 'a', 1] };
+    const obj = { a: 1, b: { c: 2 }, d: 'foo', e: true, f: [true, 'a', 1], g: null };
 
     const objectWithStringifiedValues = stringifyObjectValues(obj);
     expect(objectWithStringifiedValues).toStrictEqual({
@@ -27,6 +27,7 @@ describe('json', () => {
       d: 'foo',
       e: 'true',
       f: '[true,\"a\",1]',
+      g: 'null',
     });
 
     Object.values(objectWithStringifiedValues).forEach((key) => {

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -27,7 +27,7 @@ export function stringifyObjectValues(obj: Record<string, unknown> = {}) {
   const o: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(obj)) {
-    o[key] = isObject(value) ? JSON.stringify(value) : String(value);
+    o[key] = isObject(value) ? stringifyExternalJson(value) : String(value);
   }
 
   return o;

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -23,10 +23,12 @@ export function stringifyExternalJson(json: any = {}) {
   return JSON.stringify(json ?? {}, getCircularDependencyReplacer());
 }
 
-export function stringifyObjectValues(obj: any = {}) {
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => {
-      return [key, isObject(value) ? JSON.stringify(value) : String(value)];
-    })
-  );
+export function stringifyObjectValues(obj: Record<string, unknown> = {}) {
+  const o: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    o[key] = isObject(value) ? JSON.stringify(value) : String(value);
+  }
+
+  return o;
 }

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -1,3 +1,5 @@
+import { isObject } from './is';
+
 export function getCircularDependencyReplacer() {
   const valueSeen = new WeakSet();
   return function (_key: string | Symbol, value: unknown) {
@@ -19,4 +21,12 @@ type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
 
 export function stringifyExternalJson(json: any = {}) {
   return JSON.stringify(json ?? {}, getCircularDependencyReplacer());
+}
+
+export function stringifyObjectValues(obj: any = {}) {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      return [key, isObject(value) ? JSON.stringify(value) : String(value)];
+    })
+  );
 }

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -3,7 +3,7 @@ import { isObject } from './is';
 export function getCircularDependencyReplacer() {
   const valueSeen = new WeakSet();
   return function (_key: string | Symbol, value: unknown) {
-    if (typeof value === 'object' && value !== null) {
+    if (isObject(value) && value !== null) {
       if (valueSeen.has(value)) {
         return null;
       }
@@ -27,7 +27,7 @@ export function stringifyObjectValues(obj: Record<string, unknown> = {}) {
   const o: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(obj)) {
-    o[key] = isObject(value) ? stringifyExternalJson(value) : String(value);
+    o[key] = isObject(value) && value !== null ? stringifyExternalJson(value) : String(value);
   }
 
   return o;


### PR DESCRIPTION
## Why

The optional context object users can add to an error can only be a flat object containing values of type string.
In this case the receiver rejects the requests with a status 400

Especially when using the Faro cdn version there's no type checking and a build in place so users wouldn't be aware in advance if a value is possibly not of type string.

**Note:**
For now we keep a fixed stringifier. If we get proof that users need to be able to inject a custom stringifier we add that functionality  

## What

* Auto stringify all context values


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
