### PR TITLE
chore(release): 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.16.0
+
 - Improvement (`@grafana/faro-web-sdk`): Provide a function to start a user-action (#1115).
 - Dependencies (`@grafana/faro-*`): Upgrade OpenTelemetry dependencies to v0.200.\* (#1126).
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.13.0
+
 - Improvement (`@grafana/faro-*`) Add required Node engines to package.json ()
 
 ## 1.12.3


### PR DESCRIPTION
## 1.16.0

- Improvement (`@grafana/faro-web-sdk`): Provide a function to start a user-action (#1115).
- Dependencies (`@grafana/faro-*`): Upgrade OpenTelemetry dependencies to v0.200.\* (#1126).