### PR TITLE
chore(error tracking): provide original error to beforeSend hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+- Feature (`@grafana/faro-web-sdk`): Add configuration option to preserve the original JavaScript
+  error object, making it accessible within the `beforeSend` function for advanced error handling
+  (#1133).
+
 ## 1.16.0
 
 - Improvement (`@grafana/faro-web-sdk`): Provide a function to start a user-action (#1115).

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -1,12 +1,13 @@
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
 
+import { ExceptionEventExtended } from '@grafana/faro-core/src/api';
 import {
   initializeFaro as coreInit,
   getWebInstrumentations,
   ReactIntegration,
   ReactRouterVersion,
 } from '@grafana/faro-react';
-import type { Faro } from '@grafana/faro-react';
+import type { ExceptionEvent, Faro, TransportItem } from '@grafana/faro-react';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { env } from '../utils/env';
@@ -50,6 +51,16 @@ export function initializeFaro(): Faro {
     },
 
     trackUserActionsPreview: true,
+    preserveOriginalError: true,
+
+    beforeSend(item) {
+      if (item.type === 'exception') {
+        const originalError = (item as TransportItem<ExceptionEventExtended>).payload.originalError;
+        console.log('originalError :>> ', originalError);
+      }
+
+      return item;
+    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -1,13 +1,12 @@
 import { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType } from 'react-router-dom';
 
-import { ExceptionEventExtended } from '@grafana/faro-core/src/api';
 import {
   initializeFaro as coreInit,
   getWebInstrumentations,
   ReactIntegration,
   ReactRouterVersion,
 } from '@grafana/faro-react';
-import type { ExceptionEvent, Faro, TransportItem } from '@grafana/faro-react';
+import type { Faro } from '@grafana/faro-react';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { env } from '../utils/env';
@@ -51,16 +50,6 @@ export function initializeFaro(): Faro {
     },
 
     trackUserActionsPreview: true,
-    preserveOriginalError: true,
-
-    beforeSend(item) {
-      if (item.type === 'exception') {
-        const originalError = (item as TransportItem<ExceptionEventExtended>).payload.originalError;
-        console.log('originalError :>> ', originalError);
-      }
-
-      return item;
-    },
   });
 
   faro.api.pushLog(['Faro was initialized']);

--- a/packages/core/src/api/exceptions/index.ts
+++ b/packages/core/src/api/exceptions/index.ts
@@ -11,4 +11,5 @@ export type {
   Stacktrace,
   StacktraceParser,
   ErrorWithIndexProperties,
+  ExceptionEventExtended,
 } from './types';

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -8,7 +8,7 @@ import { ItemBuffer } from '../ItemBuffer';
 import type { API, APIEvent, ApiMessageBusMessages } from '../types';
 
 import { initializeExceptionsAPI } from './initialize';
-import type { ExceptionEvent, ExceptionStackFrame, PushErrorOptions } from './types';
+import type { ExceptionEvent, ExceptionEventExtended, ExceptionStackFrame, PushErrorOptions } from './types';
 
 describe('api.exceptions', () => {
   function createAPI({ dedupe }: { dedupe: boolean } = { dedupe: true }): [API, MockTransport] {
@@ -100,6 +100,22 @@ describe('api.exceptions', () => {
       expect(transport.items).toHaveLength(2);
       expect((transport.items[0] as TransportItem<ExceptionEvent>).payload.context).toBeUndefined();
       expect((transport.items[0] as TransportItem<ExceptionEvent>).payload.context).toBeUndefined();
+    });
+
+    it('add the original error to the payload', () => {
+      const transport = new MockTransport();
+      const config = mockConfig({
+        transports: [transport],
+        preserveOriginalError: true,
+      });
+
+      const { api } = initializeFaro(config);
+
+      const error = new Error('test');
+      api.pushError(error);
+
+      expect(transport.items).toHaveLength(1);
+      expect((transport.items[0]?.payload as ExceptionEventExtended).originalError).toEqual(error);
     });
 
     describe('Filtering', () => {

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -86,7 +86,7 @@ export function initializeExceptionsAPI({
                 span_id: spanContext.spanId,
               }
             : tracesApi.getTraceContext(),
-          context: isEmpty(ctx) ? undefined : ctx,
+          ...(isEmpty(ctx) ? {} : { context: ctx }),
           ...(preserveOriginalError ? { originalError: error } : {}),
         },
         type: TransportItemType.EXCEPTION,

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -59,7 +59,7 @@ export function initializeExceptionsAPI({
 
   const getStacktraceParser: ExceptionsAPI['getStacktraceParser'] = () => stacktraceParser;
 
-  const { ignoreErrors = [] } = config;
+  const { ignoreErrors = [], preserveOriginalError } = config;
 
   const pushError: ExceptionsAPI['pushError'] = (
     error,
@@ -74,7 +74,7 @@ export function initializeExceptionsAPI({
         ...(context ?? {}),
       });
 
-      const item: TransportItem<ExceptionEvent> = {
+      const item: TransportItem<ExceptionEvent<typeof preserveOriginalError>> = {
         meta: metas.value,
         payload: {
           type: type || error.name || defaultExceptionType,
@@ -87,6 +87,7 @@ export function initializeExceptionsAPI({
               }
             : tracesApi.getTraceContext(),
           context: isEmpty(ctx) ? undefined : ctx,
+          ...(preserveOriginalError ? { originalError: error } : {}),
         },
         type: TransportItemType.EXCEPTION,
       };

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -26,7 +26,7 @@ export interface Stacktrace {
 
 export type ExceptionContext = Record<string, string>;
 
-export interface ExceptionEvent {
+export interface ExceptionEventDefault {
   timestamp: string;
   type: string;
   value: string;
@@ -37,6 +37,19 @@ export interface ExceptionEvent {
 
   action?: UserAction;
 }
+
+/**
+ * The ExceptionEventExtended type is used to represent an exception event with an additional error
+ * property ans is only meant for client side use.The Additional property is removed by Faro before
+ * sending the event to the transport.
+ */
+export type ExceptionEventExtended = ExceptionEventDefault & {
+  originalError?: Error;
+};
+
+export type ExceptionEvent<EXTENDED = ExceptionEventDefault> = EXTENDED extends boolean
+  ? ExceptionEventExtended
+  : ExceptionEventDefault;
 
 export interface PushErrorOptions {
   skipDedupe?: boolean;

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -40,7 +40,7 @@ export interface ExceptionEventDefault {
 
 /**
  * The ExceptionEventExtended type is used to represent an exception event with an additional error
- * property ans is only meant for client side use.The Additional property is removed by Faro before
+ * property and is only meant for client side use. The additional property is removed by Faro before
  * sending the event to the transport.
  */
 export type ExceptionEventExtended = ExceptionEventDefault & {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -21,6 +21,7 @@ export type {
   PushErrorOptions,
   Stacktrace,
   StacktraceParser,
+  ExceptionEventExtended,
 } from './exceptions';
 
 export { defaultLogArgsSerializer } from './logs';

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -251,6 +251,20 @@ export interface Config<P = APIEvent> {
    * If the function returns true, the item will be excluded from user actions.
    */
   trackUserActionsExcludeItem?: (item: TransportItem<APIEvent>) => boolean;
+
+  /**
+   * When enabled, preserves the original Error object in the transport item for use in the beforeSend hook.
+   * The original error is automatically removed before the item is sent to the transport.
+   *
+   * This is useful for error post-processing in (uncontrolled) environments where you need to handle special cases:
+   * - Errors from third-party libraries
+   * - Errors with missing or incomplete data
+   * - Edge cases like `throw undefined` or `throw ''`
+   *
+   * With access to the original error in the beforeSend hook, you can enhance or modify the
+   * Faro exception payload to include additional context or fix missing information.
+   */
+  preserveOriginalError?: boolean;
 }
 
 export type Patterns = Array<string | RegExp>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type {
   EventEvent,
   EventsAPI,
   ExceptionEvent,
+  ExceptionEventExtended,
   ExceptionStackFrame,
   ExceptionsAPI,
   ExtendedError,

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -1,4 +1,5 @@
-import type { TransportItem } from '..';
+import { TransportItemType } from '..';
+import type { APIEvent, ExceptionEvent, TransportItem } from '..';
 import type { Config } from '../config';
 import type { InternalLogger } from '../internalLogger';
 import type { Metas } from '../metas';
@@ -63,7 +64,7 @@ export function initializeTransports(
         return [];
       }
 
-      filteredItems = modified;
+      filteredItems = sanitizeItems(modified, config);
     }
     return filteredItems;
   };
@@ -188,4 +189,16 @@ export function initializeTransports(
     },
     unpause,
   };
+}
+
+function sanitizeItems(filteredItems: Array<TransportItem<APIEvent>>, config: Config<APIEvent>) {
+  if (config.preserveOriginalError) {
+    for (const item of filteredItems) {
+      if (item.type === TransportItemType.EXCEPTION) {
+        delete (item as TransportItem<ExceptionEvent<true>>).payload.originalError;
+      }
+    }
+  }
+
+  return filteredItems;
 }

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -1,12 +1,12 @@
-import { TransportItemType } from '..';
-import type { APIEvent, ExceptionEvent, TransportItem } from '..';
+import type { APIEvent, ExceptionEvent } from '../api';
 import type { Config } from '../config';
 import type { InternalLogger } from '../internalLogger';
 import type { Metas } from '../metas';
 import type { UnpatchedConsole } from '../unpatchedConsole';
 
 import { BatchExecutor } from './batchExecutor';
-import type { BeforeSendHook, Transport, Transports } from './types';
+import { TransportItemType } from './const';
+import type { BeforeSendHook, Transport, TransportItem, Transports } from './types';
 
 export function initializeTransports(
   unpatchedConsole: UnpatchedConsole,

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -190,7 +190,9 @@ export function initializeTransports(
     unpause,
   };
 }
-
+/**
+ * Removes the `payload.originalError` property from the provided `TransportItem[]` parameter.
+ */
 function sanitizeItems(filteredItems: Array<TransportItem<APIEvent>>, config: Config<APIEvent>) {
   if (config.preserveOriginalError) {
     for (const item of filteredItems) {

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -164,6 +164,30 @@ describe('transports', () => {
       expect(transport.sentItems[0]).not.toHaveProperty('originalError');
       expect(transport.sentItems[1]).not.toHaveProperty('originalError');
     });
+
+    it('Original error is available in beforeSend function', () => {
+      const mockBeforeSend = jest.fn();
+      const transport = new MockTransport();
+      const { api } = initializeFaro(
+        mockConfig({
+          isolate: true,
+          instrumentations: [],
+          transports: [transport],
+          batching: {
+            enabled: true,
+            itemLimit: 1,
+          },
+          preserveOriginalError: true,
+          beforeSend: mockBeforeSend,
+        })
+      );
+
+      const myError = new Error('Kaboom');
+      api.pushError(myError);
+
+      expect(mockBeforeSend).toHaveBeenCalledTimes(1);
+      expect(mockBeforeSend.mock.calls[0][0]).toHaveProperty('payload.originalError', myError);
+    });
   });
 
   describe('multiple transports of the same type', () => {

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -141,6 +141,29 @@ describe('transports', () => {
       transports.execute(makeExceptionTransportItem('Error', 'ResizeObserver loop limit exceeded'));
       expect(mockBeforeSend).toHaveBeenCalledTimes(2);
     });
+
+    it('Sanitizes data before sending', () => {
+      const transport = new MockTransport();
+      const { api } = initializeFaro(
+        mockConfig({
+          isolate: true,
+          instrumentations: [],
+          transports: [transport],
+          batching: {
+            enabled: true,
+            itemLimit: 1,
+          },
+          preserveOriginalError: true,
+        })
+      );
+
+      api.pushError(new Error('Kaboom1'));
+      api.pushError(new Error('Kaboom2'));
+
+      expect(transport.sentItems).toHaveLength(2);
+      expect(transport.sentItems[0]).not.toHaveProperty('originalError');
+      expect(transport.sentItems[1]).not.toHaveProperty('originalError');
+    });
   });
 
   describe('multiple transports of the same type', () => {

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -46,17 +46,6 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
   }
 
   const {
-    app,
-    batching,
-    beforeSend,
-    consoleInstrumentation,
-    ignoreErrors,
-    sessionTracking,
-    trackResources,
-    trackWebVitalsAttribution,
-    user,
-    view,
-    trackGeolocation,
     // properties with default values
     dedupe = true,
     eventDomain = defaultEventDomain,
@@ -72,14 +61,17 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     webVitalsInstrumentation,
     trackUserActionsPreview = false,
     trackUserActionsDataAttributeName = userActionDataAttribute,
-    trackUserActionsExcludeItem,
+
+    // Properties without default values or which aren't used to create derived config
+    ...restProperties
   }: BrowserConfig = browserConfig;
 
   return {
-    app,
+    ...restProperties,
+
     batching: {
       ...defaultBatchingConfig,
-      ...batching,
+      ...browserConfig.batching,
     },
     dedupe: dedupe,
     globalObjectKey,
@@ -93,25 +85,20 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     preventGlobalExposure,
     transports,
     unpatchedConsole,
-    beforeSend,
     eventDomain,
-    ignoreErrors,
     // ignore cloud collector urls by default. These are URLs ending with /collect or /collect/ followed by alphanumeric characters.
     ignoreUrls: (browserConfig.ignoreUrls ?? []).concat([/\/collect(?:\/[\w]*)?$/]),
     sessionTracking: {
       ...defaultSessionTrackingConfig,
-      ...sessionTracking,
-      ...crateSessionMeta({ trackGeolocation, sessionTracking }),
+      ...browserConfig.sessionTracking,
+      ...crateSessionMeta({
+        trackGeolocation: browserConfig.trackGeolocation,
+        sessionTracking: browserConfig.sessionTracking,
+      }),
     },
-    user,
-    view,
-    trackResources,
-    trackWebVitalsAttribution,
-    consoleInstrumentation,
     webVitalsInstrumentation,
     trackUserActionsPreview,
     trackUserActionsDataAttributeName,
-    trackUserActionsExcludeItem,
   };
 }
 

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -116,6 +116,7 @@ export type {
   EventEvent,
   EventsAPI,
   ExceptionEvent,
+  ExceptionEventExtended,
   ExceptionStackFrame,
   ExceptionsAPI,
   ExtendedError,


### PR DESCRIPTION
## Why

Provide an option to instruct Faro to provide the original error in a Faro error payload.
This is useful to handle special cases in uncontrolled environments/libraries or other enhanced use cases.
I allows to enrich the Faro error before sending it to the collector.

Examples:
* `throw undefined`
* `throw ''`
* Enriching errors while they bubble up to a global error handler which rethrows itself. 
*...

To not unnecessary increase resource user for users who don't use the feature, the option needs to enabled via the `preserveOriginalError: true` property.

If enabled, Faro adds a `orginalError` property to the Faro exception payload holding a ref to the original JS Error.

The `orginalError` is not handled by the Faro receiver so it is removed before sending the data to not unnecessarily increase request payload sizes.

Faro uses the `ExceptionEventExtended` for in that case.

Example
```
beforeSend(item) {
      if (item.type === 'exception') {
        const originalError = (item as TransportItem<ExceptionEventExtended>).payload.originalError;
        // ...
      }

      return item;
    },
```

## What


## Links
[Issue](https://github.com/grafana/faro-web-sdk/issues/1123)
[Docs PR (internal)](https://github.com/grafana/website/pull/25256)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
