### PR TITLE
chore(web-tracing): attach user attributes to spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+- feat (`@grafana/faro-web-sdk`): Enhance user meta properties to align with OTEL semantic
+  conventions for user attributes (#990)
+
+- Chore (`@grafana/faro-web-tracing`): Add user attributes to spans (#990)
+
 ## 1.13.3
 
 - Chore (`@grafana/faro-web-sdk`): Ensure all properties in `attributes` and `context` objects are

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -35,9 +35,33 @@ export interface MetaApp {
 }
 
 export interface MetaUser {
+  /**
+   * User email address.
+   */
   email?: string;
+  /**
+   * Unique identifier
+   */
   id?: string;
+  /**
+   * User’s full name
+   */
   username?: string;
+  /**
+   * Short name or login/username of the user.
+   */
+  shortName?: string;
+  /**
+   * comma separated list of user roles. "admin",editor" etc.
+   */
+  roles?: string;
+  /**
+   * Unique user hash to correlate information for a user in anonymized form.
+   */
+  hash?: string;
+  /**
+   * arbitrary user attributes, must be of type string.
+   */
   attributes?: MetaAttributes;
 }
 

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -44,13 +44,13 @@ export interface MetaUser {
    */
   id?: string;
   /**
-   * User’s full name
+   * Short name or login/username of the user.
    */
   username?: string;
   /**
-   * Short name or login/username of the user.
+   * User’s full name
    */
-  shortName?: string;
+  fullName?: string;
   /**
    * comma separated list of user roles. "admin",editor" etc.
    */

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -78,6 +78,7 @@ export {
   isToString,
   isTypeof,
   isUndefined,
+  isEmpty,
   InternalLoggerLevel,
   LogLevel,
   noop,

--- a/packages/web-tracing/src/faroMetaAttributesSpanProcessor.test.ts
+++ b/packages/web-tracing/src/faroMetaAttributesSpanProcessor.test.ts
@@ -16,8 +16,8 @@ describe('faroMetaAttributesSpanProcessor', () => {
         user: {
           email: 'email',
           id: 'id',
-          username: 'username',
-          shortName: 'shortName',
+          username: 'user-short-name',
+          fullName: 'user-full-name',
           roles: 'admin, editor,viewer',
           hash: 'hash',
         },
@@ -41,8 +41,8 @@ describe('faroMetaAttributesSpanProcessor', () => {
       session_id: 'session-id',
       'user.email': 'email',
       'user.id': 'id',
-      'user.full_name': 'username',
-      'user.name': 'shortName',
+      'user.full_name': 'user-full-name',
+      'user.name': 'user-short-name',
       'user.roles': ['admin', 'editor', 'viewer'],
       'user.hash': 'hash',
     });

--- a/packages/web-tracing/src/faroMetaAttributesSpanProcessor.test.ts
+++ b/packages/web-tracing/src/faroMetaAttributesSpanProcessor.test.ts
@@ -1,0 +1,50 @@
+import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
+
+describe('faroMetaAttributesSpanProcessor', () => {
+  const processor = new FaroMetaAttributesSpanProcessor(
+    {
+      onStart: jest.fn(),
+      onEnd: jest.fn(),
+      shutdown: jest.fn(),
+      forceFlush: jest.fn(),
+    },
+    {
+      value: {
+        session: {
+          id: 'session-id',
+        },
+        user: {
+          email: 'email',
+          id: 'id',
+          username: 'username',
+          shortName: 'shortName',
+          roles: 'admin, editor,viewer',
+          hash: 'hash',
+        },
+      },
+      add: jest.fn(),
+      remove: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }
+  );
+
+  it('adds attributes to span', () => {
+    const span = {
+      attributes: {},
+    };
+
+    processor.onStart(span as any, {} as any);
+
+    expect(span.attributes).toStrictEqual({
+      'session.id': 'session-id',
+      session_id: 'session-id',
+      'user.email': 'email',
+      'user.id': 'id',
+      'user.full_name': 'username',
+      'user.name': 'shortName',
+      'user.roles': ['admin', 'editor', 'viewer'],
+      'user.hash': 'hash',
+    });
+  });
+});

--- a/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
+++ b/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
@@ -38,11 +38,11 @@ export class FaroMetaAttributesSpanProcessor implements SpanProcessor {
     }
 
     if (user.username) {
-      span.attributes['user.full_name'] = user.username;
+      span.attributes['user.name'] = user.username;
     }
 
-    if (user.shortName) {
-      span.attributes['user.name'] = user.shortName;
+    if (user.fullName) {
+      span.attributes['user.full_name'] = user.fullName;
     }
 
     if (user.roles) {

--- a/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
+++ b/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
@@ -6,11 +6,7 @@ import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating'
 
 import type { Metas } from '@grafana/faro-web-sdk';
 
-/**
- * @deprecated
- * please use FaroMetaAttributesSpanProcessor instead
- */
-export class FaroSessionSpanProcessor implements SpanProcessor {
+export class FaroMetaAttributesSpanProcessor implements SpanProcessor {
   constructor(
     private processor: SpanProcessor,
     private metas: Metas
@@ -29,6 +25,32 @@ export class FaroSessionSpanProcessor implements SpanProcessor {
        * @deprecated will be removed in the future and has been replaced by ATTR_SESSION_ID (session.id)
        */
       span.attributes['session_id'] = session.id;
+    }
+
+    const user = this.metas.value.user ?? {};
+
+    if (user.email) {
+      span.attributes['user.email'] = user.email;
+    }
+
+    if (user.id) {
+      span.attributes['user.id'] = user.id;
+    }
+
+    if (user.username) {
+      span.attributes['user.full_name'] = user.username;
+    }
+
+    if (user.shortName) {
+      span.attributes['user.name'] = user.shortName;
+    }
+
+    if (user.roles) {
+      span.attributes['user.roles'] = user.roles.split(',').map((role) => role.trim());
+    }
+
+    if (user.hash) {
+      span.attributes['user.hash'] = user.hash;
     }
 
     this.processor.onStart(span, parentContext);

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -18,10 +18,10 @@ import {
 
 import { BaseInstrumentation, Transport, VERSION } from '@grafana/faro-web-sdk';
 
+import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 import { getSamplingDecision } from './sampler';
-import { FaroSessionSpanProcessor } from './sessionSpanProcessor';
 import type { TracingInstrumentationOptions } from './types';
 
 // the providing of app name here is not great
@@ -77,7 +77,7 @@ export class TracingInstrumentation extends BaseInstrumentation {
       },
       spanProcessors: [
         options.spanProcessor ??
-          new FaroSessionSpanProcessor(
+          new FaroMetaAttributesSpanProcessor(
             new BatchSpanProcessor(new FaroTraceExporter({ api: this.api }), {
               scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
               maxExportBatchSize: 30,

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -75,18 +75,17 @@ export class TracingInstrumentation extends BaseInstrumentation {
           };
         },
       },
+      spanProcessors: [
+        options.spanProcessor ??
+          new FaroSessionSpanProcessor(
+            new BatchSpanProcessor(new FaroTraceExporter({ api: this.api }), {
+              scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
+              maxExportBatchSize: 30,
+            }),
+            this.metas
+          ),
+      ],
     });
-
-    provider.addSpanProcessor(
-      options.spanProcessor ??
-        new FaroSessionSpanProcessor(
-          new BatchSpanProcessor(new FaroTraceExporter({ api: this.api }), {
-            scheduledDelayMillis: TracingInstrumentation.SCHEDULED_BATCH_DELAY_MS,
-            maxExportBatchSize: 30,
-          }),
-          this.metas
-        )
-    );
 
     provider.register({
       propagator: options.propagator ?? new W3CTraceContextPropagator(),


### PR DESCRIPTION
## Why

The web-tracing instrumentation now takes care to add user attributes to spans.

The `UserMeta` was updated with more properties to be aligned with [otel semantic conventions for user](https://opentelemetry.io/docs/specs/semconv/attributes-registry/user/).

## What
* Add missing attributes to user meta to be compatible with otel semantic attributes
* create new span exporter which takes care of adding session and user attributes to spans

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
