### PR TITLE
chore(resource-timings): guard against negative values

### DIFF
--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -201,4 +201,12 @@ describe('performanceUtils', () => {
     const spanContextUndefined = getSpanContextFromServerTiming(undefinedServerTimings);
     expect(spanContextUndefined).toBeUndefined();
   });
+
+  it('Returns 0 if the value is negative', () => {
+    expect(createFaroResourceTiming({ fetchStart: 10, workerStart: 20 } as any).serviceWorkerTime).toBe('0');
+    expect(createFaroResourceTiming({ fetchStart: 10, workerStart: 5 } as any).serviceWorkerTime).toBe('5');
+    expect(createFaroResourceTiming({ initiatorType: 'initiatorType-test' } as any).initiatorType).toBe(
+      'initiatorType-test'
+    );
+  });
 });

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -188,7 +188,7 @@ function toFaroPerformanceTimingString(v: unknown): string {
   }
 
   if (typeof v === 'number') {
-    return Math.round(v).toString();
+    return Math.round(v > 0 ? v : 0).toString();
   }
 
   return v.toString();


### PR DESCRIPTION
## Why

Reset negative values to `0` when calculating  
`FaroResourceTiming`s

## What

* Update `toFaroPerformanceTimingString()` 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
