### PR TITLE
chore(config): flatten geolocation tracking settings

### DIFF
--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -86,9 +86,7 @@ describe('Meta API', () => {
         sessionTracking: {
           session: initialSession,
         },
-        geoLocationTracking: {
-          enabled: false,
-        },
+        trackGeolocation: false,
       });
 
       // mockConfig is the result of calling makeCoreConfig in faro-web-sdk package.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -226,18 +226,13 @@ export interface Config<P = APIEvent> {
   };
 
   /**
-   * Configuration for the location tracking (Grafana cloud only)
+   * Enable or disable geolocation tracking.
+   * Geolocation tracking must be enabled in the Grafana Cloud settings first.
+   * It cannot be enabled solely on the client side.
+   * This option allows control over tracking on the client side to comply with user
+   * privacy requirements.
    */
-  geoLocationTracking?: {
-    /**
-     * Enable or disable geolocation tracking.
-     * Geolocation tracking must be enabled in the Grafana Cloud settings first.
-     * It cannot be enabled solely on the client side.
-     * This option allows control over tracking on the client side to comply with user
-     * privacy requirements.
-     */
-    enabled?: boolean;
-  };
+  trackGeolocation?: boolean;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -133,11 +133,11 @@ describe('config', () => {
       },
     };
 
-    let config = makeCoreConfig({ ...browserConfig, geoLocationTracking: { enabled: true } });
+    let config = makeCoreConfig({ ...browserConfig, trackGeolocation: true });
     expect(config?.sessionTracking?.session?.overrides).toHaveProperty('geoLocationTrackingEnabled');
     expect(config?.sessionTracking?.session?.overrides?.geoLocationTrackingEnabled).toBe(true);
 
-    config = makeCoreConfig({ ...browserConfig, geoLocationTracking: { enabled: false } });
+    config = makeCoreConfig({ ...browserConfig, trackGeolocation: false });
     expect(config?.sessionTracking?.session?.overrides).toHaveProperty('geoLocationTrackingEnabled');
     expect(config?.sessionTracking?.session?.overrides?.geoLocationTrackingEnabled).toBe(false);
 

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -5,6 +5,7 @@ import {
   defaultInternalLoggerLevel,
   defaultLogArgsSerializer,
   defaultUnpatchedConsole,
+  isBoolean,
   isEmpty,
   isObject,
 } from '@grafana/faro-core';
@@ -54,7 +55,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     trackWebVitalsAttribution,
     user,
     view,
-    geoLocationTracking,
+    trackGeolocation,
     // properties with default values
     dedupe = true,
     eventDomain = defaultEventDomain,
@@ -96,7 +97,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     sessionTracking: {
       ...defaultSessionTrackingConfig,
       ...sessionTracking,
-      ...crateSessionMeta({ geoLocationTracking, sessionTracking }),
+      ...crateSessionMeta({ trackGeolocation, sessionTracking }),
     },
     user,
     view,
@@ -125,13 +126,13 @@ function createDefaultMetas(browserConfig: BrowserConfig): MetaItem[] {
 }
 
 function crateSessionMeta({
-  geoLocationTracking,
+  trackGeolocation,
   sessionTracking,
-}: Pick<BrowserConfig, 'geoLocationTracking' | 'sessionTracking'>): { session: MetaSession } | {} {
+}: Pick<BrowserConfig, 'trackGeolocation' | 'sessionTracking'>): { session: MetaSession } | {} {
   const overrides: MetaSession['overrides'] = {};
 
-  if (geoLocationTracking?.enabled != null) {
-    overrides.geoLocationTrackingEnabled = geoLocationTracking.enabled;
+  if (isBoolean(trackGeolocation)) {
+    overrides.geoLocationTrackingEnabled = trackGeolocation;
   }
 
   if (isEmpty(overrides)) {


### PR DESCRIPTION
## Why

Flatten the geolocation config for easy of use.
The feature isn't released so the change hasn't any negative effects on our users.

## What

Change to a simple property instead of config object with a nested `enabled` property

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added/updated
- [ ] Changelog updated
- [ ] Documentation updated
