### PR TITLE
chore: don't add empty context or attribute objects if no data is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Improvement (`@grafana/faro-core`): Avoid sending empty `attributes` or `context` objects
+  when no data is provided (#1089)
+
 ## 1.14.1
 
 - Improvement (`@grafana/faro-web-sdk`): The ignored errors parser now also parses stack traces.

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -1,3 +1,4 @@
+import type { TransportItem } from '../..';
 import { initializeFaro } from '../../initialize';
 import { mockConfig, MockTransport } from '../../testUtils';
 import type { API } from '../types';
@@ -149,6 +150,14 @@ describe('api.events', () => {
           h: 'undefined',
           i: '[1,2,3]',
         });
+      });
+
+      it('does not stringify empty attributes', () => {
+        api.pushEvent('test');
+        api.pushEvent('test2', {});
+        expect(transport.items).toHaveLength(2);
+        expect((transport.items[0] as TransportItem<EventEvent>).payload.attributes).toBeUndefined();
+        expect((transport.items[0] as TransportItem<EventEvent>).payload.attributes).toBeUndefined();
       });
     });
   });

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -1,9 +1,10 @@
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
 import type { Metas } from '../../metas';
-import { TransportItem, TransportItemType, Transports } from '../../transports';
+import { TransportItemType } from '../../transports';
+import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
+import { deepEqual, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -26,12 +27,14 @@ export function initializeEventsAPI(
     { skipDedupe, spanContext, timestampOverwriteMs } = {}
   ) => {
     try {
+      const attrs = stringifyObjectValues(attributes);
+
       const item: TransportItem<EventEvent> = {
         meta: metas.value,
         payload: {
           name,
           domain: domain ?? config.eventDomain,
-          attributes: stringifyObjectValues(attributes),
+          attributes: isEmpty(attrs) ? undefined : attrs,
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -1,6 +1,6 @@
 import { initializeFaro } from '../../initialize';
 import { mockConfig, MockTransport } from '../../testUtils';
-import { TransportItemType } from '../../transports';
+import { TransportItem, TransportItemType } from '../../transports';
 import type { API } from '../types';
 
 import type { ExceptionEvent, ExceptionStackFrame, PushErrorOptions } from './types';
@@ -230,9 +230,9 @@ describe('api.exceptions', () => {
         expect((transport.items[1]?.payload as ExceptionEvent)?.context).toEqual({ cause: '[1,3]' });
         expect((transport.items[2]?.payload as ExceptionEvent)?.context).toEqual({ cause: '{"a":"b"}' });
         expect((transport.items[3]?.payload as ExceptionEvent)?.context).toEqual({ cause: 'Error: original error' });
-        expect((transport.items[4]?.payload as ExceptionEvent)?.context).toEqual({});
-        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
-        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toEqual({});
+        expect((transport.items[4]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[5]?.payload as ExceptionEvent)?.context).toBeUndefined();
+        expect((transport.items[6]?.payload as ExceptionEvent)?.context).toBeUndefined();
       });
 
       it('stringifies all values added to the context', () => {
@@ -300,6 +300,16 @@ describe('api.exceptions', () => {
         expect(transport.items).toHaveLength(1);
         expect((transport.items[0]?.payload as ExceptionEvent).value).toEqual(typeErrorMsg);
       });
+    });
+
+    it('does not stringify empty context', () => {
+      api.pushError(new Error('test'));
+      api.pushError(new Error('test2'), {
+        context: {},
+      });
+      expect(transport.items).toHaveLength(2);
+      expect((transport.items[0] as TransportItem<ExceptionEvent>).payload.context).toBeUndefined();
+      expect((transport.items[0] as TransportItem<ExceptionEvent>).payload.context).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -8,6 +8,7 @@ import {
   deepEqual,
   getCurrentTimestamp,
   isArray,
+  isEmpty,
   isError,
   isNull,
   isObject,
@@ -55,6 +56,11 @@ export function initializeExceptionsAPI(
       return;
     }
 
+    const ctx = stringifyObjectValues({
+      ...parseCause(error),
+      ...(context ?? {}),
+    });
+
     const item: TransportItem<ExceptionEvent> = {
       meta: metas.value,
       payload: {
@@ -67,10 +73,7 @@ export function initializeExceptionsAPI(
               span_id: spanContext.spanId,
             }
           : tracesApi.getTraceContext(),
-        context: stringifyObjectValues({
-          ...parseCause(error),
-          ...(context ?? {}),
-        }),
+        context: isEmpty(ctx) ? undefined : ctx,
       },
       type: TransportItemType.EXCEPTION,
     };

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -1,5 +1,6 @@
 import { initializeFaro } from '../../initialize';
 import { mockConfig, MockTransport } from '../../testUtils';
+import type { TransportItem } from '../../transports';
 import { LogLevel } from '../../utils';
 import type { API } from '../types';
 
@@ -165,6 +166,16 @@ describe('api.logs', () => {
         h: 'undefined',
         i: '[1,2,3]',
       });
+    });
+
+    it('does not stringify empty context', () => {
+      api.pushLog(['test']);
+      api.pushLog(['test2'], {
+        context: {},
+      });
+      expect(transport.items).toHaveLength(2);
+      expect((transport.items[0] as TransportItem<LogEvent>).payload.context).toBeUndefined();
+      expect((transport.items[0] as TransportItem<LogEvent>).payload.context).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -1,10 +1,9 @@
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
 import type { Metas } from '../../metas';
-import { TransportItem, TransportItemType } from '../../transports';
-import type { Transports } from '../../transports';
+import { TransportItem, TransportItemType, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, defaultLogLevel, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
+import { deepEqual, defaultLogLevel, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -30,12 +29,14 @@ export function initializeLogsAPI(
     { context, level, skipDedupe, spanContext, timestampOverwriteMs } = {}
   ) => {
     try {
+      const ctx = stringifyObjectValues(context);
+
       const item: TransportItem<LogEvent> = {
         type: TransportItemType.LOG,
         payload: {
           message: logArgsSerializer(args),
           level: level ?? defaultLogLevel,
-          context: stringifyObjectValues(context),
+          context: isEmpty(ctx) ? undefined : ctx,
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
           trace: spanContext
             ? {

--- a/packages/core/src/api/logs/types.ts
+++ b/packages/core/src/api/logs/types.ts
@@ -6,7 +6,7 @@ import type { TraceContext } from '../traces';
 export type LogContext = Record<string, string>;
 
 export interface LogEvent {
-  context: LogContext;
+  context: LogContext | undefined;
   level: LogLevel;
   message: string;
   timestamp: string;

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -1,4 +1,4 @@
-import type { MeasurementEvent, PushMeasurementOptions } from '../..';
+import type { MeasurementEvent, PushMeasurementOptions, TransportItem } from '../..';
 import { initializeFaro } from '../../initialize';
 import { mockConfig, MockTransport } from '../../testUtils';
 import type { API } from '../types';
@@ -234,6 +234,25 @@ describe('api.measurements', () => {
         h: 'undefined',
         i: '[1,2,3]',
       });
+    });
+
+    it('does not stringify empty context', () => {
+      api.pushMeasurement(
+        {
+          type: 'custom',
+          values: {},
+        },
+        {
+          context: {},
+        }
+      );
+      api.pushMeasurement({
+        type: 'custom2',
+        values: {},
+      });
+      expect(transport.items).toHaveLength(2);
+      expect((transport.items[0] as TransportItem<MeasurementEvent>).payload.context).toBeUndefined();
+      expect((transport.items[0] as TransportItem<MeasurementEvent>).payload.context).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -4,7 +4,7 @@ import type { Metas } from '../../metas';
 import { TransportItem, TransportItemType } from '../../transports';
 import type { Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
-import { deepEqual, getCurrentTimestamp, isNull, stringifyObjectValues } from '../../utils';
+import { deepEqual, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
 import type { TracesAPI } from '../traces';
 
@@ -27,6 +27,8 @@ export function initializeMeasurementsAPI(
     { skipDedupe, context, spanContext, timestampOverwriteMs } = {}
   ) => {
     try {
+      const ctx = stringifyObjectValues(context);
+
       const item: TransportItem<MeasurementEvent> = {
         type: TransportItemType.MEASUREMENT,
         payload: {
@@ -38,7 +40,7 @@ export function initializeMeasurementsAPI(
               }
             : tracesApi.getTraceContext(),
           timestamp: timestampOverwriteMs ? timestampToIsoString(timestampOverwriteMs) : getCurrentTimestamp(),
-          context: stringifyObjectValues(context),
+          context: isEmpty(ctx) ? undefined : ctx,
         },
         meta: metas.value,
       };

--- a/packages/web-sdk/src/instrumentations/errors/getErrorDetails.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/getErrorDetails.test.ts
@@ -123,7 +123,7 @@ describe('errors', () => {
     expect((transport.items[0] as TransportItem<LogEvent>).payload.message).toBe(
       'console.error: boo ' + stringifyExternalJson(details)
     );
-    expect((transport.items[0] as TransportItem<LogEvent>).payload.context['value']).toBe(
+    expect((transport.items[0] as TransportItem<LogEvent>).payload?.context?.['value']).toBe(
       'boo ' + stringifyExternalJson(details)
     );
   });


### PR DESCRIPTION
## Why

Faro always added an empty object for empty `attribute` and `context` data.
This unnecessarily waists resources.



## What
Ensure to not add the respective properties if no data is available

## Screenshots
### Before
<img width="324" alt="Screenshot 2025-04-01 at 16 48 31" src="https://github.com/user-attachments/assets/bbe317da-772f-4c94-9207-f9c39f20dd2d" />
<img width="323" alt="Screenshot 2025-04-01 at 16 48 49" src="https://github.com/user-attachments/assets/db78c0db-b763-40c1-8012-db8aaa16e6b3" />


## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
