### PR TITLE
feat: add web tracing to default instruments

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -7,7 +7,6 @@ import {
   ReactRouterVersion,
 } from '@grafana/faro-react';
 import type { Faro } from '@grafana/faro-react';
-import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { env } from '../utils';
 
@@ -17,11 +16,7 @@ export function initializeFaro(): Faro {
     apiKey: env.faro.apiKey,
     trackWebVitalsAttribution: true,
     instrumentations: [
-      ...getWebInstrumentations({
-        captureConsole: true,
-      }),
-
-      new TracingInstrumentation(),
+      ...getWebInstrumentations(),
       new ReactIntegration({
         router: {
           version: ReactRouterVersion.V6,
@@ -40,10 +35,6 @@ export function initializeFaro(): Faro {
       namespace: env.client.packageNamespace,
       version: env.package.version,
       environment: env.mode.name,
-    },
-
-    locationTracking: {
-      enabled: true,
     },
   });
 

--- a/experimental/instrumentation-fetch/src/setupTests.ts
+++ b/experimental/instrumentation-fetch/src/setupTests.ts
@@ -1,4 +1,5 @@
 import { fetch, Request, Response } from '@remix-run/web-fetch';
+import { TextDecoder, TextEncoder } from 'node:util';
 
 if (!globalThis.fetch) {
   // @ts-expect-error
@@ -10,3 +11,5 @@ if (!globalThis.fetch) {
   // @ts-expect-error
   globalThis.Response = Response;
 }
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/experimental/instrumentation-performance-timeline/jest.config.js
+++ b/experimental/instrumentation-performance-timeline/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   ...jestBaseConfig,
   roots: ['experimental/instrumentation-performance-timeline/src'],
   testEnvironment: 'jsdom',
-  setupFiles: ['<rootDir>/packages/instrumentation-performance-timeline/setup.jest.ts'],
+  setupFiles: ['<rootDir>/experimental/instrumentation-performance-timeline/setup.jest.ts'],
 };

--- a/experimental/instrumentation-performance-timeline/jest.config.js
+++ b/experimental/instrumentation-performance-timeline/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   ...jestBaseConfig,
   roots: ['experimental/instrumentation-performance-timeline/src'],
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/packages/instrumentation-performance-timeline/setup.jest.ts'],
 };

--- a/experimental/instrumentation-performance-timeline/setup.jest.ts
+++ b/experimental/instrumentation-performance-timeline/setup.jest.ts
@@ -1,0 +1,3 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/experimental/instrumentation-xhr/jest.config.js
+++ b/experimental/instrumentation-xhr/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
     '^@remix-run/web-stream$': require.resolve('@remix-run/web-stream'),
     '^@web3-storage/multipart-parser$': require.resolve('@web3-storage/multipart-parser'),
   },
-  setupFiles: ['<rootDir>/packages/instrumentation-xhr/setup.jest.ts'],
+  setupFiles: ['<rootDir>/experimental/instrumentation-xhr/setup.jest.ts'],
 };

--- a/experimental/instrumentation-xhr/jest.config.js
+++ b/experimental/instrumentation-xhr/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
     '^@remix-run/web-stream$': require.resolve('@remix-run/web-stream'),
     '^@web3-storage/multipart-parser$': require.resolve('@web3-storage/multipart-parser'),
   },
+  setupFiles: ['<rootDir>/packages/instrumentation-xhr/setup.jest.ts'],
 };

--- a/experimental/instrumentation-xhr/setup.jest.ts
+++ b/experimental/instrumentation-xhr/setup.jest.ts
@@ -1,0 +1,3 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/packages/core/src/config/WebSdkTracingConfig.ts
+++ b/packages/core/src/config/WebSdkTracingConfig.ts
@@ -1,0 +1,41 @@
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
+import type { ResourceAttributes } from '@opentelemetry/resources';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
+
+import type { Patterns } from './types';
+
+// TODO this should not be part of faro-core because it is a concern of the web-sdk package.
+// We eventually will refactor the package so the Config can be extended with package specific options.
+// We also will remove all package specific functionality from the faro-core package.
+// For time reasons and conflicting priorities, we will leave it here for now.
+
+// type got remove by with experimental/v0.52.0 and is replaced by the following type:
+// See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0
+export type InstrumentationOption = Instrumentation | Instrumentation[];
+
+export interface TracingInstrumentationOptions {
+  resourceAttributes?: ResourceAttributes;
+  propagator?: TextMapPropagator;
+  contextManager?: ContextManager;
+  instrumentations?: InstrumentationOption[];
+  spanProcessor?: SpanProcessor;
+  instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
+}
+
+type DefaultInstrumentationsOptions = {
+  ignoreUrls?: Patterns;
+  propagateTraceHeaderCorsUrls?: Patterns;
+
+  fetchInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+
+  xhrInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+};

--- a/packages/core/src/config/WebSdkTracingConfig.ts
+++ b/packages/core/src/config/WebSdkTracingConfig.ts
@@ -17,6 +17,7 @@ import type { Patterns } from './types';
 export type InstrumentationOption = Instrumentation | Instrumentation[];
 
 export interface TracingInstrumentationOptions {
+  enabled?: boolean;
   resourceAttributes?: ResourceAttributes;
   propagator?: TextMapPropagator;
   contextManager?: ContextManager;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -6,6 +6,8 @@ import type { BatchExecutorOptions, BeforeSendHook, Transport } from '../transpo
 import type { UnpatchedConsole } from '../unpatchedConsole';
 import type { LogLevel } from '../utils';
 
+import type { TracingInstrumentationOptions } from './WebSdkTracingConfig';
+
 type SamplingContext = {
   metas: Meta;
 };
@@ -221,6 +223,8 @@ export interface Config<P = APIEvent> {
      */
     enabled?: boolean;
   };
+
+  webTracingInstrumentation?: TracingInstrumentationOptions;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -224,6 +224,13 @@ export interface Config<P = APIEvent> {
     enabled?: boolean;
   };
 
+  /**
+   * Shortcut property to enable or disable the built-in tracing instrumentation
+   */
+  tracing?: boolean;
+  /**
+   * Advanced options to configure the built-in tracing instrumentation
+   */
   tracingInstrumentation?: TracingInstrumentationOptions;
 }
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -224,7 +224,7 @@ export interface Config<P = APIEvent> {
     enabled?: boolean;
   };
 
-  webTracingInstrumentation?: TracingInstrumentationOptions;
+  tracingInstrumentation?: TracingInstrumentationOptions;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/web-sdk/jest.config.js
+++ b/packages/web-sdk/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   ...jestBaseConfig,
   roots: ['packages/web-sdk/src'],
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/packages/web-sdk/setup.jest.ts'],
 };

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -56,6 +56,17 @@
   },
   "dependencies": {
     "@grafana/faro-core": "^1.13.3",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-zone": "1.30.1",
+    "@opentelemetry/core": "^1.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/instrumentation-fetch": "^0.57.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.57.0",
+    "@opentelemetry/instrumentation": "^0.57.0",
+    "@opentelemetry/otlp-transformer": "^0.57.1",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-trace-web": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "ua-parser-js": "^1.0.32",
     "web-vitals": "^4.0.1"
   },

--- a/packages/web-sdk/setup.jest.ts
+++ b/packages/web-sdk/setup.jest.ts
@@ -1,0 +1,3 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -8,6 +8,7 @@ import {
   ViewInstrumentation,
   WebVitalsInstrumentation,
 } from '../instrumentations';
+import { TracingInstrumentation } from '../instrumentations/web-tracing';
 
 import type { GetWebInstrumentationsOptions } from './types';
 
@@ -28,6 +29,7 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
   }
 
   instrumentations.push(
+    new TracingInstrumentation(),
     new ErrorsInstrumentation(),
     new WebVitalsInstrumentation(),
     new SessionInstrumentation(),

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -12,16 +12,11 @@ import {
 import type { GetWebInstrumentationsOptions } from './types';
 
 export function getWebInstrumentations(options: GetWebInstrumentationsOptions = {}): Instrumentation[] {
-  const instrumentations: Instrumentation[] = [
-    new ErrorsInstrumentation(),
-    new WebVitalsInstrumentation(),
-    new SessionInstrumentation(),
-    new ViewInstrumentation(),
-  ];
+  const instrumentations: Instrumentation[] = [];
 
   if (options.enablePerformanceInstrumentation !== false) {
-    // unshift to ensure that initialization starts before the other instrumentations
-    instrumentations.unshift(new PerformanceInstrumentation());
+    //  ensure that initialization starts before the other instrumentations
+    instrumentations.push(new PerformanceInstrumentation());
   }
 
   if (options.captureConsole !== false) {
@@ -31,6 +26,13 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
       })
     );
   }
+
+  instrumentations.push(
+    new ErrorsInstrumentation(),
+    new WebVitalsInstrumentation(),
+    new SessionInstrumentation(),
+    new ViewInstrumentation()
+  );
 
   return instrumentations;
 }

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -70,8 +70,11 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     paused = false,
     preventGlobalExposure = false,
     unpatchedConsole = defaultUnpatchedConsole,
+    tracing = false,
     tracingInstrumentation,
   }: BrowserConfig = browserConfig;
+
+  const tracingEnabled = Boolean(tracingInstrumentation?.enabled || tracing);
 
   return {
     app,
@@ -81,7 +84,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     },
     dedupe: dedupe,
     globalObjectKey,
-    instrumentations: getInstrumentations(instrumentations, browserConfig),
+    instrumentations: preConfigureInstrumentations(instrumentations, { tracingEnabled }),
     internalLoggerLevel,
     isolate,
     logArgsSerializer,
@@ -107,7 +110,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackWebVitalsAttribution,
     consoleInstrumentation,
     tracingInstrumentation: {
-      enabled: false,
+      enabled: tracingEnabled,
       ...tracingInstrumentation,
     },
   };
@@ -152,10 +155,13 @@ function crateSessionMeta({
   };
 }
 
-function getInstrumentations(instrumentations: Instrumentation[], config: BrowserConfig): Instrumentation[] {
+function preConfigureInstrumentations(
+  instrumentations: Instrumentation[],
+  { tracingEnabled }: { tracingEnabled: boolean }
+): Instrumentation[] {
   let filteredInstrumentations = instrumentations;
 
-  if (config.tracingInstrumentation?.enabled && instrumentations.find((i) => i.name === '@grafana/faro-web-tracing')) {
+  if (tracingEnabled && instrumentations.find((i) => i.name === '@grafana/faro-web-tracing')) {
     filteredInstrumentations = instrumentations.filter(
       (instrumentation) => instrumentation.name !== TracingInstrumentation.name
     );

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -70,6 +70,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     paused = false,
     preventGlobalExposure = false,
     unpatchedConsole = defaultUnpatchedConsole,
+    webTracingInstrumentation,
   }: BrowserConfig = browserConfig;
 
   return {
@@ -105,6 +106,10 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackResources,
     trackWebVitalsAttribution,
     consoleInstrumentation,
+    webTracingInstrumentation: {
+      enabled: true,
+      ...webTracingInstrumentation,
+    },
   };
 }
 

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -70,7 +70,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     paused = false,
     preventGlobalExposure = false,
     unpatchedConsole = defaultUnpatchedConsole,
-    webTracingInstrumentation,
+    tracingInstrumentation,
   }: BrowserConfig = browserConfig;
 
   return {
@@ -106,9 +106,9 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackResources,
     trackWebVitalsAttribution,
     consoleInstrumentation,
-    webTracingInstrumentation: {
+    tracingInstrumentation: {
       enabled: true,
-      ...webTracingInstrumentation,
+      ...tracingInstrumentation,
     },
   };
 }

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -81,7 +81,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     },
     dedupe: dedupe,
     globalObjectKey,
-    instrumentations: getInstrumentations(instrumentations),
+    instrumentations: getInstrumentations(instrumentations, browserConfig),
     internalLoggerLevel,
     isolate,
     logArgsSerializer,
@@ -107,7 +107,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackWebVitalsAttribution,
     consoleInstrumentation,
     tracingInstrumentation: {
-      enabled: true,
+      enabled: false,
       ...tracingInstrumentation,
     },
   };
@@ -152,10 +152,10 @@ function crateSessionMeta({
   };
 }
 
-function getInstrumentations(instrumentations: Instrumentation[]): Instrumentation[] {
+function getInstrumentations(instrumentations: Instrumentation[], config: BrowserConfig): Instrumentation[] {
   let filteredInstrumentations = instrumentations;
 
-  if (instrumentations.find((i) => i.name === '@grafana/faro-web-tracing')) {
+  if (config.tracingInstrumentation?.enabled && instrumentations.find((i) => i.name === '@grafana/faro-web-tracing')) {
     filteredInstrumentations = instrumentations.filter(
       (instrumentation) => instrumentation.name !== TracingInstrumentation.name
     );

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -168,3 +168,5 @@ export {
 } from './instrumentations/session';
 
 export { getIgnoreUrls } from './utils/url';
+
+export { getDefaultOTELInstrumentations } from './instrumentations/web-tracing';

--- a/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.ts
@@ -1,0 +1,24 @@
+import { ExportResultCode } from '@opentelemetry/core';
+import type { ExportResult } from '@opentelemetry/core';
+import { createExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/src/trace/internal';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
+
+import { sendFaroEvents } from './faroTraceExporter.utils';
+import type { FaroTraceExporterConfig } from './types';
+
+export class FaroTraceExporter implements SpanExporter {
+  constructor(private config: FaroTraceExporterConfig) {}
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    const traceEvent = createExportTraceServiceRequest(spans, { useHex: true, useLongBits: false });
+
+    this.config.api.pushTraces(traceEvent);
+    sendFaroEvents(traceEvent.resourceSpans);
+
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.utils.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.utils.test.ts
@@ -1,0 +1,431 @@
+import type { IResourceSpans, IScopeSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
+
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { sendFaroEvents } from './faroTraceExporter.utils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Emits no faro events if no client spans are contained ', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // remove scopeSpan which contains client span
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: testData[0]?.scopeSpans?.slice(0, -1) ?? [],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(0);
+  });
+
+  it('Creates a Faro event for client spans only', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    sendFaroEvents(testData);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.fetch');
+    expect(mockPushEvent.mock.lastCall[1]).toStrictEqual({
+      component: 'fetch',
+      session_id: 'my-session-id',
+      'http.host': 'my-host',
+      'http.method': 'GET',
+      'http.response_content_length': '127',
+      'http.scheme': 'http',
+      'http.status_code': '401',
+      'http.status_text': 'Unauthorized',
+      'http.url': 'http://foo/bar',
+      'http.user_agent': 'my-user-agent',
+      duration_ns: '15000064',
+    });
+  });
+
+  it('Uses whole instrumentation name if no "-" is part of the name', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const scopeSpans = testData[0]?.scopeSpans?.map((s) => ({ ...s })) ?? [];
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans,
+    };
+
+    if (scopeSpans.length === 0) {
+      throw new Error('Test data is invalid - scopeSpans should not be empty');
+    }
+    const lastScopeSpan = scopeSpans[scopeSpans.length - 1] as IScopeSpans & { scope: { name: string } };
+    lastScopeSpan.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).toBe('faro.tracing.coolName');
+  });
+
+  it('Call Faro event API with traceID and spanID of contained in teh span', () => {
+    const faro = initializeFaro(mockConfig());
+
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    // add scope name without "-"
+    const scopeSpans = testData[0]?.scopeSpans?.map((s) => ({ ...s })) ?? [];
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans,
+    };
+
+    if (scopeSpans.length === 0) {
+      throw new Error('Test data is invalid - scopeSpans should not be empty');
+    }
+    const lastScopeSpan = scopeSpans[scopeSpans.length - 1] as IScopeSpans & { scope: { name: string } };
+    lastScopeSpan.scope.name = '@foo/coolName';
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[3]).toStrictEqual({
+      spanContext: {
+        spanId: '4c47d5f85e4b2aec',
+        traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+      },
+    });
+  });
+
+  it('Does not include duration when timestamps are missing', () => {
+    const faro = initializeFaro(mockConfig());
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: [
+        {
+          scope: {
+            name: '@opentelemetry/instrumentation-fetch',
+            version: '0.45.1',
+          },
+          spans: [
+            {
+              traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+              spanId: '4c47d5f85e4b2aec',
+              parentSpanId: 'da5a27b83e0f2871',
+              name: 'HTTP GET',
+              kind: 3,
+              startTimeUnixNano: '',
+              endTimeUnixNano: '',
+              attributes: [],
+              droppedAttributesCount: 0,
+              events: [],
+              droppedEventsCount: 0,
+              status: { code: 0 },
+              links: [],
+              droppedLinksCount: 0,
+            },
+          ],
+        },
+      ],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).not.toHaveProperty('duration_ns');
+  });
+
+  it('Does not include duration when timestamps are invalid', () => {
+    const faro = initializeFaro(mockConfig());
+    const mockPushEvent = jest.fn();
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
+
+    const data: IResourceSpans = {
+      resource: { attributes: [], droppedAttributesCount: 0 },
+      scopeSpans: [
+        {
+          scope: {
+            name: '@opentelemetry/instrumentation-fetch',
+            version: '0.45.1',
+          },
+          spans: [
+            {
+              traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+              spanId: '4c47d5f85e4b2aec',
+              parentSpanId: 'da5a27b83e0f2871',
+              name: 'HTTP GET',
+              kind: 3,
+              startTimeUnixNano: 'invalid',
+              endTimeUnixNano: 'invalid',
+              attributes: [],
+              droppedAttributesCount: 0,
+              events: [],
+              droppedEventsCount: 0,
+              status: { code: 0 },
+              links: [],
+              droppedLinksCount: 0,
+            },
+          ],
+        },
+      ],
+    };
+
+    sendFaroEvents([data]);
+
+    expect(mockPushEvent).toBeCalledTimes(1);
+    expect(mockPushEvent.mock.lastCall[0]).not.toHaveProperty('duration_ns');
+  });
+});
+
+// some unnecessary parts are removed to shorten the object a bit.
+const testData: IResourceSpans[] = [
+  {
+    resource: {
+      attributes: [],
+      droppedAttributesCount: 0,
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-document-load',
+          version: '0.35.0',
+        },
+        spans: [
+          {
+            traceId: 'b3eb030d2a6a3ea28fd81a2c3c865d32',
+            spanId: '146cbe6578eedc77',
+            parentSpanId: '411fbeb357bad860',
+            name: 'resourceFetch',
+            kind: 1,
+            startTimeUnixNano: '1709051097380000000',
+            endTimeUnixNano: '1709051097419000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue:
+                    'http://localhost:5173/@fs/Users/marcoschaefer/Code/Repos/Grafana/faro-web-sdk/packages/core/dist/esm/api/traces/index.js',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 652,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097380000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@grafana/faro-react',
+          version: '1.3.9',
+        },
+        spans: [
+          {
+            traceId: 'e2e8ca244a7f149ca0f8e820df2d2ec1',
+            spanId: 'f4e18e624b397865',
+            name: 'componentMount',
+            kind: 1,
+            startTimeUnixNano: '1709051097617000000',
+            endTimeUnixNano: '1709051097617000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: '7Zk2kA92sT',
+                },
+              },
+              {
+                key: 'react.component.name',
+                value: {
+                  stringValue: 'CounterComponent',
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+      {
+        scope: {
+          name: '@opentelemetry/instrumentation-fetch',
+          version: '0.45.1',
+        },
+        spans: [
+          {
+            // this is the only span which is of kind=3 (client)
+            traceId: '7fb8581e3db5ebc6be4e36a7a8817cfe',
+            spanId: '4c47d5f85e4b2aec',
+            parentSpanId: 'da5a27b83e0f2871',
+            name: 'HTTP GET',
+            kind: 3,
+            startTimeUnixNano: '1709051097594000000',
+            endTimeUnixNano: '1709051097609000000',
+            attributes: [
+              {
+                key: 'session_id',
+                value: {
+                  stringValue: 'my-session-id',
+                },
+              },
+              {
+                key: 'component',
+                value: {
+                  stringValue: 'fetch',
+                },
+              },
+              {
+                key: 'http.method',
+                value: {
+                  stringValue: 'GET',
+                },
+              },
+              {
+                key: 'http.url',
+                value: {
+                  stringValue: 'http://foo/bar',
+                },
+              },
+              {
+                key: 'http.status_code',
+                value: {
+                  intValue: 401,
+                },
+              },
+              {
+                key: 'http.status_text',
+                value: {
+                  stringValue: 'Unauthorized',
+                },
+              },
+              {
+                key: 'http.host',
+                value: {
+                  stringValue: 'my-host',
+                },
+              },
+              {
+                key: 'http.scheme',
+                value: {
+                  stringValue: 'http',
+                },
+              },
+              {
+                key: 'http.user_agent',
+                value: {
+                  stringValue: 'my-user-agent',
+                },
+              },
+              {
+                key: 'http.response_content_length',
+                value: {
+                  intValue: 127,
+                },
+              },
+            ],
+            droppedAttributesCount: 0,
+            events: [
+              {
+                attributes: [],
+                name: 'fetchStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'domainLookupEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectStart',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'connectEnd',
+                timeUnixNano: '1709051097594000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'requestStart',
+                timeUnixNano: '1709051097596000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseStart',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+              {
+                attributes: [],
+                name: 'responseEnd',
+                timeUnixNano: '1709051097597000000',
+                droppedAttributesCount: 0,
+              },
+            ],
+            droppedEventsCount: 0,
+            status: {
+              code: 0,
+            },
+            links: [],
+            droppedLinksCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.utils.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/faroTraceExporter.utils.ts
@@ -1,0 +1,53 @@
+import type { SpanContext } from '@opentelemetry/api';
+import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
+
+import { EventAttributes, faro, unknownString } from '@grafana/faro-core';
+
+const DURATION_NS_KEY = 'duration_ns';
+
+export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
+  for (const resourceSpan of resourceSpans) {
+    const { scopeSpans } = resourceSpan;
+
+    for (const scopeSpan of scopeSpans) {
+      const { scope, spans = [] } = scopeSpan;
+
+      for (const span of spans) {
+        if (span.kind !== ESpanKind.SPAN_KIND_CLIENT) {
+          continue;
+        }
+
+        const spanContext: Pick<SpanContext, 'traceId' | 'spanId'> = {
+          traceId: span.traceId.toString(),
+          spanId: span.spanId.toString(),
+        };
+
+        const faroEventAttributes: EventAttributes = {};
+
+        for (const attribute of span.attributes) {
+          faroEventAttributes[attribute.key] = String(Object.values(attribute.value)[0]);
+        }
+
+        // Add span duration in nanoseconds
+        if (!Number.isNaN(span.endTimeUnixNano) && !Number.isNaN(span.startTimeUnixNano)) {
+          faroEventAttributes[DURATION_NS_KEY] = String(Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano));
+        }
+
+        const index = (scope?.name ?? '').indexOf('-');
+        let eventName = unknownString;
+
+        if (scope?.name) {
+          if (index === -1) {
+            eventName = scope.name.split('/')[1] ?? scope.name;
+          }
+
+          if (index > -1) {
+            eventName = scope?.name.substring(index + 1);
+          }
+        }
+
+        faro.api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, { spanContext });
+      }
+    }
+  }
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/faroXhrInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/faroXhrInstrumentation.ts
@@ -1,0 +1,42 @@
+import type { Span } from '@opentelemetry/api';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import type { XMLHttpRequestInstrumentationConfig } from '@opentelemetry/instrumentation-xml-http-request';
+import type { OpenFunction } from '@opentelemetry/instrumentation-xml-http-request/build/src/types';
+
+type Parent = {
+  _createSpan: (xhr: XMLHttpRequest, url: string, method: string) => Span | undefined;
+};
+
+export class FaroXhrInstrumentation extends XMLHttpRequestInstrumentation {
+  private parentCreateSpan: Parent['_createSpan'];
+
+  constructor(config: XMLHttpRequestInstrumentationConfig = {}) {
+    super(config);
+
+    const self = this as any as Parent;
+    this.parentCreateSpan = self._createSpan.bind(this);
+  }
+
+  // Patching the parent's private method to handle url type string or URL
+  protected override _patchOpen() {
+    return (original: OpenFunction): OpenFunction => {
+      const plugin = this;
+      return function patchOpen(this: XMLHttpRequest, ...args): void {
+        const method: string = args[0];
+        let url: string | URL = args[1];
+
+        if (isInstanceOfURL(url)) {
+          url = url.href;
+        }
+
+        plugin.parentCreateSpan(this, url, method);
+
+        return original.apply(this, args);
+      };
+    };
+  }
+}
+
+function isInstanceOfURL(item: any): item is URL {
+  return item instanceof URL;
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/getDefaultInstrumentations.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/getDefaultInstrumentations.test.ts
@@ -1,0 +1,64 @@
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+
+import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+
+jest.mock('@opentelemetry/instrumentation-fetch');
+jest.mock('@opentelemetry/instrumentation-xml-http-request');
+
+describe('getDefaultOTELInstrumentations', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an array of instrumentations', () => {
+    const instrumentations = getDefaultOTELInstrumentations();
+    expect(instrumentations).toBeInstanceOf(Array);
+    expect(instrumentations[0]).toBeInstanceOf(FetchInstrumentation);
+    expect(instrumentations[1]).toBeInstanceOf(XMLHttpRequestInstrumentation);
+  });
+
+  it('should apply default options', () => {
+    getDefaultOTELInstrumentations();
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreNetworkEvents: true,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+
+  it('should apply custom options', () => {
+    const ignoreUrls = ['example.com'];
+    const propagateTraceHeaderCorsUrls = ['example2.com'];
+
+    getDefaultOTELInstrumentations({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      fetchInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+      xhrInstrumentationOptions: {
+        ignoreNetworkEvents: false,
+      },
+    });
+
+    expect(FetchInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+
+    expect(XMLHttpRequestInstrumentation).toHaveBeenCalledWith({
+      ignoreUrls,
+      propagateTraceHeaderCorsUrls,
+      ignoreNetworkEvents: false,
+      applyCustomAttributesOnSpan: expect.any(Function),
+    });
+  });
+});

--- a/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
@@ -1,11 +1,22 @@
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 
+import type { Config, Patterns } from '@grafana/faro-core';
+
 import { FaroXhrInstrumentation } from './faroXhrInstrumentation';
 import {
   fetchCustomAttributeFunctionWithDefaults,
   xhrCustomAttributeFunctionWithDefaults,
 } from './instrumentationUtils';
-import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
+import type { InstrumentationOption } from './types';
+
+// TODO this should not be part of faro-core because it is a concern of the web-sdk package.
+// We eventually will refactor all faro packages so the Config can be extended with package specific options.
+// We also will remove all package specific functionality from the faro-core package.
+// For time reasons and conflicting priorities, we will leave it here for now.
+type WebTracingInstrumentationOptions = NonNullable<Config['webTracingInstrumentation']>;
+type DefaultInstrumentationsOptions = NonNullable<WebTracingInstrumentationOptions['instrumentationOptions']> & {
+  ignoreUrls?: Patterns;
+};
 
 export function getDefaultOTELInstrumentations(options: DefaultInstrumentationsOptions = {}): InstrumentationOption[] {
   const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;

--- a/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
@@ -13,8 +13,8 @@ import type { InstrumentationOption } from './types';
 // We eventually will refactor all faro packages so the Config can be extended with package specific options.
 // We also will remove all package specific functionality from the faro-core package.
 // For time reasons and conflicting priorities, we will leave it here for now.
-type WebTracingInstrumentationOptions = NonNullable<Config['webTracingInstrumentation']>;
-type DefaultInstrumentationsOptions = NonNullable<WebTracingInstrumentationOptions['instrumentationOptions']> & {
+type tracingInstrumentationOptions = NonNullable<Config['tracingInstrumentation']>;
+type DefaultInstrumentationsOptions = NonNullable<tracingInstrumentationOptions['instrumentationOptions']> & {
   ignoreUrls?: Patterns;
 };
 

--- a/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
@@ -1,0 +1,48 @@
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+
+import { FaroXhrInstrumentation } from './faroXhrInstrumentation';
+import {
+  fetchCustomAttributeFunctionWithDefaults,
+  xhrCustomAttributeFunctionWithDefaults,
+} from './instrumentationUtils';
+import type { DefaultInstrumentationsOptions, InstrumentationOption } from './types';
+
+export function getDefaultOTELInstrumentations(options: DefaultInstrumentationsOptions = {}): InstrumentationOption[] {
+  const { fetchInstrumentationOptions, xhrInstrumentationOptions, ...sharedOptions } = options;
+
+  const fetchOpts = createFetchInstrumentationOptions(fetchInstrumentationOptions, sharedOptions);
+  const xhrOpts = createXhrInstrumentationOptions(xhrInstrumentationOptions, sharedOptions);
+
+  return [new FetchInstrumentation(fetchOpts), new FaroXhrInstrumentation(xhrOpts)];
+}
+function createFetchInstrumentationOptions(
+  fetchInstrumentationOptions: DefaultInstrumentationsOptions['fetchInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+    ignoreNetworkEvents: true,
+    // keep this here to overwrite the defaults above if provided by the users
+    ...fetchInstrumentationOptions,
+    // always keep this function
+    applyCustomAttributesOnSpan: fetchCustomAttributeFunctionWithDefaults(
+      fetchInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
+}
+
+function createXhrInstrumentationOptions(
+  xhrInstrumentationOptions: DefaultInstrumentationsOptions['xhrInstrumentationOptions'],
+  sharedOptions: Record<string, unknown>
+) {
+  return {
+    ...sharedOptions,
+    ignoreNetworkEvents: true,
+    // keep this here to overwrite the defaults above if provided by the users
+    ...xhrInstrumentationOptions,
+    // always keep this function
+    applyCustomAttributesOnSpan: xhrCustomAttributeFunctionWithDefaults(
+      xhrInstrumentationOptions?.applyCustomAttributesOnSpan
+    ),
+  };
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/getDefaultOTELInstrumentations.ts
@@ -9,8 +9,8 @@ import {
 } from './instrumentationUtils';
 import type { InstrumentationOption } from './types';
 
-// TODO this should not be part of faro-core because it is a concern of the web-sdk package.
-// We eventually will refactor all faro packages so the Config can be extended with package specific options.
+// The types shouldn't be part of faro-core because it is a concern of the web-sdk package.
+// We eventually will refactor all faro packages so the Config can be extended with package specific options so we keep the core clean.
 // We also will remove all package specific functionality from the faro-core package.
 // For time reasons and conflicting priorities, we will leave it here for now.
 type tracingInstrumentationOptions = NonNullable<Config['tracingInstrumentation']>;

--- a/packages/web-sdk/src/instrumentations/web-tracing/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/index.ts
@@ -1,0 +1,13 @@
+export { FaroTraceExporter } from './faroTraceExporter';
+
+export { FaroSessionSpanProcessor } from './sessionSpanProcessor';
+
+export { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+
+export { TracingInstrumentation } from './instrumentation';
+
+export { getSamplingDecision } from './sampler';
+
+export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';
+
+export { setSpanStatusOnFetchError, fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';

--- a/packages/web-sdk/src/instrumentations/web-tracing/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/index.ts
@@ -8,6 +8,6 @@ export { TracingInstrumentation } from './instrumentation';
 
 export { getSamplingDecision } from './sampler';
 
-export type { FaroTraceExporterConfig, TracingInstrumentationOptions } from './types';
+export type { FaroTraceExporterConfig } from './types';
 
-export { setSpanStatusOnFetchError, fetchCustomAttributeFunctionWithDefaults } from './instrumentationUtils';
+export { fetchCustomAttributeFunctionWithDefaults, setSpanStatusOnFetchError } from './instrumentationUtils';

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -28,7 +28,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
   static SCHEDULED_BATCH_DELAY_MS = 1000;
 
   initialize(): void {
-    if (this.config.webTracingInstrumentation?.enabled === false) {
+    if (!this.config.webTracingInstrumentation?.enabled) {
       this.logDebug('faro web-tracing instrumentation disabled');
       return;
     }

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -29,7 +29,6 @@ export class TracingInstrumentation extends BaseInstrumentation {
 
   initialize(): void {
     if (this.config.tracingInstrumentation?.enabled === false) {
-      this.logDebug('faro web-tracing instrumentation disabled');
       return;
     }
 

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -28,12 +28,12 @@ export class TracingInstrumentation extends BaseInstrumentation {
   static SCHEDULED_BATCH_DELAY_MS = 1000;
 
   initialize(): void {
-    if (this.config.webTracingInstrumentation?.enabled === false) {
+    if (this.config.tracingInstrumentation?.enabled === false) {
       this.logDebug('faro web-tracing instrumentation disabled');
       return;
     }
 
-    const options = this.config.webTracingInstrumentation ?? {};
+    const options = this.config.tracingInstrumentation ?? {};
     const attributes: ResourceAttributes = {};
 
     if (this.config.app.name) {

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -1,0 +1,114 @@
+import { context, trace } from '@opentelemetry/api';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+} from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAMESPACE,
+} from '@opentelemetry/semantic-conventions/incubating';
+
+import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-core';
+
+import { FaroTraceExporter } from './faroTraceExporter';
+import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
+import { getSamplingDecision } from './sampler';
+import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
+import type { TracingInstrumentationOptions } from './types';
+
+// the providing of app name here is not great
+// should delay initialization and provide the full Faro config,
+// taking app name from it
+
+export class TracingInstrumentation extends BaseInstrumentation {
+  readonly name = '@grafana/faro-web-sdk:instrumentation-web-tracing';
+  readonly version = VERSION;
+
+  static SCHEDULED_BATCH_DELAY_MS = 1000;
+
+  constructor(private options: TracingInstrumentationOptions = {}) {
+    super();
+  }
+
+  initialize(): void {
+    const options = this.options;
+    const attributes: ResourceAttributes = {};
+
+    if (this.config.app.name) {
+      attributes[ATTR_SERVICE_NAME] = this.config.app.name;
+    }
+
+    if (this.config.app.namespace) {
+      attributes[ATTR_SERVICE_NAMESPACE] = this.config.app.namespace;
+    }
+
+    if (this.config.app.version) {
+      attributes[ATTR_SERVICE_VERSION] = this.config.app.version;
+    }
+
+    if (this.config.app.environment) {
+      attributes[ATTR_DEPLOYMENT_ENVIRONMENT_NAME] = this.config.app.environment;
+      /**
+       * @deprecated will be removed in the future and has been replaced by ATTR_DEPLOYMENT_ENVIRONMENT_NAME (deployment.environment.name)
+       */
+      attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT] = this.config.app.environment;
+    }
+
+    Object.assign(attributes, options.resourceAttributes);
+
+    const resource = Resource.default().merge(new Resource(attributes));
+
+    const provider = new WebTracerProvider({
+      resource,
+      sampler: {
+        shouldSample: () => {
+          return {
+            decision: getSamplingDecision(this.api.getSession()),
+          };
+        },
+      },
+    });
+
+    provider.addSpanProcessor(
+      options.spanProcessor ??
+        new FaroSessionSpanProcessor(
+          new BatchSpanProcessor(new FaroTraceExporter({ api: this.api }), {
+            scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
+            maxExportBatchSize: 30,
+          }),
+          this.metas
+        )
+    );
+
+    provider.register({
+      propagator: options.propagator ?? new W3CTraceContextPropagator(),
+      contextManager: options.contextManager ?? new ZoneContextManager(),
+    });
+
+    const { propagateTraceHeaderCorsUrls, fetchInstrumentationOptions, xhrInstrumentationOptions } =
+      this.options.instrumentationOptions ?? {};
+
+    registerInstrumentations({
+      instrumentations:
+        options.instrumentations ??
+        getDefaultOTELInstrumentations({
+          ignoreUrls: this.getIgnoreUrls(),
+          propagateTraceHeaderCorsUrls,
+          fetchInstrumentationOptions,
+          xhrInstrumentationOptions,
+        }),
+    });
+
+    this.api.initOTEL(trace, context);
+  }
+
+  private getIgnoreUrls(): Array<string | RegExp> {
+    return this.transports.transports.flatMap((transport: Transport) => transport.getIgnoreUrls());
+  }
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -21,10 +21,6 @@ import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations
 import { getSamplingDecision } from './sampler';
 import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 
-// the providing of app name here is not great
-// should delay initialization and provide the full Faro config,
-// taking app name from it
-
 export class TracingInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-web-tracing';
   readonly version = VERSION;
@@ -32,6 +28,11 @@ export class TracingInstrumentation extends BaseInstrumentation {
   static SCHEDULED_BATCH_DELAY_MS = 1000;
 
   initialize(): void {
+    if (this.config.webTracingInstrumentation?.enabled === false) {
+      this.logDebug('faro web-tracing instrumentation disabled');
+      return;
+    }
+
     const options = this.config.webTracingInstrumentation ?? {};
     const attributes: ResourceAttributes = {};
 

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -28,7 +28,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
   static SCHEDULED_BATCH_DELAY_MS = 1000;
 
   initialize(): void {
-    if (!this.config.webTracingInstrumentation?.enabled) {
+    if (this.config.webTracingInstrumentation?.enabled === false) {
       this.logDebug('faro web-tracing instrumentation disabled');
       return;
     }

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentation.ts
@@ -12,6 +12,7 @@ import {
 import {
   ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
   ATTR_SERVICE_NAMESPACE,
+  // eslint-disable-next-line import/no-unresolved
 } from '@opentelemetry/semantic-conventions/incubating';
 
 import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-core';

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentationUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentationUtils.test.ts
@@ -1,0 +1,77 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+
+import { fetchCustomAttributeFunctionWithDefaults, setSpanStatusOnFetchError } from './instrumentationUtils';
+import * as instrumentationUtilsMock from './instrumentationUtils';
+
+describe('faroTraceExporter.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([500, 599, 400, 499, new Error()])('set span status on fetch error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = result instanceof Error ? result : ({ status: result } as Response);
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on fetch success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: result } as Response;
+
+    setSpanStatusOnFetchError(span, request, response);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls custom setSpanStatusOnFetchError from fetchInstrumentationOptions and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnFetchError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const request = {} as Request;
+    const response = { status: 500 } as Response;
+    const callback = jest.fn();
+
+    fetchCustomAttributeFunctionWithDefaults(callback)(span, request, response);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, request, response);
+  });
+
+  test.each([500, 599, 400, 499])('set span status on XMLHttpRequest error', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+  });
+
+  test.each([200, 300, 399])('does not set span status on XMLHttpRequest success', (result) => {
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: result } as XMLHttpRequest;
+
+    instrumentationUtilsMock.setSpanStatusOnXMLHttpRequestError(span, xhr);
+
+    expect(span.setStatus).not.toBeCalled();
+  });
+
+  it('calls custom setSpanStatusOnFetchError from xhrInstrumentationOptions and callback if provided', () => {
+    const mock = jest.fn();
+    jest.spyOn(instrumentationUtilsMock, 'setSpanStatusOnXMLHttpRequestError').mockImplementationOnce(mock);
+
+    const span = { setStatus: jest.fn() } as any;
+    const xhr = { status: 500 } as XMLHttpRequest;
+    const callback = jest.fn();
+
+    instrumentationUtilsMock.xhrCustomAttributeFunctionWithDefaults(callback)(span, xhr);
+
+    expect(span.setStatus).toBeCalledWith({ code: SpanStatusCode.ERROR });
+    expect(callback).toBeCalledWith(span, xhr);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/web-tracing/instrumentationUtils.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/instrumentationUtils.ts
@@ -1,0 +1,53 @@
+import { Span, SpanStatusCode } from '@opentelemetry/api';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
+
+export interface FetchError {
+  status?: number;
+  message: string;
+}
+
+/**
+ * Adds HTTP status code to every span.
+ *
+ * The fetch instrumentation does not always set the span status to error as defined by the spec.
+ * To work around that issue we manually set the span status.
+ *
+ * Issue: https://github.com/open-telemetry/opentelemetry-js/issues/3564
+ * Spec: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#status
+ */
+export function setSpanStatusOnFetchError(span: Span, _request: Request | RequestInit, result: Response | FetchError) {
+  const httpStatusCode = result instanceof Error ? 0 : result.status;
+  setSpanStatus(span, httpStatusCode);
+}
+
+export function setSpanStatusOnXMLHttpRequestError(span: Span, xhr: XMLHttpRequest) {
+  setSpanStatus(span, xhr.status);
+}
+
+function setSpanStatus(span: Span, httpStatusCode?: number) {
+  if (httpStatusCode == null) {
+    return;
+  }
+
+  const isError = httpStatusCode === 0;
+  const isClientOrServerError = httpStatusCode >= 400 && httpStatusCode < 600;
+
+  if (isError || isClientOrServerError) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}
+
+export function fetchCustomAttributeFunctionWithDefaults(callback?: FetchCustomAttributeFunction) {
+  return (span: Span, request: Request | RequestInit, result: Response | FetchError) => {
+    setSpanStatusOnFetchError(span, request, result);
+    callback?.(span, request, result);
+  };
+}
+
+export function xhrCustomAttributeFunctionWithDefaults(callback?: XHRCustomAttributeFunction) {
+  return (span: Span, xhr: XMLHttpRequest) => {
+    setSpanStatusOnXMLHttpRequestError(span, xhr);
+    callback?.(span, xhr);
+  };
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/sampler.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/sampler.test.ts
@@ -1,0 +1,29 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import { getSamplingDecision } from './sampler';
+
+describe('Sampler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Set SamplingDecision to NOT_RECORD (0) if session is not part of the sample', () => {
+    const samplingDecision = getSamplingDecision({
+      attributes: {
+        isSampled: 'false',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.NOT_RECORD);
+  });
+
+  it('Set SamplingDecision to RECORD_AND_SAMPLED (2) if session is part of the sample', () => {
+    const samplingDecision = getSamplingDecision({
+      attributes: {
+        isSampled: 'true',
+      },
+    });
+
+    expect(samplingDecision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/web-tracing/sampler.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/sampler.ts
@@ -1,0 +1,10 @@
+import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
+
+import type { MetaSession } from '@grafana/faro-core';
+
+export function getSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
+  const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';
+  const samplingDecision = isSessionSampled ? SamplingDecision.RECORD_AND_SAMPLED : SamplingDecision.NOT_RECORD;
+
+  return samplingDecision;
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/sessionSpanProcessor.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/sessionSpanProcessor.ts
@@ -1,0 +1,40 @@
+import type { Context } from '@opentelemetry/api';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
+// False positive. Package can be resolved.
+// eslint-disable-next-line import/no-unresolved
+import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
+
+import type { Metas } from '@grafana/faro-core';
+
+export class FaroSessionSpanProcessor implements SpanProcessor {
+  constructor(
+    private processor: SpanProcessor,
+    private metas: Metas
+  ) {}
+
+  forceFlush(): Promise<void> {
+    return this.processor.forceFlush();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    const session = this.metas.value.session;
+
+    if (session?.id) {
+      span.attributes[ATTR_SESSION_ID] = session.id;
+      /**
+       * @deprecated will be removed in the future and has been replaced by ATTR_SESSION_ID (session.id)
+       */
+      span.attributes['session_id'] = session.id;
+    }
+
+    this.processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.processor.onEnd(span);
+  }
+
+  shutdown(): Promise<void> {
+    return this.processor.shutdown();
+  }
+}

--- a/packages/web-sdk/src/instrumentations/web-tracing/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/types.ts
@@ -1,11 +1,6 @@
-import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
-import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
-import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
-import type { ResourceAttributes } from '@opentelemetry/resources';
-import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import type { API, Patterns } from '@grafana/faro-core';
+import type { API } from '@grafana/faro-core';
 
 // type got remove by with experimental/v0.52.0 and is replaced by the following type:
 // See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0
@@ -14,29 +9,3 @@ export type InstrumentationOption = Instrumentation | Instrumentation[];
 export interface FaroTraceExporterConfig {
   api: API;
 }
-
-export interface TracingInstrumentationOptions {
-  resourceAttributes?: ResourceAttributes;
-  propagator?: TextMapPropagator;
-  contextManager?: ContextManager;
-  instrumentations?: InstrumentationOption[];
-  spanProcessor?: SpanProcessor;
-  instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
-}
-
-export type MatchUrlDefinitions = Patterns;
-
-export type DefaultInstrumentationsOptions = {
-  ignoreUrls?: MatchUrlDefinitions;
-  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
-
-  fetchInstrumentationOptions?: {
-    applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
-    ignoreNetworkEvents?: boolean;
-  };
-
-  xhrInstrumentationOptions?: {
-    applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
-    ignoreNetworkEvents?: boolean;
-  };
-};

--- a/packages/web-sdk/src/instrumentations/web-tracing/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-tracing/types.ts
@@ -1,0 +1,42 @@
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch';
+import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
+import type { ResourceAttributes } from '@opentelemetry/resources';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
+
+import type { API, Patterns } from '@grafana/faro-core';
+
+// type got remove by with experimental/v0.52.0 and is replaced by the following type:
+// See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0
+export type InstrumentationOption = Instrumentation | Instrumentation[];
+
+export interface FaroTraceExporterConfig {
+  api: API;
+}
+
+export interface TracingInstrumentationOptions {
+  resourceAttributes?: ResourceAttributes;
+  propagator?: TextMapPropagator;
+  contextManager?: ContextManager;
+  instrumentations?: InstrumentationOption[];
+  spanProcessor?: SpanProcessor;
+  instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
+}
+
+export type MatchUrlDefinitions = Patterns;
+
+export type DefaultInstrumentationsOptions = {
+  ignoreUrls?: MatchUrlDefinitions;
+  propagateTraceHeaderCorsUrls?: MatchUrlDefinitions;
+
+  fetchInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+
+  xhrInstrumentationOptions?: {
+    applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+    ignoreNetworkEvents?: boolean;
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,13 +1361,6 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opentelemetry/api-logs@0.57.1":
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz#97ebd714f0b1fcdf896e85c465ae5c5b22747425"
-  integrity sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==
-  dependencies:
-    "@opentelemetry/api" "^1.3.0"
-
 "@opentelemetry/api-logs@0.57.2", "@opentelemetry/api-logs@^0.57.0":
   version "0.57.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz#d4001b9aa3580367b40fe889f3540014f766cc87"
@@ -1591,18 +1584,6 @@
     "@opentelemetry/instrumentation" "0.57.2"
     "@opentelemetry/sdk-trace-web" "1.30.1"
     "@opentelemetry/semantic-conventions" "1.28.0"
-
-"@opentelemetry/instrumentation@0.57.1":
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz#5aea772be8783a35d69d643da46582f381ba1810"
-  integrity sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==
-  dependencies:
-    "@opentelemetry/api-logs" "0.57.1"
-    "@types/shimmer" "^1.2.0"
-    import-in-the-middle "^1.8.1"
-    require-in-the-middle "^7.1.1"
-    semver "^7.5.2"
-    shimmer "^1.2.1"
 
 "@opentelemetry/instrumentation@0.57.2", "@opentelemetry/instrumentation@^0.57.0":
   version "0.57.2"
@@ -11309,16 +11290,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11454,14 +11426,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12503,7 +12468,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12516,15 +12481,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Why

Work in process

For easy of use include the web-tracing instrumentation in the default instrumentations.

If existing users already use the web-tracing package Faro takes care of removing the default web-tracing package

### This how the config changes

**new way with web-tracing  auto instrumentation if no customization is needed**

```ts
  const faro = coreInit({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },
  });
```


**New way, with web-tracing auto instrumentation and additional tracing configuration**

```ts
initializeFaro({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },

    webTracingInstrumentation: {
      enabled: true, // default true
      instrumentationOptions: {
        propagateTraceHeaderCorsUrls: ['...'],
        fetchInstrumentationOptions: {
          ignoreNetworkEvents: true,
        },
      },
    },
  });

```

**Current state**
```ts
initializeFaro({
    url: `http://localhost:${env.faro.portAppReceiver}/collect`,
    apiKey: env.faro.apiKey,
    trackWebVitalsAttribution: true,
    instrumentations: [
      ...getWebInstrumentations({
        captureConsole: true,
      }),

      new TracingInstrumentation({
        instrumentationOptions: {
          propagateTraceHeaderCorsUrls: ['...'],
          fetchInstrumentationOptions: {
            ignoreNetworkEvents: true,
          },
        },
      }),
    ],
    app: {
      name: env.client.packageName,
      namespace: env.client.packageNamespace,
      version: env.package.version,
      environment: env.mode.name,
    },
  });
```


## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
