### PR TITLE
feat: Include web-tracing into the default instrumentations

### DIFF
--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -153,57 +153,64 @@ export interface Config<P = APIEvent> {
 
   eventDomain?: string;
 
-  /**
-   * Only resource timings for fetch and xhr requests are tracked by default. Set this to true to track all resources (default: false).
-   */
-  trackResources?: boolean;
+  // /**
+  //  * Only resource timings for fetch and xhr requests are tracked by default. Set this to true to track all resources (default: false).
+  //  */
+  // trackResources?: boolean;
 
-  /**
-   * Track web vitals attribution data (default: false)
-   */
-  trackWebVitalsAttribution?: boolean;
+  // /**
+  //  * Track web vitals attribution data (default: false)
+  //  */
+  // trackWebVitalsAttribution?: boolean;
 
-  /**
-   * Configuration for the console instrumentation
-   */
-  consoleInstrumentation?: {
-    /**
-     * Configure what console levels should be captured by Faro. By default the follwoing levels
-     * are disabled: console.debug, console.trace, console.log
-     *
-     * If you want to collect all levels set captureConsoleDisabledLevels: [];
-     * If you want to disable only some levels set captureConsoleDisabledLevels: [LogLevel.DEBUG, LogLevel.TRACE];
-     */
-    disabledLevels?: LogLevel[];
-    /*
-     * By default, Faro sends an error for console.error calls. If you want to send a log instead, set this to true.
-     */
-    consoleErrorAsLog?: boolean;
+  // /**
+  //  * Configuration for the console instrumentation
+  //  */
+  // consoleInstrumentation?: {
+  //   /**
+  //    * Configure what console levels should be captured by Faro. By default the follwoing levels
+  //    * are disabled: console.debug, console.trace, console.log
+  //    *
+  //    * If you want to collect all levels set captureConsoleDisabledLevels: [];
+  //    * If you want to disable only some levels set captureConsoleDisabledLevels: [LogLevel.DEBUG, LogLevel.TRACE];
+  //    */
+  //   disabledLevels?: LogLevel[];
+  //   /*
+  //    * By default, Faro sends an error for console.error calls. If you want to send a log instead, set this to true.
+  //    */
+  //   consoleErrorAsLog?: boolean;
 
-    /**
-     * If true, use the default Faro error serializer for console.error calls. If false, simply call toString() on the error arguments.
-     * If enabled, payloads containing serialized errors may become very large. If left disabled, some error details may be lost.
-     * (default: false)
-     */
-    serializeErrors?: boolean;
+  //   /**
+  //    * If true, use the default Faro error serializer for console.error calls. If false, simply call toString() on the error arguments.
+  //    * If enabled, payloads containing serialized errors may become very large. If left disabled, some error details may be lost.
+  //    * (default: false)
+  //    */
+  //   serializeErrors?: boolean;
 
-    /**
-     * Custom function to serialize Error arguments
-     */
-    errorSerializer?: LogArgsSerializer;
-  };
+  //   /**
+  //    * Custom function to serialize Error arguments
+  //    */
+  //   errorSerializer?: LogArgsSerializer;
+  // };
 
-  pageTracking?: {
-    /**
-     * The page meta for initial page settings
-     */
-    page?: MetaPage;
+  // pageTracking?: {
+  //   /**
+  //    * The page meta for initial page settings
+  //    */
+  //   page?: MetaPage;
 
-    /**
-     * Allows to provide a template for the page id
-     */
-    generatePageId?: (location: Location) => string;
-  };
+  //   /**
+  //    * Allows to provide a template for the page id
+  //    */
+  //   generatePageId?: (location: Location) => string;
+  // };
+
+  // webTracingInstrumentation?: {
+  //   /**
+  //    * Enable tracing instrumentation (default: true)
+  //    */
+  //   enabled?: boolean;
+  // };
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,10 +1,9 @@
 import type { APIEvent, LogArgsSerializer, StacktraceParser } from '../api';
 import type { Instrumentation } from '../instrumentations';
 import type { InternalLoggerLevel } from '../internalLogger';
-import type { Meta, MetaApp, MetaItem, MetaPage, MetaSession, MetaUser, MetaView } from '../metas';
+import type { Meta, MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '../metas';
 import type { BatchExecutorOptions, BeforeSendHook, Transport } from '../transports';
 import type { UnpatchedConsole } from '../unpatchedConsole';
-import type { LogLevel } from '../utils';
 
 type SamplingContext = {
   metas: Meta;
@@ -99,118 +98,6 @@ export interface Config<P = APIEvent> {
    * Path patterns for Endpoints that should be ignored form being tracked
    */
   ignoreUrls?: Patterns;
-
-  /**
-   * Configuration for the built in session tracker
-   */
-  sessionTracking?: {
-    /**
-     * Enable session tracking (default: true)
-     */
-    enabled?: boolean;
-    /**
-     * Wether to use sticky sessions (default: false)
-     */
-    persistent?: boolean;
-    /**
-     * Session metadata object to be used when initializing session tracking
-     */
-    session?: MetaSession;
-    /**
-     * How long is a sticky session valid for recurring users (default: 15 minutes)
-     */
-    maxSessionPersistenceTime?: number;
-    /**
-     * Called each time a session changes. This can be when a new session is created or when an existing session is updated.
-     * @param oldSession
-     * @param newSession
-     */
-    onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
-    /**
-     * Then sampling rate for the session based sampler (default: 1). If a session is not part of a sample, no signals for this session are tracked.
-     */
-    samplingRate?: number;
-    /**
-     * Custom sampler function if custom sampling logic is needed.
-     * @param context
-     */
-    sampler?: (context: SamplingContext) => number;
-    /**
-     * Custom function to generate session id. If available Faro uses this function instead of the internal one.
-     */
-    generateSessionId?: () => string;
-  };
-
-  /**
-   * Meta object for user data
-   */
-  user?: MetaUser;
-
-  /**
-   * Meta object for view data
-   */
-  view?: MetaView;
-
-  eventDomain?: string;
-
-  // /**
-  //  * Only resource timings for fetch and xhr requests are tracked by default. Set this to true to track all resources (default: false).
-  //  */
-  // trackResources?: boolean;
-
-  // /**
-  //  * Track web vitals attribution data (default: false)
-  //  */
-  // trackWebVitalsAttribution?: boolean;
-
-  // /**
-  //  * Configuration for the console instrumentation
-  //  */
-  // consoleInstrumentation?: {
-  //   /**
-  //    * Configure what console levels should be captured by Faro. By default the follwoing levels
-  //    * are disabled: console.debug, console.trace, console.log
-  //    *
-  //    * If you want to collect all levels set captureConsoleDisabledLevels: [];
-  //    * If you want to disable only some levels set captureConsoleDisabledLevels: [LogLevel.DEBUG, LogLevel.TRACE];
-  //    */
-  //   disabledLevels?: LogLevel[];
-  //   /*
-  //    * By default, Faro sends an error for console.error calls. If you want to send a log instead, set this to true.
-  //    */
-  //   consoleErrorAsLog?: boolean;
-
-  //   /**
-  //    * If true, use the default Faro error serializer for console.error calls. If false, simply call toString() on the error arguments.
-  //    * If enabled, payloads containing serialized errors may become very large. If left disabled, some error details may be lost.
-  //    * (default: false)
-  //    */
-  //   serializeErrors?: boolean;
-
-  //   /**
-  //    * Custom function to serialize Error arguments
-  //    */
-  //   errorSerializer?: LogArgsSerializer;
-  // };
-
-  // pageTracking?: {
-  //   /**
-  //    * The page meta for initial page settings
-  //    */
-  //   page?: MetaPage;
-
-  //   /**
-  //    * Allows to provide a template for the page id
-  //    */
-  //   generatePageId?: (location: Location) => string;
-  // };
-
-  // webTracingInstrumentation?: {
-  //   /**
-  //    * Enable tracing instrumentation (default: true)
-  //    */
-  //   enabled?: boolean;
-  // };
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -98,6 +98,18 @@ export interface Config<P = APIEvent> {
    * Path patterns for Endpoints that should be ignored form being tracked
    */
   ignoreUrls?: Patterns;
+
+  /**
+   * Meta object for user data
+   */
+  user?: MetaUser;
+
+  /**
+   * Meta object for view data
+   */
+  view?: MetaView;
+
+  eventDomain?: string;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,9 +1,10 @@
 import type { APIEvent, LogArgsSerializer, StacktraceParser } from '../api';
 import type { Instrumentation } from '../instrumentations';
 import type { InternalLoggerLevel } from '../internalLogger';
-import type { Meta, MetaApp, MetaItem, MetaSession, MetaUser, MetaView } from '../metas';
+import type { Meta, MetaApp, MetaItem, MetaPage, MetaSession, MetaUser, MetaView } from '../metas';
 import type { BatchExecutorOptions, BeforeSendHook, Transport } from '../transports';
 import type { UnpatchedConsole } from '../unpatchedConsole';
+import type { LogLevel } from '../utils';
 
 type SamplingContext = {
   metas: Meta;
@@ -100,6 +101,47 @@ export interface Config<P = APIEvent> {
   ignoreUrls?: Patterns;
 
   /**
+   * Configuration for the built in session tracker
+   */
+  sessionTracking?: {
+    /**
+     * Enable session tracking (default: true)
+     */
+    enabled?: boolean;
+    /**
+     * Wether to use sticky sessions (default: false)
+     */
+    persistent?: boolean;
+    /**
+     * Session metadata object to be used when initializing session tracking
+     */
+    session?: MetaSession;
+    /**
+     * How long is a sticky session valid for recurring users (default: 15 minutes)
+     */
+    maxSessionPersistenceTime?: number;
+    /**
+     * Called each time a session changes. This can be when a new session is created or when an existing session is updated.
+     * @param oldSession
+     * @param newSession
+     */
+    onSessionChange?: (oldSession: MetaSession | null, newSession: MetaSession) => void;
+    /**
+     * Then sampling rate for the session based sampler (default: 1). If a session is not part of a sample, no signals for this session are tracked.
+     */
+    samplingRate?: number;
+    /**
+     * Custom sampler function if custom sampling logic is needed.
+     * @param context
+     */
+    sampler?: (context: SamplingContext) => number;
+    /**
+     * Custom function to generate session id. If available Faro uses this function instead of the internal one.
+     */
+    generateSessionId?: () => string;
+  };
+
+  /**
    * Meta object for user data
    */
   user?: MetaUser;
@@ -110,6 +152,65 @@ export interface Config<P = APIEvent> {
   view?: MetaView;
 
   eventDomain?: string;
+
+  /**
+   * Only resource timings for fetch and xhr requests are tracked by default. Set this to true to track all resources (default: false).
+   */
+  trackResources?: boolean;
+
+  /**
+   * Track web vitals attribution data (default: false)
+   */
+  trackWebVitalsAttribution?: boolean;
+
+  /**
+   * Configuration for the console instrumentation
+   */
+  consoleInstrumentation?: {
+    /**
+     * Configure what console levels should be captured by Faro. By default the follwoing levels
+     * are disabled: console.debug, console.trace, console.log
+     *
+     * If you want to collect all levels set captureConsoleDisabledLevels: [];
+     * If you want to disable only some levels set captureConsoleDisabledLevels: [LogLevel.DEBUG, LogLevel.TRACE];
+     */
+    disabledLevels?: LogLevel[];
+    /*
+     * By default, Faro sends an error for console.error calls. If you want to send a log instead, set this to true.
+     */
+    consoleErrorAsLog?: boolean;
+
+    /**
+     * If true, use the default Faro error serializer for console.error calls. If false, simply call toString() on the error arguments.
+     * If enabled, payloads containing serialized errors may become very large. If left disabled, some error details may be lost.
+     * (default: false)
+     */
+    serializeErrors?: boolean;
+
+    /**
+     * Custom function to serialize Error arguments
+     */
+    errorSerializer?: LogArgsSerializer;
+  };
+
+  pageTracking?: {
+    /**
+     * The page meta for initial page settings
+     */
+    page?: MetaPage;
+
+    /**
+     * Allows to provide a template for the page id
+     */
+    generatePageId?: (location: Location) => string;
+  };
+
+  webTracingInstrumentation?: {
+    /**
+     * Enable tracing instrumentation (default: true)
+     */
+    enabled?: boolean;
+  };
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -57,7 +57,18 @@
   "dependencies": {
     "@grafana/faro-core": "^1.13.3",
     "ua-parser-js": "^1.0.32",
-    "web-vitals": "^4.0.1"
+    "web-vitals": "^4.0.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-zone": "1.30.1",
+    "@opentelemetry/core": "^1.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/instrumentation": "^0.57.0",
+    "@opentelemetry/instrumentation-fetch": "^0.57.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.57.0",
+    "@opentelemetry/otlp-transformer": "^0.57.1",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-trace-web": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -5,6 +5,7 @@ import {
   ErrorsInstrumentation,
   PerformanceInstrumentation,
   SessionInstrumentation,
+  TracingInstrumentation,
   ViewInstrumentation,
   WebVitalsInstrumentation,
 } from '../instrumentations';
@@ -22,6 +23,11 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
   if (options.enablePerformanceInstrumentation !== false) {
     // unshift to ensure that initialization starts before the other instrumentations
     instrumentations.unshift(new PerformanceInstrumentation());
+  }
+
+  if (options.enablePerformanceInstrumentation !== false) {
+    // unshift to ensure that initialization starts before the other instrumentations
+    instrumentations.push(new TracingInstrumentation());
   }
 
   if (options.captureConsole !== false) {

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -12,6 +12,7 @@ import type { Config, LogArgsSerializer, LogLevel, MetaItem, MetaPage, Transport
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultSessionTrackingConfig } from '../instrumentations/session';
+import { TracingInstrumentationOptions } from '../instrumentations/webTracing';
 import { browserMeta } from '../metas';
 import { k6Meta } from '../metas/k6';
 import { createPageMeta } from '../metas/page';
@@ -79,7 +80,7 @@ type WebSdkConfig = Config & {
      * Enable tracing instrumentation (default: true)
      */
     enabled?: boolean;
-  };
+  } & TracingInstrumentationOptions;
 };
 
 export interface BrowserConfig

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -21,7 +21,7 @@ import type {
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultSessionTrackingConfig } from '../instrumentations/session';
-import { TracingInstrumentationOptions } from '../instrumentations/webTracing';
+import type { TracingInstrumentationOptions } from '../instrumentations/webTracing';
 import { browserMeta } from '../metas';
 import { k6Meta } from '../metas/k6';
 import { createPageMeta } from '../metas/page';

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -9,4 +9,5 @@ export interface GetWebInstrumentationsOptions {
   captureConsole?: boolean;
   captureConsoleDisabledLevels?: LogLevel[];
   enablePerformanceInstrumentation?: boolean;
+  enableWebTracing?: boolean;
 }

--- a/packages/web-sdk/src/instrumentations/console/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/console/instrumentation.ts
@@ -25,6 +25,7 @@ export class ConsoleInstrumentation extends BaseInstrumentation {
   }
 
   initialize() {
+    // TODO: we can make base instrumentation generic to inject Config
     this.options = { ...this.options, ...this.config.consoleInstrumentation };
 
     const serializeErrors = this.options?.serializeErrors || !!this.options?.errorSerializer;

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -27,3 +27,5 @@ export {
 } from './session';
 
 export { PerformanceInstrumentation } from './performance';
+
+export { TracingInstrumentation } from './webTracing';

--- a/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.ts
@@ -1,0 +1,24 @@
+import { ExportResultCode } from '@opentelemetry/core';
+import type { ExportResult } from '@opentelemetry/core';
+import { createExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/src/trace/internal';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
+
+import { sendFaroEvents } from './faroTraceExporter.utils';
+import type { FaroTraceExporterConfig } from './types';
+
+export class FaroTraceExporter implements SpanExporter {
+  constructor(private config: FaroTraceExporterConfig) {}
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    const traceEvent = createExportTraceServiceRequest(spans, { useHex: true, useLongBits: false });
+
+    this.config.api.pushTraces(traceEvent);
+    sendFaroEvents(traceEvent.resourceSpans);
+
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.test.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.test.ts
@@ -1,0 +1,431 @@
+import type { IResourceSpans, IScopeSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
+
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { sendFaroEvents } from './faroTraceExporter.utils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Emits no faro events if no client spans are contained ', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // remove scopeSpan which contains client span
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: testData[0]?.scopeSpans?.slice(0, -1) ?? [],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(0);
+  });
+
+  it('Creates a Faro event for client spans only', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    sendFaroEvents(testData);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.fetch');
+    expect(mockPushEvent.mock.lastCall[1]).toStrictEqual({
+      component: 'fetch',
+      session_id: 'my-session-id',
+      'http.host': 'my-host',
+      'http.method': 'GET',
+      'http.response_content_length': '127',
+      'http.scheme': 'http',
+      'http.status_code': '401',
+      'http.status_text': 'Unauthorized',
+      'http.url': 'http://foo/bar',
+      'http.user_agent': 'my-user-agent',
+      duration_ns: '15000064',
+    });
+  });
+
+  it('Uses whole instrumentation name if no "-" is part of the name', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const scopeSpans = testData[0]?.scopeSpans?.map((s) => ({ ...s })) ?? [];
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans,
+    };
+
+    if (scopeSpans.length === 0) {
+      throw new Error('Test data is invalid - scopeSpans should not be empty');
+    }
+    const lastScopeSpan = scopeSpans[scopeSpans.length - 1] as IScopeSpans & { scope: { name: string } };
+    lastScopeSpan.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.coolName');
+  });
+
+  it('Call Faro event API with traceID and spanID of contained in teh span', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const scopeSpans = testData[0]?.scopeSpans?.map((s) => ({ ...s })) ?? [];
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans,
+    };
+
+    if (scopeSpans.length === 0) {
+      throw new Error('Test data is invalid - scopeSpans should not be empty');
+    }
+    const lastScopeSpan = scopeSpans[scopeSpans.length - 1] as IScopeSpans & { scope: { name: string } };
+    lastScopeSpan.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[3]).toStrictEqual({
+      spanContext: {
+        spanId: '4c47d5f85e4b2aec',
+        traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+      },
+    });
+  });
+
+  it('Does not include duration when timestamps are missing', () => {
+    const faro = initializeFaro(mockConfig());
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: [
+        {
+          scope: {
+            name: '@opentelemetry/instrumentation-fetch',
+            version: '0.45.1',
+          },
+          spans: [
+            {
+              traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+              spanId: '4c47d5f85e4b2aec',
+              parentSpanId: 'da5a27b83e0f2871',
+              name: 'HTTP GET',
+              kind: 3,
+              startTimeUnixNano: '',
+              endTimeUnixNano: '',
+              attributes: [],
+              droppedAttributesCount: 0,
+              events: [],
+              droppedEventsCount: 0,
+              status: { code: 0 },
+              links: [],
+              droppedLinksCount: 0,
+            },
+          ],
+        },
+      ],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).not.toHaveProperty('duration_ns');
+  });
+
+  it('Does not include duration when timestamps are invalid', () => {
+    const faro = initializeFaro(mockConfig());
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: [
+        {
+          scope: {
+            name: '@opentelemetry/instrumentation-fetch',
+            version: '0.45.1',
+          },
+          spans: [
+            {
+              traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+              spanId: '4c47d5f85e4b2aec',
+              parentSpanId: 'da5a27b83e0f2871',
+              name: 'HTTP GET',
+              kind: 3,
+              startTimeUnixNano: 'invalid',
+              endTimeUnixNano: 'invalid',
+              attributes: [],
+              droppedAttributesCount: 0,
+              events: [],
+              droppedEventsCount: 0,
+              status: { code: 0 },
+              links: [],
+              droppedLinksCount: 0,
+            },
+          ],
+        },
+      ],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).not.toHaveProperty('duration_ns');
+  });
+});
+
+// some unnecessary parts are removed to shorten the object a bit.
+const testData: IResourceSpans[] = [
+  {
+    resource: {
+      attributes: [],
+      droppedAttributesCount: 0,
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-document-load',
+          version: '0.35.0',
+        },
+        spans: [
+          {
+            traceId: 'b3eb030d2a6a3ea28fd81a2c3c865d32',
+            spanId: '146cbe6578eedc77',
+            parentSpanId: '411fbeb357bad860',
+            name: 'resourceFetch',
+            kind: 1,
+            startTimeUnixNano: '1709051097380000000',
+            endTimeUnixNano: '1709051097419000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue:
+                    'http://localhost:5173/@fs/Users/marcoschaefer/Code/Repos/Grafana/faro-web-sdk/packages/core/dist/esm/api/traces/index.js',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 652,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097380000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@grafana/faro-react',
+          version: '1.3.9',
+        },
+        spans: [
+          {
+            traceId: 'e2e8ca244a7f149ca0f8e820df2d2ec1',
+            spanId: 'f4e18e624b397865',
+            name: 'componentMount',
+            kind: 1,
+            startTimeUnixNano: '1709051097617000000',
+            endTimeUnixNano: '1709051097617000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'react.component.name',
+                value: {
+                  stringValue: 'CounterComponent',
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-fetch',
+          version: '0.45.1',
+        },
+        spans: [
+          {
+            // this is the only span which is of kind=3 (client)
+            traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+            spanId: '4c47d5f85e4b2aec',
+            parentSpanId: 'da5a27b83e0f2871',
+            name: 'HTTP GET',
+            kind: 3,
+            startTimeUnixNano: '1709051097594000000',
+            endTimeUnixNano: '1709051097609000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: 'my-session-id',
+                },
+              },
+              {
+                key: 'component',
+                value: {
+                  stringValue: 'fetch',
+                },
+              },
+              {
+                key: 'http.method',
+                value: {
+                  stringValue: 'GET',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue: 'http://foo/bar',
+                },
+              },
+              {
+                key: 'http.status_code',
+                value: {
+                  intValue: 401,
+                },
+              },
+              {
+                key: 'http.status_text',
+                value: {
+                  stringValue: 'Unauthorized',
+                },
+              },
+              {
+                key: 'http.host',
+                value: {
+                  stringValue: 'my-host',
+                },
+              },
+              {
+                key: 'http.scheme',
+                value: {
+                  stringValue: 'http',
+                },
+              },
+              {
+                key: 'http.user_agent',
+                value: {
+                  stringValue: 'my-user-agent',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 127,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'requestStart',
+                timeUnixNano: '1709051097596000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseStart',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseEnd',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.ts
@@ -1,0 +1,54 @@
+import type { SpanContext } from '@opentelemetry/api';
+import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
+
+import { faro, unknownString } from '@grafana/faro-core';
+import type { EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
+
+const DURATION_NS_KEY = 'duration_ns';
+
+export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
+  for (const resourceSpan of resourceSpans) {
+    const { scopeSpans } = resourceSpan;
+
+    for (const scopeSpan of scopeSpans) {
+      const { scope, spans = [] } = scopeSpan;
+
+      for (const span of spans) {
+        if (span.kind !== ESpanKind.SPAN_KIND_CLIENT) {
+          continue;
+        }
+
+        const spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
+          traceId: span.traceId.toString(),
+          spanId: span.spanId.toString(),
+        };
+
+        const faroEventAttributes: FaroEventAttributes = {};
+
+        for (const attribute of span.attributes) {
+          faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);
+        }
+
+        // Add span duration in nanoseconds
+        if (!Number.isNaN(span.endTimeUnixNano) && !Number.isNaN(span.startTimeUnixNano)) {
+          faroEventAttributes[DURATION_NS_KEY] = String(Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano));
+        }
+
+        const index = (scope?.name ?? '').indexOf('-');
+        let eventName = unknownString;
+
+        if (scope?.name) {
+          if (index === -1) {
+            eventName = scope.name.split('/')[1] ?? scope.name;
+          }
+
+          if (index > -1) {
+            eventName = scope?.name.substring(index + 1);
+          }
+        }
+
+        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, { spanContext });
+      }
+    }
+  }
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/faroTraceExporter.utils.ts
@@ -1,8 +1,7 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
-import { faro, unknownString } from '@grafana/faro-core';
-import type { EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
+import { EventAttributes, faro, unknownString } from '@grafana/faro-core';
 
 const DURATION_NS_KEY = 'duration_ns';
 
@@ -23,7 +22,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
           spanId: span.spanId.toString(),
         };
 
-        const faroEventAttributes: FaroEventAttributes = {};
+        const faroEventAttributes: EventAttributes = {};
 
         for (const attribute of span.attributes) {
           faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);

--- a/packages/web-sdk/src/instrumentations/webTracing/faroXhrInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/faroXhrInstrumentation.ts
@@ -1,0 +1,42 @@
+import type { Span } from '@opentelemetry/api';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import type { XMLHttpRequestInstrumentationConfig } from '@opentelemetry/instrumentation-xml-http-request';
+import type { OpenFunction } from '@opentelemetry/instrumentation-xml-http-request/build/src/types';
+
+type Parent = {
+  _createSpan: (xhr: XMLHttpRequest, url: string, method: string) => Span | undefined;
+};
+
+export class FaroXhrInstrumentation extends XMLHttpRequestInstrumentation {
+  private parentCreateSpan: Parent['_createSpan'];
+
+  constructor(config: XMLHttpRequestInstrumentationConfig = {}) {
+    super(config);
+
+    const self = this as any as Parent;
+    this.parentCreateSpan = self._createSpan.bind(this);
+  }
+
+  // Patching the parent's private method to handle url type string or URL
+  protected override _patchOpen() {
+    return (original: OpenFunction): OpenFunction => {
+      const plugin = this;
+      return function patchOpen(this: XMLHttpRequest, ...args): void {
+        const method: string = args[0];
+        let url: string | URL = args[1];
+
+        if (isInstanceOfURL(url)) {
+          url = url.href;
+        }
+
+        plugin.parentCreateSpan(this, url, method);
+
+        return original.apply(this, args);
+      };
+    };
+  }
+}
+
+function isInstanceOfURL(item: any): item is URL {
+  return item instanceof URL;
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/getDefaultInstrumentations.test.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/getDefaultInstrumentations.test.ts
@@ -1,0 +1,64 @@
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+
+import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+
+jest.mock('@opentelemetry/instrumentation-fetch');
+jest.mock('@opentelemetry/instrumentation-xml-http-request');
+
+describe('getDefaultOTELInstrumentations', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an array of instrumentations', () => {
+    const instrumentations = getDefaultOTELInstrumentations();
+    expect(instrumentations).toBeInstanceOf(Array);
+    expect(instrumentations[0]).toBeInstanceOf(FetchInstrumentation);
+    expect(instrumentations[1]).toBeInstanceOf(XMLHttpRequestInstrumentation);
+  });
+
+  it('should apply default options', () => {
+    getDefaultOTELInstrumentations();
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+
+  it('should apply custom options', () => {
+    const ignoreUrls = ['example.com'];
+    const propagateTraceHeaderCorsUrls = ['example2.com'];
+
+    getDefaultOTELInstrumentations({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      fetchInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+      xhrInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+    });
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+});

--- a/packages/web-sdk/src/instrumentations/webTracing/getDefaultOTELInstrumentations.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/getDefaultOTELInstrumentations.ts
@@ -1,0 +1,48 @@
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+
+import { FaroXhrInstrumentation } from './faroXhrInstrumentation';
+import {
+  fetchCustomAttributeFunctionWithDefaults,
+  xhrCustomAttributeFunctionWithDefaults,
+} from './instrumentationUtils';
+import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
+
+export function getDefaultOTELInstrumentations(options: DefaultInstrumentationsOptions = {}): InstrumentationOption[] {
+  const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
+
+  const fetchOpts = createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions);
+  const xhrOpts = createXhrInstrumentationOptions(xhrInstrumentationOptions, sharedOptions);
+
+  return [new FetchInstrumentation(fetchOpts), new FaroXhrInstrumentation(xhrOpts)];
+}
+function createFetchInstrumentationOptions(
+  fetchInstrumentationOptions: DefaultInstrumentationsOptions['fetchInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+    ignoreNetworkEvents: true,
+    // keep this here to overwrite the defaults above if provided by the users
+    ...fetchInstrumentationOptions,
+    // always keep this function
+    applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
+      fetchInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
+}
+
+function createXhrInstrumentationOptions(
+  xhrInstrumentationOptions: DefaultInstrumentationsOptions['xhrInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+    ignoreNetworkEvents: true,
+    // keep this here to overwrite the defaults above if provided by the users
+    ...xhrInstrumentationOptions,
+    // always keep this function
+    applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
+      xhrInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/index.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/index.ts
@@ -1,0 +1,13 @@
+export { FaroTraceExporter } from './faroTraceExporter';
+
+export { FaroSessionSpanProcessor } from './sessionSpanProcessor';
+
+export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+
+export { TracingInstrumentation } from './instrumentation';
+
+export { getSamplingDecision } from './sampler';
+
+export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';
+
+export { setSpanStatusOnFetchError, fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';

--- a/packages/web-sdk/src/instrumentations/webTracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/instrumentation.ts
@@ -1,0 +1,116 @@
+import { context, trace } from '@opentelemetry/api';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+} from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAMESPACE,
+  // False positive. Package can be resolved.
+  // eslint-disable-next-line import/no-unresolved
+} from '@opentelemetry/semantic-conventions/incubating';
+
+import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
+
+import { FaroTraceExporter } from './faroTraceExporter';
+import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+import { getSamplingDecision } from './sampler';
+import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
+import type { TracingInstrumentationOptions } from './types';
+
+// the providing of app name here is not great
+// should delay initialization and provide the full Faro config,
+// taking app name from it
+
+export class TracingInstrumentation extends BaseInstrumentation {
+  name = '@grafana/faro-web-tracing';
+  version = VERSION;
+
+  static SCHEDULED_BATCH_DELAY_MS = 1000;
+
+  constructor(private options: TracingInstrumentationOptions = {}) {
+    super();
+  }
+
+  initialize(): void {
+    const options = this.options;
+    const attributes: ResourceAttributes = {};
+
+    if (this.config.app.name) {
+      attributes[ATTR_SERVICE_NAME] = this.config.app.name;
+    }
+
+    if (this.config.app.namespace) {
+      attributes[ATTR_SERVICE_NAMESPACE] = this.config.app.namespace;
+    }
+
+    if (this.config.app.version) {
+      attributes[ATTR_SERVICE_VERSION] = this.config.app.version;
+    }
+
+    if (this.config.app.environment) {
+      attributes[ATTR_DEPLOYMENT_ENVIRONMENT_NAME] = this.config.app.environment;
+      /**
+       * @deprecated will be removed in the future and has been replaced by ATTR_DEPLOYMENT_ENVIRONMENT_NAME (deployment.environment.name)
+       */
+      attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT] = this.config.app.environment;
+    }
+
+    Object.assign(attributes, options.resourceAttributes);
+
+    const resource = Resource.default().merge(new Resource(attributes));
+
+    const provider = new WebTracerProvider({
+      resource,
+      sampler: {
+        shouldSample: () => {
+          return {
+            decision: getSamplingDecision(this.api.getSession()),
+          };
+        },
+      },
+    });
+
+    provider.addSpanProcessor(
+      options.spanProcessor ??
+        new FaroSessionSpanProcessor(
+          new BatchSpanProcessor(new FaroTraceExporter({ api: this.api }), {
+            scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
+            maxExportBatchSize: 30,
+          }),
+          this.metas
+        )
+    );
+
+    provider.register({
+      propagator: options.propagator ?? new W3CTraceContextPropagator(),
+      contextManager: options.contextManager ?? new ZoneContextManager(),
+    });
+
+    const { propagateTraceHeaderCorsUrls, fetchInstrumentationOptions, xhrInstrumentationOptions } =
+      this.options.instrumentationOptions ?? {};
+
+    registerInstrumentations({
+      instrumentations:
+        options.instrumentations ??
+        getDefaultOTELInstrumentations({
+          ignoreUrls: this.getIgnoreUrls(),
+          propagateTraceHeaderCorsUrls,
+          fetchInstrumentationOptions,
+          xhrInstrumentationOptions,
+        }),
+    });
+
+    this.api.initOTEL(trace, context);
+  }
+
+  private getIgnoreUrls(): Array<string | RegExp> {
+    return this.transports.transports.flatMap((transport: Transport) => transport.getIgnoreUrls());
+  }
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/instrumentation.ts
@@ -16,7 +16,10 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from '@opentelemetry/semantic-conventions/incubating';
 
-import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
+// import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
+
+import { BaseInstrumentation, VERSION } from '@grafana/faro-core';
+import type { Transport } from '@grafana/faro-core';
 
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';

--- a/packages/web-sdk/src/instrumentations/webTracing/instrumentationUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/instrumentationUtils.test.ts
@@ -1,0 +1,77 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+
+import { fetchCustomAttributeFunctionWithDefaults, setSpanStatusOnFetchError } from './instrumentationUtils';
+import * as instrumentationUtilsMock from './instrumentationUtils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([500, 599, 400, 499, new Error()])('set span status on fetch error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = result instanceof Error ? result : ({ status: result } as Response);
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on fetch success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: result } as Response;
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls custom setSpanStatusOnFetchError from fetchInstrumentationOptions and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnFetchError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: 500 } as Response;
+    const callback = jest.fn();
+
+    fetchCustomAttributeFunctionWithDefaults(callback)(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, request, response);
+  });
+
+  test.each([500, 599, 400, 499])('set span status on XMLHttpRequest error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on XMLHttpRequest success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls custom setSpanStatusOnFetchError from xhrInstrumentationOptions and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnXMLHttpRequestError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: 500 } as XMLHttpRequest;
+    const callback = jest.fn();
+
+    instrumentationUtilsMock.xhrCustomAttributeFunctionWithDefaults(callback)(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, xhr);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/webTracing/instrumentationUtils.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/instrumentationUtils.ts
@@ -1,0 +1,53 @@
+import { Span, SpanStatusCode } from '@opentelemetry/api';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
+
+export interface FetchError {
+  status?: number;
+  message: string;
+}
+
+/**
+ * Adds HTTP status code to every span.
+ *
+ * The fetch instrumentation does not always set the span status to error as defined by the spec.
+ * To work around that issue we manually set the span status.
+ *
+ * Issue: https://github.com/open-telemetry/opentelemetry-js/issues/3564
+ * Spec: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#status
+ */
+export function setSpanStatusOnFetchError(span: Span, _request: Request | RequestInit, result: Response | FetchError) {
+  const httpStatusCode = result instanceof Error ? 0 : result.status;
+  setSpanStatus(span, httpStatusCode);
+}
+
+export function setSpanStatusOnXMLHttpRequestError(span: Span, xhr: XMLHttpRequest) {
+  setSpanStatus(span, xhr.status);
+}
+
+function setSpanStatus(span: Span, httpStatusCode?: number) {
+  if (httpStatusCode == null) {
+    return;
+  }
+
+  const isError = httpStatusCode === 0;
+  const isClientOrServerError = httpStatusCode >= 400 && httpStatusCode < 600;
+
+  if (isError || isClientOrServerError) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}
+
+export function fetchCustomAttributeFunctionWithDefaults(callback?: FetchCustomAttributeFunction) {
+  return (span: Span, request: Request | RequestInit, result: Response | FetchError) => {
+    setSpanStatusOnFetchError(span, request, result);
+    callback?.(span, request, result);
+  };
+}
+
+export function xhrCustomAttributeFunctionWithDefaults(callback?: XHRCustomAttributeFunction) {
+  return (span: Span, xhr: XMLHttpRequest) => {
+    setSpanStatusOnXMLHttpRequestError(span, xhr);
+    callback?.(span, xhr);
+  };
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/sampler.test.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/sampler.test.ts
@@ -1,0 +1,29 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import { getSamplingDecision } from './sampler';
+
+describe('Sampler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Set SamplingDecision to NOT_RECORD (0) if session is not part of the sample', () => {
+    const samplingDecision = getSamplingDecision({
+      attributes: {
+        isSampled: 'false',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.NOT_RECORD);
+  });
+
+  it('Set SamplingDecision to RECORD_AND_SAMPLED (2) if session is part of the sample', () => {
+    const samplingDecision = getSamplingDecision({
+      attributes: {
+        isSampled: 'true',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/webTracing/sampler.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/sampler.ts
@@ -1,0 +1,10 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import type { MetaSession } from '@grafana/faro-web-sdk';
+
+export function getSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
+  const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';
+  const samplingDecision = isSessionSampled ? SamplingDecision.RECORD_AND_SAMPLED : SamplingDecision.NOT_RECORD;
+
+  return samplingDecision;
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/sampler.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/sampler.ts
@@ -1,6 +1,6 @@
 import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
 
-import type { MetaSession } from '@grafana/faro-web-sdk';
+import type { MetaSession } from '@grafana/faro-core';
 
 export function getSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
   const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';

--- a/packages/web-sdk/src/instrumentations/webTracing/sessionSpanProcessor.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/sessionSpanProcessor.ts
@@ -4,7 +4,7 @@ import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace
 // eslint-disable-next-line import/no-unresolved
 import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
 
-import type { Metas } from '@grafana/faro-web-sdk';
+import type { Metas } from '@grafana/faro-core';
 
 export class FaroSessionSpanProcessor implements SpanProcessor {
   constructor(

--- a/packages/web-sdk/src/instrumentations/webTracing/sessionSpanProcessor.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/sessionSpanProcessor.ts
@@ -1,0 +1,40 @@
+import type { Context } from '@opentelemetry/api';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
+// False positive. Package can be resolved.
+// eslint-disable-next-line import/no-unresolved
+import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
+
+import type { Metas } from '@grafana/faro-web-sdk';
+
+export class FaroSessionSpanProcessor implements SpanProcessor {
+  constructor(
+    private processor: SpanProcessor,
+    private metas: Metas
+  ) {}
+
+  forceFlush(): Promise<void> {
+    return this.processor.forceFlush();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    const session = this.metas.value.session;
+
+    if (session?.id) {
+      span.attributes[ATTR_SESSION_ID] = session.id;
+      /**
+       * @deprecated will be removed in the future and has been replaced by ATTR_SESSION_ID (session.id)
+       */
+      span.attributes['session_id'] = session.id;
+    }
+
+    this.processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.processor.onEnd(span);
+  }
+
+  shutdown(): Promise<void> {
+    return this.processor.shutdown();
+  }
+}

--- a/packages/web-sdk/src/instrumentations/webTracing/types.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/types.ts
@@ -5,8 +5,7 @@ import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-
 import type { ResourceAttributes } from '@opentelemetry/resources';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import type { Patterns } from '@grafana/faro-core';
-import type { API } from '@grafana/faro-web-sdk';
+import type { API, Patterns } from '@grafana/faro-core';
 
 // type got remove by with experimental/v0.52.0 and is replaced by the following type:
 // See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0

--- a/packages/web-sdk/src/instrumentations/webTracing/types.ts
+++ b/packages/web-sdk/src/instrumentations/webTracing/types.ts
@@ -1,0 +1,43 @@
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
+import type { ResourceAttributes } from '@opentelemetry/resources';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
+
+import type { Patterns } from '@grafana/faro-core';
+import type { API } from '@grafana/faro-web-sdk';
+
+// type got remove by with experimental/v0.52.0 and is replaced by the following type:
+// See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0
+export type InstrumentationOption = Instrumentation | Instrumentation[];
+
+export interface FaroTraceExporterConfig {
+  api: API;
+}
+
+export interface TracingInstrumentationOptions {
+  resourceAttributes?: ResourceAttributes;
+  propagator?: TextMapPropagator;
+  contextManager?: ContextManager;
+  instrumentations?: InstrumentationOption[];
+  spanProcessor?: SpanProcessor;
+  instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
+}
+
+export type MatchUrlDefinitions = Patterns;
+
+export type DefaultInstrumentationsOptions = {
+  ignoreUrls?: MatchUrlDefinitions;
+  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
+
+  fetchInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+
+  xhrInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+};


### PR DESCRIPTION
## Why

Work in process

For easy of use include the web-tracing instrumentation in the default instrumentations.

For existing users we need to ensure that Faro takes up their already configured
Faro detects duplicated instrumentations and ensures that only one is initialized.
But it uses the first instrument it finds, so it would always pick up the default instrument. 
-> Ensure that the user configured instrument takes precedence.

### This how the config changes:**

**new way with web-tracing  auto instrumentation if no customization is needed**

```ts
  const faro = coreInit({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },
  });
```


**New way, with web-tracing auto instrumentation and additional tracing configuration**

```ts
initializeFaro({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },

    webTracingInstrumentation: {
      enabled: true, // default true
      instrumentationOptions: {
        propagateTraceHeaderCorsUrls: ['...'],
        fetchInstrumentationOptions: {
          ignoreNetworkEvents: true,
        },
      },
    },
  });

```

**Current state**
```ts
initializeFaro({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    instrumentations: [
      ...getWebInstrumentations({
        captureConsole: true,
      }),

      new TracingInstrumentation({
        instrumentationOptions: {
          propagateTraceHeaderCorsUrls: ['...'],
          fetchInstrumentationOptions: {
            ignoreNetworkEvents: true,
          },
        },
      }),
    ],
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },
  });
```


## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
