### PR TITLE
chore(User actions): provide function to start an action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Improvement (`@grafana/faro-web-sdk`): Provide a function to start a user-action (#1115).
+
 ## 1.15.0
 
 - Feature (`@grafana/faro-web-sdk`): Alpha version of user actions instrumentation (#1101).

--- a/demo/src/client/pages/Features/TracingInstrumentation.tsx
+++ b/demo/src/client/pages/Features/TracingInstrumentation.tsx
@@ -2,9 +2,11 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import { Button, ButtonGroup } from 'react-bootstrap';
 
 import { faro } from '@grafana/faro-react';
+import { startUserAction } from '@grafana/faro-web-sdk';
 
 export function TracingInstrumentation() {
   const fetchSuccess = () => {
+    startUserAction('fetch-success', { foo: 'bar' });
     fetch('/');
   };
 
@@ -32,7 +34,7 @@ export function TracingInstrumentation() {
     <>
       <h3>Tracing Instrumentation</h3>
       <ButtonGroup>
-        <Button data-cy="btn-fetch-success" onClick={fetchSuccess} data-faro-user-action-name="fetch-success">
+        <Button data-cy="btn-fetch-success" onClick={fetchSuccess}>
           Fetch Success
         </Button>
         <Button data-cy="btn-xhr-success" onClick={xhrSuccess} data-faro-user-action-name="xhr-success">

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -181,4 +181,4 @@ export {
 
 export { getIgnoreUrls, getUrlFromResource } from './utils/url';
 
-export { userActionDataAttribute } from './instrumentations/userActions/const';
+export { userActionDataAttribute, startUserAction } from './instrumentations/userActions';

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -28,4 +28,4 @@ export {
 
 export { PerformanceInstrumentation } from './performance';
 
-export { UserActionInstrumentation, userActionDataAttribute } from './userActions';
+export { UserActionInstrumentation, userActionDataAttribute, startUserAction } from './userActions';

--- a/packages/web-sdk/src/instrumentations/userActions/index.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/index.ts
@@ -1,10 +1,12 @@
-export { UserActionInstrumentation } from './instrumentation';
+export { UserActionInstrumentation, startUserAction } from './instrumentation';
+
 export type {
   DomMutationMessage,
   HttpRequestEndMessage,
   HttpRequestStartMessage,
   HttpRequestMessagePayload,
 } from './types';
+
 export {
   MESSAGE_TYPE_DOM_MUTATION,
   MESSAGE_TYPE_HTTP_REQUEST_END,

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
@@ -1,0 +1,38 @@
+import { startUserAction, UserActionInstrumentation } from './instrumentation';
+
+const mockProcessUserEvent = jest.fn();
+jest.mock('./processUserActionEventHandler', () => ({
+  getUserEventHandler: jest.fn().mockImplementation(() => mockProcessUserEvent),
+}));
+
+const originalXMLHttpRequest = global.XMLHttpRequest;
+
+describe('UserActionsInstrumentation', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    jest.clearAllTimers();
+    global.XMLHttpRequest = originalXMLHttpRequest;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+    jest.clearAllTimers();
+  });
+
+  it('startUserAction executes processUserEventHandler', () => {
+    const userActionInstrumentation = new UserActionInstrumentation();
+    userActionInstrumentation.initialize();
+    startUserAction('test-action', { test: 'test-property' });
+
+    expect(mockProcessUserEvent).toHaveBeenCalledWith({
+      name: 'test-action',
+      attributes: { test: 'test-property' },
+      type: 'apiEvent',
+    });
+  });
+});

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
@@ -1,14 +1,29 @@
 import { BaseInstrumentation, faro, VERSION } from '@grafana/faro-core';
 
 import { getUserEventHandler } from './processUserActionEventHandler';
+import type { ApiEvent } from './types';
+
+let processUserEventHandler: ReturnType<typeof getUserEventHandler> | undefined;
 
 export class UserActionInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-user-action';
   readonly version = VERSION;
 
   initialize(): void {
-    const processUserEventHandler = getUserEventHandler(faro);
+    processUserEventHandler = getUserEventHandler(faro);
     window.addEventListener('pointerdown', processUserEventHandler);
     window.addEventListener('keydown', processUserEventHandler);
   }
+}
+
+export function startUserAction(name: string, attributes?: Record<string, string>) {
+  processUserEventHandler?.(createUserActionApiEvent(name, attributes));
+}
+
+function createUserActionApiEvent(name: string, attributes?: Record<string, string>): ApiEvent {
+  return {
+    name,
+    attributes,
+    type: 'apiEvent',
+  };
 }

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -37,8 +37,6 @@ export function getUserEventHandler(faro: Faro) {
   function processUserEvent(event: PointerEvent | KeyboardEvent | ApiEvent) {
     let userActionName: string | undefined;
 
-    console.log('userActionName::before :>> ', userActionName);
-
     const isApiEventDetected = isApiEvent(event);
     if (isApiEventDetected) {
       userActionName = event.name;
@@ -48,8 +46,6 @@ export function getUserEventHandler(faro: Faro) {
         config.trackUserActionsDataAttributeName ?? userActionDataAttribute
       );
     }
-
-    console.log('userActionName::after :>> ', userActionName);
 
     if (actionRunning || userActionName == null) {
       return;
@@ -82,8 +78,6 @@ export function getUserEventHandler(faro: Faro) {
       maxFollowUpActionTimeRange
     );
 
-    console.log('actionRunning :>> ', actionRunning);
-
     const runningRequests = new Map<string, HttpRequestMessagePayload>();
     let isHalted = false;
     let pendingActionTimeoutId: number | undefined;
@@ -92,7 +86,6 @@ export function getUserEventHandler(faro: Faro) {
       .merge(httpMonitor, domMutationsMonitor, performanceEntriesMonitor)
       .takeWhile(() => actionRunning)
       .filter((msg) => {
-        console.log('msg :>> ', msg);
         // If the user action is in halt state, we only keep listening to ended http requests
         if (isHalted && !(isRequestEndMessage(msg) && runningRequests.has(msg.request.requestId))) {
           return false;

--- a/packages/web-sdk/src/instrumentations/userActions/types.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/types.ts
@@ -26,3 +26,9 @@ export type HttpRequestEndMessage = {
   type: typeof MESSAGE_TYPE_HTTP_REQUEST_END;
   request: HttpRequestMessagePayload;
 };
+
+export type ApiEvent = {
+  name: string;
+  attributes?: Record<string, string>;
+  type: 'apiEvent';
+};


### PR DESCRIPTION
## Why

Provide a function to start user actions.
Sometimes it isn't possible to add `data-` attributes to elements to trigger an action.

Another use case it to add custom attributes to a user-action event which can be doen via the function

I decided against a dedicated API yet bc I am not sure if this really belongs there. But I am open for discussion.

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
