### PR TITLE
chore: tag if resource is fetched form a third party or first party

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+Chore (`@grafana/faro-web-sdk`): Add round-trip-time (RTT) and first-party/third-party indicators
+to `faro.performance.*` events (#974)
+
+Chore (`@grafana/faro-web-sdk`): Add first-party and third-party indicators to fetch and xhr request
+attributes (#974)
+
 ## 1.13.3
 
 - Chore (`@grafana/faro-web-sdk`): Ensure all properties in `attributes` and `context` objects are

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -16,8 +16,7 @@ describe('Meta API', () => {
     });
   });
 
-  beforeEach(() => {
-    jest.resetModules();
+  afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
   });

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -167,4 +167,4 @@ export {
   STORAGE_KEY,
 } from './instrumentations/session';
 
-export { getIgnoreUrls } from './utils/url';
+export { getIgnoreUrls, getDomainLevelAttribute, isSameDomain } from './utils/url';

--- a/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
@@ -129,7 +129,7 @@ describe('Performance Instrumentation', () => {
     const config = mockConfig({
       transports: [fetchTransport],
       instrumentations: [new PerformanceInstrumentation()],
-      ignoreUrls: [/.*foo-analytics/, /.*.analytics.com/, 'http://example.com/awesome-image'],
+      ignoreUrls: [/.*foo-analytics/, /.*.analytics.com/, 'http://third-party.com/awesome-image'],
       trackResources: true,
     });
 
@@ -147,6 +147,6 @@ describe('Performance Instrumentation', () => {
     expect(mockTransport.items.length).toBe(1);
 
     const item = mockTransport.items[0] as TransportItem<EventEvent>;
-    expect(item.payload.attributes?.['name']).toBe('http://example.com');
+    expect(item.payload.attributes?.['name']).toBe('http://dummy.com');
   });
 });

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -48,6 +48,7 @@ describe('performanceUtils', () => {
       renderBlockingStatus: 'unknown',
       protocol: 'h2',
       initiatorType: 'navigation',
+      rtt: '305',
     } as FaroNavigationTiming);
   });
 
@@ -73,6 +74,7 @@ describe('performanceUtils', () => {
       initiatorType: 'img',
       ttfb: '359',
       visibilityState: 'visible',
+      rtt: '370',
     } as FaroResourceTiming);
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -18,7 +18,30 @@ Object.defineProperty(window, 'performance', {
   writable: true,
 });
 
+const originalWindow = window;
 describe('performanceUtils', () => {
+  const mockUrl = 'http://dummy.com';
+
+  beforeEach(() => {
+    window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: mockUrl,
+        hostname: 'dummy.com',
+      },
+      writable: true, // possibility to override
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window = originalWindow;
+  });
+
   it(`calculates navigation timing`, () => {
     const faroNavigationTiming = createFaroNavigationTiming(performanceNavigationEntry);
     expect(faroNavigationTiming).toStrictEqual({
@@ -32,7 +55,7 @@ describe('performanceUtils', () => {
       ttfb: '542',
       type: 'navigate',
 
-      name: 'http://example.com',
+      name: 'http://dummy.com',
       tcpHandshakeTime: '53',
       dnsLookupTime: '139',
       tlsNegotiationTime: '33',
@@ -49,13 +72,14 @@ describe('performanceUtils', () => {
       protocol: 'h2',
       initiatorType: 'navigation',
       rtt: '305',
+      domainLevel: 'firstParty',
     } as FaroNavigationTiming);
   });
 
   it(`calculates resource timings`, () => {
     const faroResourceTiming = createFaroResourceTiming(performanceResourceEntry);
     expect(faroResourceTiming).toStrictEqual({
-      name: 'http://example.com/awesome-image',
+      name: 'http://third-party.com/awesome-image',
       duration: '370',
       tcpHandshakeTime: '0',
       dnsLookupTime: '0',
@@ -75,6 +99,7 @@ describe('performanceUtils', () => {
       ttfb: '359',
       visibilityState: 'visible',
       rtt: '370',
+      domainLevel: 'firstParty',
     } as FaroResourceTiming);
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -120,6 +120,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
     initiatorType: initiatorType,
     visibilityState: document.visibilityState,
     ttfb: toFaroPerformanceTimingString(responseStart - requestStart),
+    rtt: toFaroPerformanceTimingString(responseStart - fetchStart),
 
     // TODO: add in future iteration, ideally after nested objects are supported by the collector.
     // serverTiming: resourceEntryRaw.serverTiming,

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -1,5 +1,7 @@
 import { isArray, type PushEventOptions, unknownString } from '@grafana/faro-core';
 
+import { getDomainLevelAttribute } from '../../utils/url';
+
 import type { CacheType, FaroNavigationTiming, FaroResourceTiming } from './types';
 
 const w3cTraceparentFormat = /^00-[a-f0-9]{32}-[a-f0-9]{16}-[0-9]{1,2}$/;
@@ -121,6 +123,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
     visibilityState: document.visibilityState,
     ttfb: toFaroPerformanceTimingString(responseStart - requestStart),
     rtt: toFaroPerformanceTimingString(responseStart - fetchStart),
+    domainLevel: getDomainLevelAttribute(new URL(name)),
 
     // TODO: add in future iteration, ideally after nested objects are supported by the collector.
     // serverTiming: resourceEntryRaw.serverTiming,

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -1,6 +1,6 @@
 // the values of this timings are contrived for testing.They do not necessarily reflect reality.
 export const performanceNavigationEntry = {
-  name: 'http://example.com',
+  name: 'http://dummy.com',
   entryType: 'navigation',
   startTime: 0,
   duration: 2700,
@@ -42,7 +42,7 @@ export const performanceNavigationEntry = {
 } as unknown as PerformanceNavigationTiming;
 
 export const performanceResourceEntry = {
-  name: 'http://example.com/awesome-image',
+  name: 'http://third-party.com/awesome-image',
   entryType: 'resource',
   startTime: 778,
   duration: 370,

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -33,6 +33,7 @@ export type FaroResourceTiming = Readonly<{
   // serverTiming: PerformanceServerTiming[];
   visibilityState: DocumentVisibilityState;
   ttfb: string;
+  rtt: string;
 }>;
 
 export type FaroNavigationItem = {

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -34,6 +34,7 @@ export type FaroResourceTiming = Readonly<{
   visibilityState: DocumentVisibilityState;
   ttfb: string;
   rtt: string;
+  domainLevel: 'firstParty' | 'thirdParty';
 }>;
 
 export type FaroNavigationItem = {

--- a/packages/web-sdk/src/utils/url.ts
+++ b/packages/web-sdk/src/utils/url.ts
@@ -7,3 +7,14 @@ import type { Transport } from '@grafana/faro-core';
 export function getIgnoreUrls() {
   return faro.transports.transports.flatMap((transport: Transport) => transport.getIgnoreUrls());
 }
+
+export function isSameDomain(url: URL): boolean {
+  return url.hostname === window.location.hostname;
+}
+
+export const firstPartyDomainAttribute = 'firstParty';
+export const thirdPartyDomainAttribute = 'thirdParty';
+
+export function getDomainLevelAttribute(url: URL): typeof firstPartyDomainAttribute | typeof thirdPartyDomainAttribute {
+  return isSameDomain(url) ? firstPartyDomainAttribute : thirdPartyDomainAttribute;
+}

--- a/packages/web-sdk/src/utils/urls.test.ts
+++ b/packages/web-sdk/src/utils/urls.test.ts
@@ -2,7 +2,13 @@ import { BaseTransport, initializeFaro, VERSION } from '@grafana/faro-core';
 import type { Patterns, TransportItem } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
-import { getIgnoreUrls } from './url';
+import {
+  firstPartyDomainAttribute,
+  getDomainLevelAttribute,
+  getIgnoreUrls,
+  isSameDomain,
+  thirdPartyDomainAttribute,
+} from './url';
 
 class MockTransport extends BaseTransport {
   readonly name = '@grafana/transport-mock';
@@ -26,8 +32,31 @@ class MockTransport extends BaseTransport {
     return (this.ignoreURLs ?? ([] as Patterns[])).concat(this.config.ignoreUrls ?? []);
   }
 }
+const originalWindow = window;
 
 describe('Urls', () => {
+  const mockUrl = 'http://dummy.com';
+
+  beforeEach(() => {
+    window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: mockUrl,
+        hostname: 'dummy.com',
+      },
+      writable: true, // possibility to override
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window = originalWindow;
+  });
+
   it('should return the correct ignore urls for the given configuration', () => {
     const transport = new MockTransport(['http://foo.com']);
 
@@ -41,5 +70,15 @@ describe('Urls', () => {
     const urls = getIgnoreUrls();
 
     expect(urls).toEqual(['http://foo.com', 'http://example.com', 'http://example2.com/test']);
+  });
+
+  it('should correctly determine if a URL is on the same domain', () => {
+    expect(isSameDomain(new URL('http://dummy.com'))).toBe(true);
+    expect(isSameDomain(new URL('http://other-domain.com'))).toBe(false);
+  });
+
+  it('should return the correct attribute based on whether the URL is on the same domain', () => {
+    expect(getDomainLevelAttribute(new URL('http://dummy.com'))).toBe(firstPartyDomainAttribute);
+    expect(getDomainLevelAttribute(new URL('http://other-domain.com'))).toBe(thirdPartyDomainAttribute);
   });
 });

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -49,6 +49,7 @@ describe('faroTraceExporter.utils', () => {
       'http.url': 'http://foo/bar',
       'http.user_agent': 'my-user-agent',
       duration_ns: '15000064',
+      domainLevel: 'thirdParty',
     });
   });
 

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -2,7 +2,7 @@ import type { SpanContext } from '@opentelemetry/api';
 import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
 import { faro, unknownString } from '@grafana/faro-core';
-import type { EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
+import { type EventAttributes as FaroEventAttributes, getDomainLevelAttribute } from '@grafana/faro-web-sdk';
 
 const DURATION_NS_KEY = 'duration_ns';
 
@@ -33,6 +33,13 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = []) {
         if (!Number.isNaN(span.endTimeUnixNano) && !Number.isNaN(span.startTimeUnixNano)) {
           faroEventAttributes[DURATION_NS_KEY] = String(Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano));
         }
+
+        const url = faroEventAttributes['http.url'];
+        if (url) {
+          faroEventAttributes['domainLevel'] = getDomainLevelAttribute(new URL(url));
+        }
+
+        console.log('faroEventAttributes :>> ', faroEventAttributes);
 
         const index = (scope?.name ?? '').indexOf('-');
         let eventName = unknownString;


### PR DESCRIPTION
## Why
It also adds a `domainLevel` attribute to `fetch` and `xhr` events and to `faro.performance.resource|navigation` timings

Note:
Because we only can add string values to the attributes objects, I decided to be explicit and take `"firstParty"` and `"thirdParty"` instead of the string values `"true"` and `"false"`
I am a bit unsure about the correctness of the naming. Input is very appreciated.

## What
See above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
