### PR TITLE
fix(quick-start-browser docs): update default otel instruments

### DIFF
--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -181,8 +181,8 @@ const faro = initializeFaro({
 Due to it's large size, [OpenTelemetry][opentelemetry-js] tracing support is provided in a separate
 `@grafana/faro-web-tracing` package.
 
-The provided default OTel setup includes tracing instrumentations for user interaction, fetch and document load, and W3C
-trace context propagation via `fetch` and `xhr`.
+The provided default OTel setup includes tracing instrumentations for fetch and xhr requests as well
+as W3C trace context propagation via `fetch` and `xhr`.
 
 ```ts
 import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';


### PR DESCRIPTION
## Why

rom quick-start-browser docs: Remove instruments fwe do longer include by default 

## What

See above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated
