### PR TITLE
fix(web-tracing): no Faro events for HTTP requests in CDN bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-tracing`): Fixed an issue with HTTP request sidecar events not being
+  transmitted when using the CDN distribution (#1139).
+
 - Fix (`@grafana/faro-react`): Export the `ExceptionEventExtended` type from the package, allowing
   users to import all necessary types from a single source (#1141).
 

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -99,6 +99,7 @@ export {
   USER_ACTION_CANCEL,
   USER_ACTION_END,
   USER_ACTION_START,
+  unknownString,
 } from '@grafana/faro-core';
 
 export type {

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -1,7 +1,7 @@
 import type { IResourceSpans, IScopeSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
-import { initializeFaro } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+import { initializeFaro } from '@grafana/faro-web-sdk';
 
 import { sendFaroEvents } from './faroTraceExporter.utils';
 

--- a/packages/web-tracing/src/faroTraceExporter.utils.test.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.test.ts
@@ -249,10 +249,10 @@ describe('faroTraceExporter.utils', () => {
         parentId: 'test-parent-id',
       },
       attributes: {
-        duration_ns: 'NaN',
+        duration_ns: expect.any(String),
         // 'faro.action.user.name' and 'faro.action.user.parentId' should be removed from the attributes by the customPayloadTransformer
       },
-      domain: undefined,
+      domain: 'browser',
       name: 'faro.tracing.fetch',
       timestamp: expect.any(String),
       trace: {

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -1,7 +1,7 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
-import { faro, unknownString } from '@grafana/faro-core';
+import { faro, unknownString } from '@grafana/faro-web-sdk';
 import type { EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
 
 const DURATION_NS_KEY = 'duration_ns';

--- a/packages/web-tracing/src/faroUserActionSpanProcessor.test.ts
+++ b/packages/web-tracing/src/faroUserActionSpanProcessor.test.ts
@@ -1,7 +1,6 @@
 import { SpanKind } from '@opentelemetry/api';
 
-import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-core';
-import { apiMessageBus } from '@grafana/faro-web-sdk';
+import { apiMessageBus, USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-web-sdk';
 import type { UserActionCancelMessage, UserActionEndMessage, UserActionStartMessage } from '@grafana/faro-web-sdk';
 
 import { FaroUserActionSpanProcessor } from './faroUserActionSpanProcessor';

--- a/packages/web-tracing/src/faroUserActionSpanProcessor.ts
+++ b/packages/web-tracing/src/faroUserActionSpanProcessor.ts
@@ -1,8 +1,8 @@
 import { type Context, SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import { USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-core';
-import { apiMessageBus, type UserActionStartMessage } from '@grafana/faro-web-sdk';
+import { apiMessageBus, USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-web-sdk';
+import type { UserActionStartMessage } from '@grafana/faro-web-sdk';
 
 export class FaroUserActionSpanProcessor implements SpanProcessor {
   message: UserActionStartMessage | undefined;

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -4,8 +4,7 @@ import type { FetchCustomAttributeFunction } from '@opentelemetry/instrumentatio
 import type { XHRCustomAttributeFunction } from '@opentelemetry/instrumentation-xml-http-request';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import type { Patterns } from '@grafana/faro-core';
-import type { API } from '@grafana/faro-web-sdk';
+import type { API, Patterns } from '@grafana/faro-web-sdk';
 
 // type got remove by with experimental/v0.52.0 and is replaced by the following type:
 // See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.52.0


### PR DESCRIPTION
## Why

On HTTP request Faro sned to items: a `trace` and a Faro sidecar event (`faro.tracing.fecth|xhr`). For cloud users the Faro is shown in the user-journey table.

The Faro event wasn't send for the CDN bundle.

The issue was that the imported `faro` object was `undefined` so `faro.api.pushEvent()` couldn't be executed.
The reason why it was undefined was because some items where imported from the `faro-core` package which isn't flagged a dependency for the `web-tracing` package.
While this is no issue with the other bundles, it is for the `IIFE` (cdn) bundle.

We do only add the web-sdk package as an explicit dependency to IIFE bundle because it already contains the faro-core code. 

The solution was to import the re-exported items from the web-sdk package instead of the faro-core package



## What

* Replace imports from faro core with import from faro-web-sdk


## Links

<!-- Add issues the PR solves or other useful links here. -->


# Screenshots
## Before
- No `faro.tracing.fetch` existent in the Faro beacons 
- After enabling to pause the debugger on caught exception we can see the debugger halts on the a `faro.api.pushEvent` call because the faro object is undefined.  

https://github.com/user-attachments/assets/6843a81d-bc40-40f4-b739-a5fe671de14f


## After
- `faro.tracing.fetch` is available
- No more pause on caught exceptions 

https://github.com/user-attachments/assets/9e6e52e9-91a5-4797-bdc1-3eb4acb2e646



## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
