### PR TITLE
fix(faro-react): re-export the ExceptionEventExtended type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-react`): Export the `ExceptionEventExtended` type from the package, allowing
+  users to import all necessary types from a single source (#1141).
+
 ## 1.17.0
 
 - Feature (`@grafana/faro-web-sdk`): Add option to preserve original JavaScript error objects,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -127,6 +127,7 @@ export {
   VERSION,
   ViewInstrumentation,
   WebVitalsInstrumentation,
+  userActionDataAttribute,
 } from '@grafana/faro-web-sdk';
 
 export type {
@@ -193,4 +194,5 @@ export type {
   TransportItemPayload,
   Transports,
   UnpatchedConsole,
+  ExceptionEventExtended,
 } from '@grafana/faro-web-sdk';


### PR DESCRIPTION
## Why

The ExceptionEventExtended event wasn't exported by the faro-react package.

USer could import it form the web-sdk package but it's confusing if all other imports are provded by the faro-react package

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
