### PR TITLE
chore: 1.14.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.14.2
+
 - Improvement (`@grafana/faro-core`): Avoid sending empty `attributes` or `context` objects
   when no data is provided (#1089)
 


### PR DESCRIPTION
## 1.14.2

- Improvement (`@grafana/faro-core`): Avoid sending empty `attributes` or `context` objects
  when no data is provided (#1089)