### PR TITLE
chore: User action update durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+- Improvement (`@grafana/faro-web-sdk`): User actions improvements (#1101)
+
+- Improvement (`@grafana/faro-web-sdk`): User actions improvements (#1101)
+
 - Fix (`@grafana/faro-web-tracing`): Fixed unexpected behavior in xhr instrumentation when custom
   objects with a `toString` method were used as URLs (#1100).
 

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -9,7 +9,7 @@ import {
 import type { Faro } from '@grafana/faro-react';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
-import { env } from '../utils';
+import { env } from '../utils/env';
 
 export function initializeFaro(): Faro {
   const faro = coreInit({
@@ -42,6 +42,7 @@ export function initializeFaro(): Faro {
       version: env.package.version,
       environment: env.mode.name,
     },
+
     trackResources: true,
 
     batching: {

--- a/packages/core/src/api/const.ts
+++ b/packages/core/src/api/const.ts
@@ -1,3 +1,4 @@
-export const USER_ACTION_START_MESSAGE_TYPE = 'user-action-start';
-export const USER_ACTION_END_MESSAGE_TYPE = 'user-action-end';
-export const USER_ACTION_CANCEL_MESSAGE_TYPE = 'user-action-cancel';
+export const USER_ACTION_START = 'user-action-start';
+export const USER_ACTION_END = 'user-action-end';
+export const USER_ACTION_CANCEL = 'user-action-cancel';
+export const USER_ACTION_HALT = 'user-action-halt';

--- a/packages/core/src/api/events/initialize.test.ts
+++ b/packages/core/src/api/events/initialize.test.ts
@@ -3,11 +3,7 @@ import { initializeFaro } from '../../initialize';
 import { mockConfig, mockInternalLogger, MockTransport } from '../../testUtils';
 import { dateNow } from '../../utils';
 import { mockMetas, mockTracesApi, mockTransports } from '../apiTestHelpers';
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '../const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '../const';
 import { ItemBuffer } from '../ItemBuffer';
 import type { API, APIEvent, ApiMessageBusMessages } from '../types';
 
@@ -183,7 +179,7 @@ describe('api.events', () => {
       const getMessage = () => message;
 
       message = {
-        type: USER_ACTION_START_MESSAGE_TYPE,
+        type: USER_ACTION_START,
         name: 'testAction',
         startTime: Date.now(),
         parentId: 'parent-id',
@@ -203,7 +199,7 @@ describe('api.events', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_END_MESSAGE_TYPE,
+        type: USER_ACTION_END,
         name: 'testAction',
         id: 'parent-id',
         startTime: dateNow(),
@@ -216,7 +212,7 @@ describe('api.events', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+        type: USER_ACTION_CANCEL,
         name: 'testAction',
         parentId: 'parent-id',
       };

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -6,7 +6,7 @@ import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
-import { USER_ACTION_START_MESSAGE_TYPE } from '../const';
+import { USER_ACTION_START } from '../const';
 import type { ItemBuffer } from '../ItemBuffer';
 import type { TracesAPI } from '../traces';
 import type { ApiMessageBusMessages } from '../types';
@@ -76,7 +76,7 @@ export function initializeEventsAPI({
       internalLogger.debug('Pushing event\n', item);
 
       const msg = getMessage();
-      if (msg && msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+      if (msg && msg.type === USER_ACTION_START) {
         actionBuffer.addItem(item);
       } else {
         transports.execute(item);

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -3,11 +3,7 @@ import { mockConfig, mockInternalLogger, MockTransport } from '../../testUtils';
 import { TransportItem, TransportItemType } from '../../transports';
 import { dateNow } from '../../utils';
 import { mockMetas, mockTracesApi, mockTransports } from '../apiTestHelpers';
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '../const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '../const';
 import { ItemBuffer } from '../ItemBuffer';
 import type { API, APIEvent, ApiMessageBusMessages } from '../types';
 
@@ -333,7 +329,7 @@ describe('api.exceptions', () => {
         const getMessage = () => message;
 
         message = {
-          type: USER_ACTION_START_MESSAGE_TYPE,
+          type: USER_ACTION_START,
           name: 'testAction',
           startTime: Date.now(),
           parentId: 'parent-id',
@@ -353,7 +349,7 @@ describe('api.exceptions', () => {
         expect(actionBuffer.size()).toBe(1);
 
         message = {
-          type: USER_ACTION_END_MESSAGE_TYPE,
+          type: USER_ACTION_END,
           name: 'testAction',
           id: 'parent-id',
           startTime: dateNow(),
@@ -366,7 +362,7 @@ describe('api.exceptions', () => {
         expect(actionBuffer.size()).toBe(1);
 
         message = {
-          type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+          type: USER_ACTION_CANCEL,
           name: 'testAction',
           parentId: 'parent-id',
         };

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -16,7 +16,7 @@ import {
   stringifyObjectValues,
 } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
-import { USER_ACTION_START_MESSAGE_TYPE } from '../const';
+import { USER_ACTION_START } from '../const';
 import type { ItemBuffer } from '../ItemBuffer';
 import type { TracesAPI } from '../traces';
 import type { ApiMessageBusMessages } from '../types';
@@ -117,7 +117,7 @@ export function initializeExceptionsAPI({
       internalLogger.debug('Pushing exception\n', item);
 
       const msg = getMessage();
-      if (msg && msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+      if (msg && msg.type === USER_ACTION_START) {
         actionBuffer.addItem(item);
       } else {
         transports.execute(item);

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -6,6 +6,7 @@ export type {
   UserActionCancelMessage,
   UserActionEndMessage,
   UserActionStartMessage,
+  UserActionHaltMessage,
   UserAction,
 } from './types';
 
@@ -33,4 +34,4 @@ export type { OTELApi, TraceContext, TraceEvent, TracesAPI } from './traces';
 
 export { apiMessageBus } from './initialize';
 
-export { USER_ACTION_CANCEL_MESSAGE_TYPE, USER_ACTION_END_MESSAGE_TYPE, USER_ACTION_START_MESSAGE_TYPE } from './const';
+export { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START, USER_ACTION_HALT } from './const';

--- a/packages/core/src/api/logs/initialize.test.ts
+++ b/packages/core/src/api/logs/initialize.test.ts
@@ -3,11 +3,7 @@ import { mockConfig, mockInternalLogger, MockTransport } from '../../testUtils';
 import type { TransportItem } from '../../transports';
 import { dateNow, LogLevel } from '../../utils';
 import { mockMetas, mockTracesApi, mockTransports } from '../apiTestHelpers';
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '../const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '../const';
 import { ItemBuffer } from '../ItemBuffer';
 import type { API, APIEvent, ApiMessageBusMessages } from '../types';
 
@@ -249,7 +245,7 @@ describe('api.logs', () => {
       const getMessage = () => message;
 
       message = {
-        type: USER_ACTION_START_MESSAGE_TYPE,
+        type: USER_ACTION_START,
         name: 'testAction',
         startTime: Date.now(),
         parentId: 'parent-id',
@@ -269,7 +265,7 @@ describe('api.logs', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_END_MESSAGE_TYPE,
+        type: USER_ACTION_END,
         name: 'testAction',
         id: 'parent-id',
         startTime: dateNow(),
@@ -282,7 +278,7 @@ describe('api.logs', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+        type: USER_ACTION_CANCEL,
         name: 'testAction',
         parentId: 'parent-id',
       };

--- a/packages/core/src/api/logs/initialize.ts
+++ b/packages/core/src/api/logs/initialize.ts
@@ -6,7 +6,7 @@ import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, defaultLogLevel, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
-import { USER_ACTION_START_MESSAGE_TYPE } from '../const';
+import { USER_ACTION_START } from '../const';
 import type { ItemBuffer } from '../ItemBuffer';
 import type { TracesAPI } from '../traces';
 import type { ApiMessageBusMessages } from '../types';
@@ -79,7 +79,7 @@ export function initializeLogsAPI({
       internalLogger.debug('Pushing log\n', item);
 
       const msg = getMessage();
-      if (msg && msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+      if (msg && msg.type === USER_ACTION_START) {
         actionBuffer.addItem(item);
       } else {
         transports.execute(item);

--- a/packages/core/src/api/measurements/initialize.test.ts
+++ b/packages/core/src/api/measurements/initialize.test.ts
@@ -9,11 +9,7 @@ import {
 import { initializeFaro } from '../../initialize';
 import { mockConfig, mockInternalLogger, MockTransport } from '../../testUtils';
 import { mockMetas, mockTracesApi, mockTransports } from '../apiTestHelpers';
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '../const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '../const';
 import { ItemBuffer } from '../ItemBuffer';
 import type { API } from '../types';
 
@@ -334,7 +330,7 @@ describe('api.measurements', () => {
       const getMessage = () => message;
 
       message = {
-        type: USER_ACTION_START_MESSAGE_TYPE,
+        type: USER_ACTION_START,
         name: 'testAction',
         startTime: Date.now(),
         parentId: 'parent-id',
@@ -354,7 +350,7 @@ describe('api.measurements', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_END_MESSAGE_TYPE,
+        type: USER_ACTION_END,
         name: 'testAction',
         id: 'parent-id',
         startTime: dateNow(),
@@ -367,7 +363,7 @@ describe('api.measurements', () => {
       expect(actionBuffer.size()).toBe(1);
 
       message = {
-        type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+        type: USER_ACTION_CANCEL,
         name: 'testAction',
         parentId: 'parent-id',
       };

--- a/packages/core/src/api/measurements/initialize.ts
+++ b/packages/core/src/api/measurements/initialize.ts
@@ -6,7 +6,7 @@ import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
 import { deepEqual, getCurrentTimestamp, isEmpty, isNull, stringifyObjectValues } from '../../utils';
 import { timestampToIsoString } from '../../utils/date';
-import { USER_ACTION_START_MESSAGE_TYPE } from '../const';
+import { USER_ACTION_START } from '../const';
 import type { ItemBuffer } from '../ItemBuffer';
 import type { TracesAPI } from '../traces';
 import type { ApiMessageBusMessages } from '../types';
@@ -75,7 +75,7 @@ export function initializeMeasurementsAPI({
       internalLogger.debug('Pushing measurement\n', item);
 
       const msg = getMessage();
-      if (msg && msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+      if (msg && msg.type === USER_ACTION_START) {
         actionBuffer.addItem(item);
       } else {
         transports.execute(item);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,8 +1,4 @@
-import type {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from './const';
+import type { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_HALT, USER_ACTION_START } from './const';
 import type { EventEvent, EventsAPI } from './events';
 import type { ExceptionEvent, ExceptionsAPI } from './exceptions';
 import type { LogEvent, LogsAPI } from './logs';
@@ -14,15 +10,20 @@ export type APIEvent = LogEvent | ExceptionEvent | MeasurementEvent | TraceEvent
 
 export type API = LogsAPI & ExceptionsAPI & MeasurementsAPI & TracesAPI & MetaAPI & EventsAPI;
 
-export type ApiMessageBusMessages = UserActionStartMessage | UserActionEndMessage | UserActionCancelMessage;
+export type ApiMessageBusMessages =
+  | UserActionStartMessage
+  | UserActionEndMessage
+  | UserActionCancelMessage
+  | UserActionHaltMessage;
 
 export type UserActionMessageType =
-  | typeof USER_ACTION_START_MESSAGE_TYPE
-  | typeof USER_ACTION_END_MESSAGE_TYPE
-  | typeof USER_ACTION_CANCEL_MESSAGE_TYPE;
+  | typeof USER_ACTION_START
+  | typeof USER_ACTION_END
+  | typeof USER_ACTION_CANCEL
+  | typeof USER_ACTION_HALT;
 
 export type UserActionStartMessage = {
-  type: typeof USER_ACTION_START_MESSAGE_TYPE;
+  type: typeof USER_ACTION_START;
   name: string;
   startTime: number;
 
@@ -33,7 +34,7 @@ export type UserActionStartMessage = {
 };
 
 export type UserActionEndMessage = {
-  type: typeof USER_ACTION_END_MESSAGE_TYPE;
+  type: typeof USER_ACTION_END;
   name: string;
   startTime: number;
   endTime: number;
@@ -47,8 +48,20 @@ export type UserActionEndMessage = {
 };
 
 export type UserActionCancelMessage = {
-  type: typeof USER_ACTION_CANCEL_MESSAGE_TYPE;
+  type: typeof USER_ACTION_CANCEL;
   name: string;
+
+  /**
+   * Unique identifier of the parent user action to which this action belongs.
+   */
+  parentId?: string;
+};
+
+export type UserActionHaltMessage = {
+  type: typeof USER_ACTION_HALT;
+  name: string;
+  reason: 'pending-requests';
+  haltTime: number;
 
   /**
    * Unique identifier of the parent user action to which this action belongs.

--- a/packages/core/src/api/userActionLifecycleHandler.test.ts
+++ b/packages/core/src/api/userActionLifecycleHandler.test.ts
@@ -7,12 +7,14 @@ import {
   type Meta,
   TransportItem,
   TransportItemType,
+  USER_ACTION_HALT,
   UserActionStartMessage,
 } from '..';
 import { Observable } from '../utils/reactive';
 
 import { mockTransports } from './apiTestHelpers';
-import { USER_ACTION_CANCEL_MESSAGE_TYPE, USER_ACTION_END_MESSAGE_TYPE, USER_ACTION_START_MESSAGE_TYPE } from './const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from './const';
+import type { UserActionHaltMessage } from './types';
 import { createUserActionLifecycleHandler } from './userActionLifecycleHandler';
 
 describe('userActionLifecycleHandler', () => {
@@ -26,10 +28,32 @@ describe('userActionLifecycleHandler', () => {
     });
 
     const message: UserActionStartMessage = {
-      type: USER_ACTION_START_MESSAGE_TYPE,
-      name: '',
+      type: USER_ACTION_START,
+      name: 'start-test',
       startTime: 0,
-      parentId: '',
+      parentId: '123',
+    };
+
+    apiMessageBus.notify(message);
+
+    expect(getMessage()).toEqual(message);
+  });
+
+  it('assigns the user-action-halt message to the message variable when it receives it', () => {
+    const apiMessageBus = new Observable<ApiMessageBusMessages>();
+
+    const { getMessage } = createUserActionLifecycleHandler({
+      apiMessageBus,
+      transports: mockTransports,
+      config: {} as Config,
+    });
+
+    const message: UserActionHaltMessage = {
+      type: USER_ACTION_HALT,
+      name: 'halt-test',
+      haltTime: 0,
+      reason: 'pending-requests',
+      parentId: '123',
     };
 
     apiMessageBus.notify(message);
@@ -51,7 +75,7 @@ describe('userActionLifecycleHandler', () => {
     });
 
     const message: UserActionStartMessage = {
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
       name: '',
       startTime: 0,
       parentId: '',
@@ -63,7 +87,7 @@ describe('userActionLifecycleHandler', () => {
     actionBuffer.addItem(item);
 
     const cancelMessage: ApiMessageBusMessages = {
-      type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+      type: USER_ACTION_CANCEL,
       name: 'pointerdown',
     };
 
@@ -89,7 +113,7 @@ describe('userActionLifecycleHandler', () => {
     });
 
     const message: UserActionStartMessage = {
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
       name: 'pointerdown',
       startTime: 0,
       parentId: '123',
@@ -101,7 +125,7 @@ describe('userActionLifecycleHandler', () => {
     actionBuffer.addItem(item);
 
     const endMessage: ApiMessageBusMessages = {
-      type: USER_ACTION_END_MESSAGE_TYPE,
+      type: USER_ACTION_END,
       id: '123',
       name: 'pointerdown',
       startTime: 100,
@@ -143,7 +167,7 @@ describe('userActionLifecycleHandler', () => {
     });
 
     const message: UserActionStartMessage = {
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
       name: 'pointerdown',
       startTime: 0,
       parentId: '123',
@@ -172,7 +196,7 @@ describe('userActionLifecycleHandler', () => {
     actionBuffer.addItem(itemEventExcluded);
 
     const endMessage: ApiMessageBusMessages = {
-      type: USER_ACTION_END_MESSAGE_TYPE,
+      type: USER_ACTION_END,
       id: '123',
       name: 'pointerdown',
       startTime: 100,

--- a/packages/core/src/api/userActionLifecycleHandler.ts
+++ b/packages/core/src/api/userActionLifecycleHandler.ts
@@ -2,7 +2,7 @@ import type { Config } from '../config';
 import { type TransportItem, TransportItemType, type Transports } from '../transports';
 import type { Observable } from '../utils';
 
-import { USER_ACTION_CANCEL_MESSAGE_TYPE, USER_ACTION_END_MESSAGE_TYPE, USER_ACTION_START_MESSAGE_TYPE } from './const';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_HALT, USER_ACTION_START } from './const';
 import { ItemBuffer } from './ItemBuffer';
 import type { MeasurementEvent } from './measurements';
 import type { APIEvent, ApiMessageBusMessages } from './types';
@@ -21,12 +21,12 @@ export function createUserActionLifecycleHandler({
   let message: ApiMessageBusMessages | undefined;
 
   apiMessageBus.subscribe((msg) => {
-    if (msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+    if (USER_ACTION_START === msg.type || USER_ACTION_HALT === msg.type) {
       message = msg;
       return;
     }
 
-    if (msg.type === USER_ACTION_END_MESSAGE_TYPE) {
+    if (msg.type === USER_ACTION_END) {
       const { id, name } = msg;
 
       actionBuffer.flushBuffer((item) => {
@@ -53,7 +53,7 @@ export function createUserActionLifecycleHandler({
       return;
     }
 
-    if (msg.type === USER_ACTION_CANCEL_MESSAGE_TYPE) {
+    if (msg.type === USER_ACTION_CANCEL) {
       message = undefined;
       actionBuffer.flushBuffer((item) => {
         transports.execute(item);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,9 +3,10 @@ export {
   defaultLogArgsSerializer,
   defaultErrorArgsSerializer,
   apiMessageBus,
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
+  USER_ACTION_CANCEL,
+  USER_ACTION_END,
+  USER_ACTION_START,
+  USER_ACTION_HALT,
 } from './api';
 export type {
   API,
@@ -38,6 +39,7 @@ export type {
   UserActionStartMessage,
   UserActionEndMessage,
   UserActionCancelMessage,
+  UserActionHaltMessage,
   UserAction,
 } from './api';
 
@@ -143,7 +145,6 @@ export {
   stringifyExternalJson,
   stringifyObjectValues,
   Observable,
-  merge,
 } from './utils';
 export type {
   BaseObject,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -52,5 +52,5 @@ export { dateNow } from './date';
 
 export { getCircularDependencyReplacer, stringifyExternalJson, stringifyObjectValues } from './json';
 
-export { Observable, merge } from './reactive';
+export { Observable } from './reactive';
 export type { Subscription } from './reactive';

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -96,10 +96,9 @@ export {
   EVENT_VIEW_CHANGED,
   apiMessageBus,
   Observable,
-  merge,
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
+  USER_ACTION_CANCEL,
+  USER_ACTION_END,
+  USER_ACTION_START,
 } from '@grafana/faro-core';
 
 export type {

--- a/packages/web-sdk/src/instrumentations/userActions/const.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/const.ts
@@ -1,7 +1,6 @@
 export const MESSAGE_TYPE_RESOURCE_ENTRY = 'resource-entry';
 export const MESSAGE_TYPE_HTTP_REQUEST_START = 'http-request-start';
 export const MESSAGE_TYPE_HTTP_REQUEST_END = 'http-request-end';
-export const MESSAGE_TYPE_HTTP_REQUEST_PENDING = 'http-request-pending';
 export const MESSAGE_TYPE_DOM_MUTATION = 'dom-mutation';
 
 export const userActionDataAttributeParsed = 'faroUserActionName';

--- a/packages/web-sdk/src/instrumentations/userActions/httpRequestMonitor.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/httpRequestMonitor.test.ts
@@ -36,8 +36,24 @@ describe('monitorHttpRequests', () => {
     });
 
     expect(mockSubscribe).toHaveBeenCalledTimes(2);
-    expect(mockSubscribe).toHaveBeenNthCalledWith(1, { type: MESSAGE_TYPE_HTTP_REQUEST_START, pending: 1 });
-    expect(mockSubscribe).toHaveBeenNthCalledWith(2, { type: MESSAGE_TYPE_HTTP_REQUEST_END, pending: 0 });
+    expect(mockSubscribe).toHaveBeenNthCalledWith(1, {
+      type: MESSAGE_TYPE_HTTP_REQUEST_START,
+      request: {
+        apiType: 'xhr',
+        method: 'GET',
+        requestId: expect.any(String),
+        url: 'https://www.grafana.com',
+      },
+    });
+    expect(mockSubscribe).toHaveBeenNthCalledWith(2, {
+      type: MESSAGE_TYPE_HTTP_REQUEST_END,
+      request: {
+        apiType: 'xhr',
+        method: 'GET',
+        requestId: expect.any(String),
+        url: 'https://www.grafana.com',
+      },
+    });
   });
 
   it('Monitors fetch requests and sends a message if request are pending', async () => {
@@ -55,11 +71,29 @@ describe('monitorHttpRequests', () => {
 
     initializeFaro(mockConfig());
 
-    await fetch('https://www.grafana.com');
+    await fetch('https://www.grafana.com', {
+      method: 'GET',
+    });
 
     expect(mockSubscribe).toHaveBeenCalledTimes(2);
-    expect(mockSubscribe).toHaveBeenNthCalledWith(1, { type: MESSAGE_TYPE_HTTP_REQUEST_START, pending: 1 });
-    expect(mockSubscribe).toHaveBeenNthCalledWith(2, { type: MESSAGE_TYPE_HTTP_REQUEST_END, pending: 0 });
+    expect(mockSubscribe).toHaveBeenNthCalledWith(1, {
+      type: MESSAGE_TYPE_HTTP_REQUEST_START,
+      request: {
+        apiType: 'fetch',
+        method: 'GET',
+        requestId: expect.any(String),
+        url: 'https://www.grafana.com',
+      },
+    });
+    expect(mockSubscribe).toHaveBeenNthCalledWith(2, {
+      type: MESSAGE_TYPE_HTTP_REQUEST_END,
+      request: {
+        apiType: 'fetch',
+        method: 'GET',
+        requestId: expect.any(String),
+        url: 'https://www.grafana.com',
+      },
+    });
 
     global.fetch = originalFetch;
   });

--- a/packages/web-sdk/src/instrumentations/userActions/httpRequestMonitor.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/httpRequestMonitor.ts
@@ -1,126 +1,125 @@
-import { Observable } from '@grafana/faro-core';
+import { genShortID, Observable } from '@grafana/faro-core';
 
 import { getUrlFromResource, isUrlIgnored } from '../../utils/url';
 
 import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './const';
-import type { HttpRequestEndMessage, HttpRequestStartMessage } from './types';
+import type { HttpRequestEndMessage, HttpRequestMessagePayload, HttpRequestStartMessage } from './types';
+
+type RequestProps = HttpRequestMessagePayload;
+
+const apiTypeFetch = 'fetch';
+const apiTypeXhr = 'xhr';
 
 /**
  * Monitors if any http requests are in progress.
  */
-export function monitorHttpRequests(): {
-  observable: Observable<HttpRequestStartMessage | HttpRequestEndMessage>;
-  resetCounters: () => void;
-} {
+export function monitorHttpRequests(): Observable<HttpRequestStartMessage | HttpRequestEndMessage> {
   const observable = new Observable<HttpRequestStartMessage | HttpRequestEndMessage>();
 
-  let pendingXhrRequests = 0;
-  let pendingFetchRequests = 0;
-
-  function emitStartMessage() {
-    observable.notify({ type: MESSAGE_TYPE_HTTP_REQUEST_START, pending: pendingXhrRequests + pendingFetchRequests });
+  function emitStartMessage(requestProps: RequestProps) {
+    observable.notify({
+      type: MESSAGE_TYPE_HTTP_REQUEST_START,
+      request: requestProps,
+    });
   }
 
-  function emitEndMessage() {
-    observable.notify({ type: MESSAGE_TYPE_HTTP_REQUEST_END, pending: pendingXhrRequests + pendingFetchRequests });
+  function emitEndMessage(requestProps: RequestProps) {
+    observable.notify({
+      type: MESSAGE_TYPE_HTTP_REQUEST_END,
+      request: requestProps,
+    });
   }
 
   monitorFetch({
-    onRequestStart: () => {
-      pendingFetchRequests++;
-      emitStartMessage();
-    },
-    onRequestEnd: () => {
-      pendingFetchRequests--;
-      emitEndMessage();
-    },
+    onRequestStart: emitStartMessage,
+    onRequestEnd: emitEndMessage,
   });
 
   monitorXhr({
-    onRequestStart: () => {
-      pendingXhrRequests++;
-      emitStartMessage();
-    },
-    onRequestEnd: () => {
-      pendingXhrRequests--;
-      emitEndMessage();
-    },
+    onRequestStart: emitStartMessage,
+    onRequestEnd: emitEndMessage,
   });
 
-  function resetCounters() {
-    pendingXhrRequests = 0;
-    pendingFetchRequests = 0;
-  }
-
-  return { observable, resetCounters };
+  return observable;
 }
 
-function monitorXhr({ onRequestStart, onRequestEnd }: { onRequestStart: () => void; onRequestEnd: () => void }) {
+function monitorXhr({
+  onRequestStart,
+  onRequestEnd,
+}: {
+  onRequestStart: (props: RequestProps) => void;
+  onRequestEnd: (props: RequestProps) => void;
+}) {
   const originalOpen = XMLHttpRequest.prototype.open;
-  const originalSend = XMLHttpRequest.prototype.send;
 
   XMLHttpRequest.prototype.open = function () {
     const url = arguments[1];
     const isIgnoredUrl = isUrlIgnored(url);
+    const method = arguments[0];
 
+    const requestId = genShortID();
+
+    // request has started to load data.
+    this.addEventListener('loadstart', function () {
+      if (!isIgnoredUrl) {
+        onRequestStart({ url, method, requestId, apiType: apiTypeXhr });
+      }
+    });
+
+    // transaction completes successfully.
     this.addEventListener('load', function () {
       if (!isIgnoredUrl) {
-        onRequestEnd();
+        onRequestEnd({ url, method, requestId, apiType: apiTypeXhr });
       }
     });
 
     this.addEventListener('error', function () {
       if (!isIgnoredUrl) {
-        onRequestEnd();
+        onRequestEnd({ url, method, requestId, apiType: apiTypeXhr });
       }
     });
 
     this.addEventListener('abort', function () {
       if (!isIgnoredUrl) {
-        onRequestEnd();
+        onRequestEnd({ url, method, requestId, apiType: apiTypeXhr });
       }
     });
 
     originalOpen.apply(this, arguments as any);
   };
-
-  XMLHttpRequest.prototype.send = function () {
-    const url = getUrlFromResource(arguments[0]);
-
-    console.log('url', url);
-
-    const isIgnoredUrl = isUrlIgnored(url);
-
-    if (!isIgnoredUrl) {
-      onRequestStart();
-    }
-
-    originalSend.apply(this, arguments as any);
-  };
 }
 
-function monitorFetch({ onRequestEnd, onRequestStart }: { onRequestStart: () => void; onRequestEnd: () => void }) {
+function monitorFetch({
+  onRequestEnd,
+  onRequestStart,
+}: {
+  onRequestStart: (props: RequestProps) => void;
+  onRequestEnd: (props: RequestProps) => void;
+}) {
   const originalFetch = window.fetch;
 
   window.fetch = function () {
-    const url = getUrlFromResource(arguments[0]);
+    const url = getUrlFromResource(arguments[0]) ?? '';
     const isIgnoredUrl = isUrlIgnored(url);
+    const method = (arguments[1] ?? {}).method;
+
+    const requestId = genShortID();
 
     if (!isIgnoredUrl) {
-      onRequestStart();
+      onRequestStart({ url, method, requestId, apiType: apiTypeFetch });
     }
 
     return originalFetch
       .apply(this, arguments as any)
       .then((response) => {
         if (!isIgnoredUrl) {
-          onRequestEnd();
+          onRequestEnd({ url, method, requestId, apiType: apiTypeFetch });
         }
         return response;
       })
       .catch((error) => {
         if (!isIgnoredUrl) {
-          onRequestEnd();
+          onRequestEnd({ url, method, requestId, apiType: apiTypeFetch });
         }
         throw error;
       });

--- a/packages/web-sdk/src/instrumentations/userActions/index.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/index.ts
@@ -1,5 +1,10 @@
 export { UserActionInstrumentation } from './instrumentation';
-export type { DomMutationMessage, HttpRequestEndMessage, HttpRequestStartMessage } from './types';
+export type {
+  DomMutationMessage,
+  HttpRequestEndMessage,
+  HttpRequestStartMessage,
+  HttpRequestMessagePayload,
+} from './types';
 export {
   MESSAGE_TYPE_DOM_MUTATION,
   MESSAGE_TYPE_HTTP_REQUEST_END,

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -3,12 +3,12 @@ import {
   dateNow,
   genShortID,
   Observable,
-  Subscription,
   USER_ACTION_CANCEL,
   USER_ACTION_END,
   USER_ACTION_HALT,
   USER_ACTION_START,
 } from '@grafana/faro-core';
+import type { Faro, Subscription } from '@grafana/faro-core';
 
 import {
   MESSAGE_TYPE_HTTP_REQUEST_END,

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -2,29 +2,33 @@ import {
   apiMessageBus,
   dateNow,
   genShortID,
-  merge,
   Observable,
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
+  Subscription,
+  USER_ACTION_CANCEL,
+  USER_ACTION_END,
+  USER_ACTION_HALT,
+  USER_ACTION_START,
 } from '@grafana/faro-core';
-import type { Faro, Subscription } from '@grafana/faro-core';
 
-import { userActionDataAttributeParsed as userActionDataAttribute } from './const';
+import {
+  MESSAGE_TYPE_HTTP_REQUEST_END,
+  MESSAGE_TYPE_HTTP_REQUEST_START,
+  userActionDataAttributeParsed as userActionDataAttribute,
+} from './const';
 import { monitorDomMutations } from './domMutationMonitor';
 import { monitorHttpRequests } from './httpRequestMonitor';
 import { monitorPerformanceEntries } from './performanceEntriesMonitor';
+import type { HttpRequestEndMessage, HttpRequestMessagePayload, HttpRequestStartMessage } from './types';
 import { convertDataAttributeName } from './util';
+
+const maxFollowUpActionTimeRange = 100;
 
 export function getUserEventHandler(faro: Faro) {
   const { api, config } = faro;
 
-  const { observable: httpMonitor, resetCounters: resetHttpCounters } = monitorHttpRequests();
+  const httpMonitor = monitorHttpRequests();
   const domMutationsMonitor = monitorDomMutations();
   const performanceEntriesMonitor = monitorPerformanceEntries();
-
-  let allMonitorsSub: Subscription | undefined;
-  let allMonitorsObserver: Observable | undefined;
 
   let timeoutId: number | undefined;
   let actionRunning = false;
@@ -39,8 +43,6 @@ export function getUserEventHandler(faro: Faro) {
       return;
     }
 
-    resetHttpCounters();
-
     actionRunning = true;
 
     const startTime = dateNow();
@@ -49,81 +51,154 @@ export function getUserEventHandler(faro: Faro) {
     const actionId = genShortID();
 
     apiMessageBus.notify({
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
       name: userActionName,
       startTime: startTime,
       parentId: actionId,
     });
 
     // Triggers if no initial action happened within the first 100ms
-    timeoutId = startTimeout(timeoutId, () => {
-      endTime = dateNow();
+    timeoutId = startTimeout(
+      timeoutId,
+      () => {
+        endTime = dateNow();
 
-      // Listening for follow up activities stops once action is cancelled (set to false)
-      actionRunning = false;
-      sendUserActionCancelMessage(userActionName, actionId);
-    });
+        // Listening for follow up activities stops once action is cancelled (set to false)
+        actionRunning = false;
+        sendUserActionCancelMessage(userActionName, actionId);
+      },
+      maxFollowUpActionTimeRange
+    );
 
-    allMonitorsObserver = merge(httpMonitor, domMutationsMonitor, performanceEntriesMonitor);
+    const runningRequests = new Map<string, HttpRequestMessagePayload>();
+    let isHalted = false;
+    let pendingActionTimeoutId: number | undefined;
 
-    allMonitorsSub = allMonitorsObserver
+    const allMonitorsSub = new Observable()
+      .merge(httpMonitor, domMutationsMonitor, performanceEntriesMonitor)
       .takeWhile(() => actionRunning)
+      .filter((msg) => {
+        // If the user action is in halt state, we only keep listening to ended http requests
+        if (isHalted && !(isRequestEndMessage(msg) && runningRequests.has(msg.request.requestId))) {
+          return false;
+        }
+
+        return true;
+      })
       .subscribe((msg) => {
-        console.log('msg', msg);
+        if (isRequestStartMessage(msg)) {
+          // An action is on halt if it has pending items, like pending HTTP requests.
+          // In this case we start a separate timeout to wait for the requests to finish
+          // If in the halt state, we stop adding Faro signals to the action's buffer (see userActionLifecycleHandler.ts)
+          // But we are still subscribed to
+          runningRequests.set(msg.request.requestId, msg.request);
+        }
+        if (isRequestEndMessage(msg)) {
+          // console.log('request end msg :>> ', msg);
+          runningRequests.delete(msg.request.requestId);
+        }
 
         // A http request, a DOM mutation or a performance entry happened so we have a follow up activity and start the timeout again
         // If timeout is triggered the user action is done and we send respective messages and events
-        timeoutId = startTimeout(timeoutId, () => {
-          endTime = dateNow();
+        timeoutId = startTimeout(
+          timeoutId,
+          () => {
+            endTime = dateNow();
 
-          const duration = endTime - startTime;
-          const eventType = event.type;
+            const userActionParentEventProps = { api, userActionName, startTime, endTime: endTime!, actionId, event };
 
-          // order matters, first emit the user-action-end event and then push the event
-          apiMessageBus.notify({
-            type: USER_ACTION_END_MESSAGE_TYPE,
-            name: userActionName,
-            id: actionId,
-            startTime,
-            endTime,
-            duration,
-            eventType,
-          });
+            const hasPendingRequests = runningRequests.size > 0;
+            const isAllPendingRequestsResolved = isHalted && !hasPendingRequests;
 
-          // Send the final action parent event
-          api.pushEvent(
-            userActionName,
-            {
-              userActionStartTime: startTime.toString(),
-              userActionEndTime: endTime.toString(),
-              userActionDuration: duration.toString(),
-              userActionEventType: eventType,
-            },
-            undefined,
-            {
-              timestampOverwriteMs: startTime,
-              customPayloadTransformer: (payload) => {
-                payload.action = {
-                  id: actionId,
-                  name: userActionName,
-                };
-
-                return payload;
-              },
+            if (isAllPendingRequestsResolved) {
+              clearTimeout(pendingActionTimeoutId);
+              isHalted = false;
             }
-          );
 
-          // Ensure action is blocked until it is fully processed.
-          actionRunning = false;
-          allMonitorsSub?.unsubscribe();
-          allMonitorsObserver?.unsubscribeAll();
-        });
+            if (hasPendingRequests) {
+              isHalted = true;
+
+              apiMessageBus.notify({
+                type: USER_ACTION_HALT,
+                name: userActionName,
+                parentId: actionId,
+                reason: 'pending-requests',
+                haltTime: dateNow(),
+              });
+
+              pendingActionTimeoutId = startTimeout(
+                undefined,
+                () => {
+                  unsubscribeAllMonitors(allMonitorsSub);
+                  endUserAction(userActionParentEventProps);
+                  actionRunning = false;
+                  isHalted = false;
+                },
+                1000 * 10
+              );
+            } else {
+              unsubscribeAllMonitors(allMonitorsSub);
+              endUserAction(userActionParentEventProps);
+              actionRunning = false;
+              isHalted = false;
+            }
+          },
+          maxFollowUpActionTimeRange
+        );
       });
   }
 
-  registerVisibilityChangeHandler(allMonitorsSub, allMonitorsObserver);
-
   return processUserEvent;
+}
+
+/**
+ * User action was successfully completed and we send the final event(s)
+ */
+function endUserAction(props: {
+  api: Faro['api'];
+  userActionName: string;
+  startTime: number;
+  endTime: number;
+  actionId: string;
+  event: PointerEvent | KeyboardEvent;
+}) {
+  const { api, userActionName, startTime, endTime, actionId, event } = props;
+  const duration = endTime - startTime;
+  const eventType = event.type;
+
+  // order matters, first emit the user-action-end event and afterwards push the parent event
+  apiMessageBus.notify({
+    type: USER_ACTION_END,
+    name: userActionName,
+    id: actionId,
+    startTime,
+    endTime,
+    duration,
+    eventType,
+  });
+
+  // Send the final action parent event
+  api.pushEvent(
+    userActionName,
+    {
+      userActionStartTime: startTime.toString(),
+      userActionEndTime: endTime.toString(),
+      userActionDuration: duration.toString(),
+      userActionEventType: eventType,
+    },
+    undefined,
+    {
+      timestampOverwriteMs: startTime,
+      customPayloadTransformer: (payload) => {
+        payload.action = {
+          id: actionId,
+          name: userActionName,
+        };
+
+        return payload;
+      },
+    }
+  );
 }
 
 function getUserActionName(element: HTMLElement, dataAttributeName: string): string | undefined {
@@ -139,9 +214,7 @@ function getUserActionName(element: HTMLElement, dataAttributeName: string): str
   return undefined;
 }
 
-function startTimeout(timeoutId: number | undefined, cb: () => void) {
-  const maxTimeSpanTillUserActionEnd = 100;
-
+function startTimeout(timeoutId: number | undefined, cb: () => void, delay: number) {
   if (timeoutId) {
     clearTimeout(timeoutId);
   }
@@ -149,33 +222,28 @@ function startTimeout(timeoutId: number | undefined, cb: () => void) {
   //@ts-expect-error for some reason vscode is using the node types
   timeoutId = setTimeout(() => {
     cb();
-  }, maxTimeSpanTillUserActionEnd);
+  }, delay);
 
   return timeoutId;
 }
 
 function sendUserActionCancelMessage(userActionName: string, actionId: string) {
   apiMessageBus.notify({
-    type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+    type: USER_ACTION_CANCEL,
     name: userActionName,
     parentId: actionId,
   });
 }
 
-function registerVisibilityChangeHandler(
-  allMonitorsSub: Subscription | undefined,
-  allMonitorsObserver: Observable | undefined
-) {
-  // stop monitoring in background tabs
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') {
-      // Unsubscribe from all monitors when the tab goes into the background to free up resources (merge.unsubscribe() also unsubscribes from all inner observables)
-      // Monitors will be re-subscribed in the processEvent function when the first user action is detected
-      allMonitorsSub?.unsubscribe();
-      allMonitorsSub = undefined;
+function unsubscribeAllMonitors(allMonitorsSub: Subscription | undefined) {
+  allMonitorsSub?.unsubscribe();
+  allMonitorsSub = undefined;
+}
 
-      allMonitorsObserver?.unsubscribeAll();
-      allMonitorsObserver = undefined;
-    }
-  });
+function isRequestStartMessage(msg: any): msg is HttpRequestStartMessage {
+  return msg.type === MESSAGE_TYPE_HTTP_REQUEST_START;
+}
+
+function isRequestEndMessage(msg: any): msg is HttpRequestEndMessage {
+  return msg.type === MESSAGE_TYPE_HTTP_REQUEST_END;
 }

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -19,7 +19,7 @@ import { convertDataAttributeName } from './util';
 export function getUserEventHandler(faro: Faro) {
   const { api, config } = faro;
 
-  const httpMonitor = monitorHttpRequests();
+  const { observable: httpMonitor, resetCounters: resetHttpCounters } = monitorHttpRequests();
   const domMutationsMonitor = monitorDomMutations();
   const performanceEntriesMonitor = monitorPerformanceEntries();
 
@@ -38,6 +38,8 @@ export function getUserEventHandler(faro: Faro) {
     if (actionRunning || userActionName == null) {
       return;
     }
+
+    resetHttpCounters();
 
     actionRunning = true;
 
@@ -66,7 +68,9 @@ export function getUserEventHandler(faro: Faro) {
 
     allMonitorsSub = allMonitorsObserver
       .takeWhile(() => actionRunning)
-      .subscribe(() => {
+      .subscribe((msg) => {
+        console.log('msg', msg);
+
         // A http request, a DOM mutation or a performance entry happened so we have a follow up activity and start the timeout again
         // If timeout is triggered the user action is done and we send respective messages and events
         timeoutId = startTimeout(timeoutId, () => {

--- a/packages/web-sdk/src/instrumentations/userActions/types.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/types.ts
@@ -8,12 +8,21 @@ export type DomMutationMessage = {
   type: typeof MESSAGE_TYPE_DOM_MUTATION;
 };
 
+type RequestApiType = 'xhr' | 'fetch';
+
+export type HttpRequestMessagePayload = {
+  requestId: string;
+  url: string;
+  method: string;
+  apiType: RequestApiType;
+};
+
 export type HttpRequestStartMessage = {
   type: typeof MESSAGE_TYPE_HTTP_REQUEST_START;
-  pending: number;
+  request: HttpRequestMessagePayload;
 };
 
 export type HttpRequestEndMessage = {
   type: typeof MESSAGE_TYPE_HTTP_REQUEST_END;
-  pending: number;
+  request: HttpRequestMessagePayload;
 };

--- a/packages/web-tracing/src/faroUserActionSpanProcessor.test.ts
+++ b/packages/web-tracing/src/faroUserActionSpanProcessor.test.ts
@@ -1,10 +1,6 @@
 import { SpanKind } from '@opentelemetry/api';
 
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '@grafana/faro-core';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-core';
 import { apiMessageBus } from '@grafana/faro-web-sdk';
 import type { UserActionCancelMessage, UserActionEndMessage, UserActionStartMessage } from '@grafana/faro-web-sdk';
 
@@ -30,7 +26,7 @@ describe('faroUserActionSpanProcessor', () => {
     apiMessageBus.notify({
       name: 'test-action',
       parentId: 'test-parent-id',
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
     } as UserActionStartMessage);
 
     const span = {
@@ -50,7 +46,7 @@ describe('faroUserActionSpanProcessor', () => {
     apiMessageBus.notify({
       name: 'test-action',
       parentId: 'test-parent-id',
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
     } as UserActionStartMessage);
 
     let span = {
@@ -73,7 +69,7 @@ describe('faroUserActionSpanProcessor', () => {
     apiMessageBus.notify({
       name: 'test-action',
       parentId: 'test-parent-id',
-      type: USER_ACTION_END_MESSAGE_TYPE,
+      type: USER_ACTION_END,
       startTime: Date.now(),
       endTime: Date.now(),
       duration: 0,
@@ -88,7 +84,7 @@ describe('faroUserActionSpanProcessor', () => {
     apiMessageBus.notify({
       name: 'test-action',
       parentId: 'test-parent-id',
-      type: USER_ACTION_START_MESSAGE_TYPE,
+      type: USER_ACTION_START,
     } as UserActionStartMessage);
 
     span = {
@@ -110,7 +106,7 @@ describe('faroUserActionSpanProcessor', () => {
 
     apiMessageBus.notify({
       name: 'test-action',
-      type: USER_ACTION_CANCEL_MESSAGE_TYPE,
+      type: USER_ACTION_CANCEL,
       id: 'test-id',
     } as UserActionCancelMessage);
 

--- a/packages/web-tracing/src/faroUserActionSpanProcessor.ts
+++ b/packages/web-tracing/src/faroUserActionSpanProcessor.ts
@@ -1,11 +1,7 @@
 import { type Context, SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import {
-  USER_ACTION_CANCEL_MESSAGE_TYPE,
-  USER_ACTION_END_MESSAGE_TYPE,
-  USER_ACTION_START_MESSAGE_TYPE,
-} from '@grafana/faro-core';
+import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-core';
 import { apiMessageBus, type UserActionStartMessage } from '@grafana/faro-web-sdk';
 
 export class FaroUserActionSpanProcessor implements SpanProcessor {
@@ -13,12 +9,12 @@ export class FaroUserActionSpanProcessor implements SpanProcessor {
 
   constructor(private processor: SpanProcessor) {
     apiMessageBus.subscribe((msg) => {
-      if (msg.type === USER_ACTION_START_MESSAGE_TYPE) {
+      if (msg.type === USER_ACTION_START) {
         this.message = msg;
         return;
       }
 
-      if ([USER_ACTION_END_MESSAGE_TYPE, USER_ACTION_CANCEL_MESSAGE_TYPE].includes(msg.type)) {
+      if ([USER_ACTION_END, USER_ACTION_CANCEL].includes(msg.type)) {
         this.message = undefined;
       }
     });


### PR DESCRIPTION
## Why

Second iteration on the user-actions feature.

It:
- Refactors the observables for ease of use
- Takes long running HTTP requests into account

When a pending HTTP requests is detected, the instrumentation sends a 'halt' event/
Once in halt state:
- no additional signals are attached to the action
- A timeout to wait for pending requests starts.
   -  If the timeout is reached, faro ends the user-action and sends the event and it's child events

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
