### PR TITLE
chore(release): prepare 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Next
 
-- Improvement (`@grafana/faro-web-sdk`): User actions improvements (#1101)
+## 1.15.0
+
+- Feature (`@grafana/faro-web-sdk`): Alpha version of user actions instrumentation (#1101).
+
 - Fix (`@grafana/faro-web-tracing`): Fixed unexpected behavior in xhr instrumentation when custom
   objects with a `toString` method were used as URLs (#1100).
-- Improvement (`@grafana/faro-*`): Upgrade to TypeScript 5.8.2 (#1092)
+
+- Dependencies (`@grafana/faro-*`): Upgrade to TypeScript 5.8.2 (#1092)
 
 ## 1.14.3
 


### PR DESCRIPTION
## Why

Prepare release 1.15.0.


Main reason for a the minor version increase is the fact that we moved to TS5.

It also contains the alpha/preview version of the user actions feature.
It's not meant to use in production and subject to frequent changes.

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
