### PR TITLE
feat: adding ability to track all changes for web vitals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Feature (`@grafana/faro-web-sdk`): Provide a `webVitals.reportAllWebVitalChanges` option to report all changes for web vitals (#981)
+
 ## 1.13.3
 
 - Chore (`@grafana/faro-web-sdk`): Ensure all properties in `attributes` and `context` objects are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Feature (`@grafana/faro-web-sdk`): Provide a `webVitals.reportAllWebVitalChanges` option to report
+- Feature (`@grafana/faro-web-sdk`): Provide a `webVitalsInstrumentation.reportAllChanges` option to report
   all changes for web vitals (#981)
 
 ## 1.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- Feature (`@grafana/faro-web-sdk`): Provide a `webVitals.reportAllWebVitalChanges` option to report all changes for web vitals (#981)
+- Feature (`@grafana/faro-web-sdk`): Provide a `webVitals.reportAllWebVitalChanges` option to report
+  all changes for web vitals (#981)
 
 ## 1.13.3
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -164,20 +164,28 @@ export interface Config<P = APIEvent> {
   trackWebVitalsAttribution?: boolean;
 
   /**
-   * Report all changes for web vitals (default: false)
-   *
-   * In most cases, you only want the callback function to be called when the metric is ready to be reported.
-   * However, it is possible to report every change (e.g. each larger layout shift as it happens)
-   * by setting reportAllChanges to true.
+   * Configuration for the web vitals instrumentation
    */
-  reportAllWebVitalChanges?: boolean;
+  webVitals?: {
+    /**
+     * Report all changes for web vitals (default: false)
+     *
+     * In most cases, you only want the callback function to be called when the metric is ready to be reported.
+     * However, it is possible to report every change (e.g. each larger layout shift as it happens)
+     * by setting reportAllChanges to true.
+     *
+     * This can be useful when debugging, but in general using reportAllWebVitalChanges is not needed (or recommended)
+     * for measuring these metrics in production.
+     */
+    reportAllWebVitalChanges?: boolean;
+  };
 
   /**
    * Configuration for the console instrumentation
    */
   consoleInstrumentation?: {
     /**
-     * Configure what console levels should be captured by Faro. By default the follwoing levels
+     * Configure what console levels should be captured by Faro. By default the following levels
      * are disabled: console.debug, console.trace, console.log
      *
      * If you want to collect all levels set captureConsoleDisabledLevels: [];

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -166,7 +166,7 @@ export interface Config<P = APIEvent> {
   /**
    * Configuration for the web vitals instrumentation
    */
-  webVitals?: {
+  webVitalsInstrumentation?: {
     /**
      * Report all changes for web vitals (default: false)
      *
@@ -174,10 +174,10 @@ export interface Config<P = APIEvent> {
      * However, it is possible to report every change (e.g. each larger layout shift as it happens)
      * by setting reportAllChanges to true.
      *
-     * This can be useful when debugging, but in general using reportAllWebVitalChanges is not needed (or recommended)
+     * This can be useful when debugging, but in general using reportAllChanges is not needed (or recommended)
      * for measuring these metrics in production.
      */
-    reportAllWebVitalChanges?: boolean;
+    reportAllChanges?: boolean;
   };
 
   /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -164,6 +164,15 @@ export interface Config<P = APIEvent> {
   trackWebVitalsAttribution?: boolean;
 
   /**
+   * Report all changes for web vitals (default: false)
+   *
+   * In most cases, you only want the callback function to be called when the metric is ready to be reported.
+   * However, it is possible to report every change (e.g. each larger layout shift as it happens)
+   * by setting reportAllChanges to true.
+   */
+  reportAllWebVitalChanges?: boolean;
+
+  /**
    * Configuration for the console instrumentation
    */
   consoleInstrumentation?: {

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -88,15 +88,15 @@ describe('config', () => {
       url: 'http://example.com/my-collector',
       app: {},
       trackWebVitalsAttribution: true,
-      webVitals: {
-        reportAllWebVitalChanges: true,
+      webVitalsInstrumentation: {
+        reportAllChanges: true,
       },
     };
     const config = makeCoreConfig(browserConfig);
 
     expect(config).toBeTruthy();
     expect(config?.trackWebVitalsAttribution).toBe(true);
-    expect(config?.webVitals?.reportAllWebVitalChanges).toBe(true);
+    expect(config?.webVitalsInstrumentation?.reportAllChanges).toBe(true);
   });
 
   it('merges configured urls with default URLs into ignoreUrls list', () => {

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -83,6 +83,22 @@ describe('config', () => {
     expect(config?.ignoreUrls).toEqual([/\/collect(?:\/[\w]*)?$/]);
   });
 
+  it('enables web vitals feature when trackWebVitalsAttribution is true', () => {
+    const browserConfig = {
+      url: 'http://example.com/my-collector',
+      app: {},
+      trackWebVitalsAttribution: true,
+      webVitals: {
+        reportAllWebVitalChanges: true,
+      },
+    };
+    const config = makeCoreConfig(browserConfig);
+
+    expect(config).toBeTruthy();
+    expect(config?.trackWebVitalsAttribution).toBe(true);
+    expect(config?.webVitals?.reportAllWebVitalChanges).toBe(true);
+  });
+
   it('merges configured urls with default URLs into ignoreUrls list', () => {
     const browserConfig = {
       url: 'http://example.com/my-collector',

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -67,7 +67,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     paused = false,
     preventGlobalExposure = false,
     unpatchedConsole = defaultUnpatchedConsole,
-    webVitals,
+    webVitalsInstrumentation,
   }: BrowserConfig = browserConfig;
 
   return {
@@ -103,7 +103,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackResources,
     trackWebVitalsAttribution,
     consoleInstrumentation,
-    webVitals,
+    webVitalsInstrumentation,
   };
 }
 

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -55,7 +55,6 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     user,
     view,
     geoLocationTracking,
-
     // properties with default values
     dedupe = true,
     eventDomain = defaultEventDomain,
@@ -68,6 +67,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     paused = false,
     preventGlobalExposure = false,
     unpatchedConsole = defaultUnpatchedConsole,
+    webVitals,
   }: BrowserConfig = browserConfig;
 
   return {
@@ -103,6 +103,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackResources,
     trackWebVitalsAttribution,
     consoleInstrumentation,
+    webVitals,
   };
 }
 

--- a/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
@@ -14,9 +14,9 @@ export class WebVitalsInstrumentation extends BaseInstrumentation {
   }
 
   private intializeWebVitalsInstrumentation() {
-    if (this.config.trackWebVitalsAttribution) {
-      return new WebVitalsWithAttribution(this.api.pushMeasurement, this.config.reportAllWebVitalChanges);
+    if (this.config?.trackWebVitalsAttribution) {
+      return new WebVitalsWithAttribution(this.api.pushMeasurement, this.config.webVitals);
     }
-    return new WebVitalsBasic(this.api.pushMeasurement, this.config.reportAllWebVitalChanges);
+    return new WebVitalsBasic(this.api.pushMeasurement, this.config.webVitals);
   }
 }

--- a/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
@@ -15,8 +15,8 @@ export class WebVitalsInstrumentation extends BaseInstrumentation {
 
   private intializeWebVitalsInstrumentation() {
     if (this.config.trackWebVitalsAttribution) {
-      return new WebVitalsWithAttribution(this.api.pushMeasurement);
+      return new WebVitalsWithAttribution(this.api.pushMeasurement, this.config.reportAllWebVitalChanges);
     }
-    return new WebVitalsBasic(this.api.pushMeasurement);
+    return new WebVitalsBasic(this.api.pushMeasurement, this.config.reportAllWebVitalChanges);
   }
 }

--- a/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/instrumentation.ts
@@ -15,8 +15,8 @@ export class WebVitalsInstrumentation extends BaseInstrumentation {
 
   private intializeWebVitalsInstrumentation() {
     if (this.config?.trackWebVitalsAttribution) {
-      return new WebVitalsWithAttribution(this.api.pushMeasurement, this.config.webVitals);
+      return new WebVitalsWithAttribution(this.api.pushMeasurement, this.config.webVitalsInstrumentation);
     }
-    return new WebVitalsBasic(this.api.pushMeasurement, this.config.webVitals);
+    return new WebVitalsBasic(this.api.pushMeasurement, this.config.webVitalsInstrumentation);
   }
 }

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
@@ -12,7 +12,7 @@ export class WebVitalsBasic {
     ttfb: onTTFB,
   };
 
-  constructor(private pushMeasurement: MeasurementsAPI['pushMeasurement']) {}
+  constructor(private pushMeasurement: MeasurementsAPI['pushMeasurement'], private reportAllChanges?: boolean) {}
 
   initialize(): void {
     Object.entries(WebVitalsBasic.mapping).forEach(([indicator, executor]) => {
@@ -24,7 +24,7 @@ export class WebVitalsBasic {
             [indicator]: metric.value,
           },
         });
-      });
+      }, { reportAllChanges: this.reportAllChanges });
     });
   }
 }

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
@@ -14,7 +14,7 @@ export class WebVitalsBasic {
 
   constructor(
     private pushMeasurement: MeasurementsAPI['pushMeasurement'],
-    private webVitalConfig?: Config['webVitals']
+    private webVitalConfig?: Config['webVitalsInstrumentation']
   ) {}
 
   initialize(): void {
@@ -29,7 +29,7 @@ export class WebVitalsBasic {
             },
           });
         },
-        { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+        { reportAllChanges: this.webVitalConfig?.reportAllChanges }
       );
     });
   }

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
@@ -12,19 +12,25 @@ export class WebVitalsBasic {
     ttfb: onTTFB,
   };
 
-  constructor(private pushMeasurement: MeasurementsAPI['pushMeasurement'], private reportAllChanges?: boolean) {}
+  constructor(
+    private pushMeasurement: MeasurementsAPI['pushMeasurement'],
+    private reportAllChanges?: boolean
+  ) {}
 
   initialize(): void {
     Object.entries(WebVitalsBasic.mapping).forEach(([indicator, executor]) => {
-      executor((metric) => {
-        this.pushMeasurement({
-          type: 'web-vitals',
+      executor(
+        (metric) => {
+          this.pushMeasurement({
+            type: 'web-vitals',
 
-          values: {
-            [indicator]: metric.value,
-          },
-        });
-      }, { reportAllChanges: this.reportAllChanges });
+            values: {
+              [indicator]: metric.value,
+            },
+          });
+        },
+        { reportAllChanges: this.reportAllChanges }
+      );
     });
   }
 }

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsBasic.ts
@@ -1,6 +1,6 @@
 import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals';
 
-import type { MeasurementsAPI } from '@grafana/faro-core';
+import type { Config, MeasurementsAPI } from '@grafana/faro-core';
 
 export class WebVitalsBasic {
   static mapping = {
@@ -14,7 +14,7 @@ export class WebVitalsBasic {
 
   constructor(
     private pushMeasurement: MeasurementsAPI['pushMeasurement'],
-    private reportAllChanges?: boolean
+    private webVitalConfig?: Config['webVitals']
   ) {}
 
   initialize(): void {
@@ -29,7 +29,7 @@ export class WebVitalsBasic {
             },
           });
         },
-        { reportAllChanges: this.reportAllChanges }
+        { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
       );
     });
   }

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
@@ -2,7 +2,7 @@ import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals/attributio
 import type { Metric } from 'web-vitals/attribution';
 
 import { unknownString } from '@grafana/faro-core';
-import type { MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from '@grafana/faro-core';
+import type { Config, MeasurementEvent, MeasurementsAPI, PushMeasurementOptions } from '@grafana/faro-core';
 
 import { getItem, webStorageType } from '../../utils';
 import { NAVIGATION_ID_STORAGE_KEY } from '../instrumentationConstants';
@@ -18,7 +18,7 @@ const timeToFirstByteKey = 'time_to_first_byte';
 export class WebVitalsWithAttribution {
   constructor(
     private corePushMeasurement: MeasurementsAPI['pushMeasurement'],
-    private reportAllChanges?: boolean
+    private webVitalConfig?: Config['webVitals']
   ) {}
 
   initialize(): void {
@@ -45,7 +45,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 
@@ -63,7 +63,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 
@@ -82,7 +82,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 
@@ -114,7 +114,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 
@@ -135,7 +135,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 
@@ -155,7 +155,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.reportAllChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
     );
   }
 

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
@@ -18,7 +18,7 @@ const timeToFirstByteKey = 'time_to_first_byte';
 export class WebVitalsWithAttribution {
   constructor(
     private corePushMeasurement: MeasurementsAPI['pushMeasurement'],
-    private webVitalConfig?: Config['webVitals']
+    private webVitalConfig?: Config['webVitalsInstrumentation']
   ) {}
 
   initialize(): void {
@@ -45,7 +45,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 
@@ -63,7 +63,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 
@@ -82,7 +82,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 
@@ -114,7 +114,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 
@@ -135,7 +135,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 
@@ -155,7 +155,7 @@ export class WebVitalsWithAttribution {
 
         this.pushMeasurement(values, context);
       },
-      { reportAllChanges: this.webVitalConfig?.reportAllWebVitalChanges }
+      { reportAllChanges: this.webVitalConfig?.reportAllChanges }
     );
   }
 

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
@@ -16,7 +16,7 @@ const loadStateKey = 'load_state';
 const timeToFirstByteKey = 'time_to_first_byte';
 
 export class WebVitalsWithAttribution {
-  constructor(private corePushMeasurement: MeasurementsAPI['pushMeasurement']) {}
+  constructor(private corePushMeasurement: MeasurementsAPI['pushMeasurement'], private reportAllChanges?: boolean) {}
 
   initialize(): void {
     this.measureCLS();
@@ -40,7 +40,7 @@ export class WebVitalsWithAttribution {
       this.addIfPresent(context, 'largest_shift_target', largestShiftTarget);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private measureFCP(): void {
@@ -55,7 +55,7 @@ export class WebVitalsWithAttribution {
       this.addIfPresent(context, loadStateKey, loadState);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private measureFID(): void {
@@ -71,7 +71,7 @@ export class WebVitalsWithAttribution {
       this.addIfPresent(context, loadStateKey, loadState);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private measureINP(): void {
@@ -100,7 +100,7 @@ export class WebVitalsWithAttribution {
       this.addIfPresent(context, 'interaction_type', interactionType);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private measureLCP(): void {
@@ -118,7 +118,7 @@ export class WebVitalsWithAttribution {
       this.addIfPresent(context, 'element', element);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private measureTTFB(): void {
@@ -135,7 +135,7 @@ export class WebVitalsWithAttribution {
       const context = this.buildInitialContext(metric);
 
       this.pushMeasurement(values, context);
-    });
+    }, { reportAllChanges: this.reportAllChanges });
   }
 
   private buildInitialValues(metric: Metric): Values {

--- a/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
+++ b/packages/web-sdk/src/instrumentations/webVitals/webVitalsWithAttribution.ts
@@ -16,7 +16,10 @@ const loadStateKey = 'load_state';
 const timeToFirstByteKey = 'time_to_first_byte';
 
 export class WebVitalsWithAttribution {
-  constructor(private corePushMeasurement: MeasurementsAPI['pushMeasurement'], private reportAllChanges?: boolean) {}
+  constructor(
+    private corePushMeasurement: MeasurementsAPI['pushMeasurement'],
+    private reportAllChanges?: boolean
+  ) {}
 
   initialize(): void {
     this.measureCLS();
@@ -28,114 +31,132 @@ export class WebVitalsWithAttribution {
   }
 
   private measureCLS(): void {
-    onCLS((metric) => {
-      const { loadState, largestShiftValue, largestShiftTime, largestShiftTarget } = metric.attribution;
+    onCLS(
+      (metric) => {
+        const { loadState, largestShiftValue, largestShiftTime, largestShiftTarget } = metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'largest_shift_value', largestShiftValue);
-      this.addIfPresent(values, 'largest_shift_time', largestShiftTime);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'largest_shift_value', largestShiftValue);
+        this.addIfPresent(values, 'largest_shift_time', largestShiftTime);
 
-      const context = this.buildInitialContext(metric);
-      this.addIfPresent(context, loadStateKey, loadState);
-      this.addIfPresent(context, 'largest_shift_target', largestShiftTarget);
+        const context = this.buildInitialContext(metric);
+        this.addIfPresent(context, loadStateKey, loadState);
+        this.addIfPresent(context, 'largest_shift_target', largestShiftTarget);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private measureFCP(): void {
-    onFCP((metric) => {
-      const { firstByteToFCP, timeToFirstByte, loadState } = metric.attribution;
+    onFCP(
+      (metric) => {
+        const { firstByteToFCP, timeToFirstByte, loadState } = metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'first_byte_to_fcp', firstByteToFCP);
-      this.addIfPresent(values, timeToFirstByteKey, timeToFirstByte);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'first_byte_to_fcp', firstByteToFCP);
+        this.addIfPresent(values, timeToFirstByteKey, timeToFirstByte);
 
-      const context = this.buildInitialContext(metric);
-      this.addIfPresent(context, loadStateKey, loadState);
+        const context = this.buildInitialContext(metric);
+        this.addIfPresent(context, loadStateKey, loadState);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private measureFID(): void {
-    onFID((metric) => {
-      const { eventTime, eventTarget, eventType, loadState } = metric.attribution;
+    onFID(
+      (metric) => {
+        const { eventTime, eventTarget, eventType, loadState } = metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'event_time', eventTime);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'event_time', eventTime);
 
-      const context = this.buildInitialContext(metric);
-      this.addIfPresent(context, 'event_target', eventTarget);
-      this.addIfPresent(context, 'event_type', eventType);
-      this.addIfPresent(context, loadStateKey, loadState);
+        const context = this.buildInitialContext(metric);
+        this.addIfPresent(context, 'event_target', eventTarget);
+        this.addIfPresent(context, 'event_type', eventType);
+        this.addIfPresent(context, loadStateKey, loadState);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private measureINP(): void {
-    onINP((metric) => {
-      const {
-        interactionTime,
-        presentationDelay,
-        inputDelay,
-        processingDuration,
-        nextPaintTime,
-        loadState,
-        interactionTarget,
-        interactionType,
-      } = metric.attribution;
+    onINP(
+      (metric) => {
+        const {
+          interactionTime,
+          presentationDelay,
+          inputDelay,
+          processingDuration,
+          nextPaintTime,
+          loadState,
+          interactionTarget,
+          interactionType,
+        } = metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'interaction_time', interactionTime);
-      this.addIfPresent(values, 'presentation_delay', presentationDelay);
-      this.addIfPresent(values, 'input_delay', inputDelay);
-      this.addIfPresent(values, 'processing_duration', processingDuration);
-      this.addIfPresent(values, 'next_paint_time', nextPaintTime);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'interaction_time', interactionTime);
+        this.addIfPresent(values, 'presentation_delay', presentationDelay);
+        this.addIfPresent(values, 'input_delay', inputDelay);
+        this.addIfPresent(values, 'processing_duration', processingDuration);
+        this.addIfPresent(values, 'next_paint_time', nextPaintTime);
 
-      const context = this.buildInitialContext(metric);
-      this.addIfPresent(context, loadStateKey, loadState);
-      this.addIfPresent(context, 'interaction_target', interactionTarget);
-      this.addIfPresent(context, 'interaction_type', interactionType);
+        const context = this.buildInitialContext(metric);
+        this.addIfPresent(context, loadStateKey, loadState);
+        this.addIfPresent(context, 'interaction_target', interactionTarget);
+        this.addIfPresent(context, 'interaction_type', interactionType);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private measureLCP(): void {
-    onLCP((metric) => {
-      const { elementRenderDelay, resourceLoadDelay, resourceLoadDuration, timeToFirstByte, element } =
-        metric.attribution;
+    onLCP(
+      (metric) => {
+        const { elementRenderDelay, resourceLoadDelay, resourceLoadDuration, timeToFirstByte, element } =
+          metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'element_render_delay', elementRenderDelay);
-      this.addIfPresent(values, 'resource_load_delay', resourceLoadDelay);
-      this.addIfPresent(values, 'resource_load_duration', resourceLoadDuration);
-      this.addIfPresent(values, timeToFirstByteKey, timeToFirstByte);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'element_render_delay', elementRenderDelay);
+        this.addIfPresent(values, 'resource_load_delay', resourceLoadDelay);
+        this.addIfPresent(values, 'resource_load_duration', resourceLoadDuration);
+        this.addIfPresent(values, timeToFirstByteKey, timeToFirstByte);
 
-      const context = this.buildInitialContext(metric);
-      this.addIfPresent(context, 'element', element);
+        const context = this.buildInitialContext(metric);
+        this.addIfPresent(context, 'element', element);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private measureTTFB(): void {
-    onTTFB((metric) => {
-      const { dnsDuration, connectionDuration, requestDuration, waitingDuration, cacheDuration } = metric.attribution;
+    onTTFB(
+      (metric) => {
+        const { dnsDuration, connectionDuration, requestDuration, waitingDuration, cacheDuration } = metric.attribution;
 
-      const values = this.buildInitialValues(metric);
-      this.addIfPresent(values, 'dns_duration', dnsDuration);
-      this.addIfPresent(values, 'connection_duration', connectionDuration);
-      this.addIfPresent(values, 'request_duration', requestDuration);
-      this.addIfPresent(values, 'waiting_duration', waitingDuration);
-      this.addIfPresent(values, 'cache_duration', cacheDuration);
+        const values = this.buildInitialValues(metric);
+        this.addIfPresent(values, 'dns_duration', dnsDuration);
+        this.addIfPresent(values, 'connection_duration', connectionDuration);
+        this.addIfPresent(values, 'request_duration', requestDuration);
+        this.addIfPresent(values, 'waiting_duration', waitingDuration);
+        this.addIfPresent(values, 'cache_duration', cacheDuration);
 
-      const context = this.buildInitialContext(metric);
+        const context = this.buildInitialContext(metric);
 
-      this.pushMeasurement(values, context);
-    }, { reportAllChanges: this.reportAllChanges });
+        this.pushMeasurement(values, context);
+      },
+      { reportAllChanges: this.reportAllChanges }
+    );
   }
 
   private buildInitialValues(metric: Metric): Values {


### PR DESCRIPTION
## Why

solves #947 

provides the option to enable the `trackAllChanges` feature in the web-vitals package 

## What

add `reportAllWebVitalChanges` to the config object to enable that feature in the web-vitals package 