### PR TITLE
chore: transform all properties in `context` and `attributes` objects to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+## 1.13.3
+
+- Chore (`@grafana/faro-web-sdk`): Ensure all properties in `attributes` and `context` objects are
+  stringified when sending custom signals (#952)
+
 ## 1.13.2
 
 - Fix (`@grafana/faro-web-sdk`): The optional context object in the `pushError` API now correctly

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -121,6 +121,35 @@ describe('api.events', () => {
         expect(transport.items).toHaveLength(1);
         expect((transport.items[0]?.payload as EventEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
       });
+
+      it('stringifies all values in the attributes object', () => {
+        api.pushEvent('test', {
+          // @ts-expect-error
+          a: 1,
+          b: 'foo',
+          // @ts-expect-error
+          c: true,
+          // @ts-expect-error
+          d: { e: 'bar' },
+          // @ts-expect-error
+          g: null,
+          // @ts-expect-error
+          h: undefined,
+          // @ts-expect-error
+          i: [1, 2, 3],
+        });
+
+        // @ts-expect-error
+        expect(transport.items[0]?.payload.attributes).toStrictEqual({
+          a: '1',
+          b: 'foo',
+          c: 'true',
+          d: '{"e":"bar"}',
+          g: 'null',
+          h: 'undefined',
+          i: '[1,2,3]',
+        });
+      });
     });
   });
 });

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -3,7 +3,7 @@ import type { InternalLogger } from '../../internalLogger';
 import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isNull } from '../../utils';
+import { deepEqual, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -31,7 +31,7 @@ export function initializeEventsAPI(
         payload: {
           name,
           domain: domain ?? config.eventDomain,
-          attributes,
+          attributes: stringifyObjectValues(attributes),
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -131,9 +131,40 @@ describe('api.logs', () => {
     });
 
     it('Sets the timestamp to the provided custom timestamp', () => {
-      api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+      api.pushLog(['test'], { timestampOverwriteMs: 123 });
       expect(transport.items).toHaveLength(1);
       expect((transport.items[0]?.payload as LogEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+    });
+
+    it('stringifies all values in the context object', () => {
+      api.pushLog(['test'], {
+        context: {
+          // @ts-expect-error
+          a: 1,
+          b: 'foo',
+          // @ts-expect-error
+          c: true,
+          // @ts-expect-error
+          d: { e: 'bar' },
+          // @ts-expect-error
+          g: null,
+          // @ts-expect-error
+          h: undefined,
+          // @ts-expect-error
+          i: [1, 2, 3],
+        },
+      });
+
+      // @ts-expect-error
+      expect(transport.items[0]?.payload.context).toStrictEqual({
+        a: '1',
+        b: 'foo',
+        c: 'true',
+        d: '{"e":"bar"}',
+        g: 'null',
+        h: 'undefined',
+        i: '[1,2,3]',
+      });
     });
   });
 });

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -4,7 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType } from '../../transports';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, defaultLogLevel, getCurrentTimestamp, isNull } from '../../utils';
+import { deepEqual, defaultLogLevel, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -35,7 +35,7 @@ export function initializeLogsAPI(
         payload: {
           message: logArgsSerializer(args),
           level: level ?? defaultLogLevel,
-          context: context ?? {},
+          context: stringifyObjectValues(context),
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -194,9 +194,46 @@ describe('api.measurements', () => {
     });
 
     it('Sets the timestamp to the provided custom timestamp', () => {
-      api.pushEvent('test', undefined, undefined, { timestampOverwriteMs: 123 });
+      api.pushMeasurement(
+        {
+          type: 'custom',
+          values: {
+            a: 1,
+          },
+        },
+        { timestampOverwriteMs: 123 }
+      );
       expect(transport.items).toHaveLength(1);
       expect((transport.items[0]?.payload as MeasurementEvent).timestamp).toBe('1970-01-01T00:00:00.123Z');
+    });
+
+    it('stringifies all values in the attributes object', () => {
+      api.pushEvent('test', {
+        // @ts-expect-error
+        a: 1,
+        b: 'foo',
+        // @ts-expect-error
+        c: true,
+        // @ts-expect-error
+        d: { e: 'bar' },
+        // @ts-expect-error
+        g: null,
+        // @ts-expect-error
+        h: undefined,
+        // @ts-expect-error
+        i: [1, 2, 3],
+      });
+
+      // @ts-expect-error
+      expect(transport.items[0]?.payload.attributes).toStrictEqual({
+        a: '1',
+        b: 'foo',
+        c: 'true',
+        d: '{"e":"bar"}',
+        g: 'null',
+        h: 'undefined',
+        i: '[1,2,3]',
+      });
     });
   });
 });

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -4,7 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType } from '../../transports';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isNull } from '../../utils';
+import { deepEqual, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -38,7 +38,7 @@ export function initializeMeasurementsAPI(
               }
             : tracesApi.getTraceContext(),
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
-          context: context ?? {},
+          context: stringifyObjectValues(context),
         },
         meta: metas.value,
       };

--- a/packages/core/src/utils/json.test.ts
+++ b/packages/core/src/utils/json.test.ts
@@ -34,4 +34,8 @@ describe('json', () => {
       expect(typeof key).toBe('string');
     });
   });
+
+  it('stringifyObjectValues function return an empty object if parameter is undefined', () => {
+    expect(stringifyObjectValues()).toStrictEqual({});
+  });
 });


### PR DESCRIPTION
## Why

Add a property stringifier for `attributes` and `context` to all Faro APIs

## What


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
