### PR TITLE
fix(resource timings): tlsNegotiationTime was wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+## 1.17.2
+
+Fix (`@grafana/faro-web-sdk`): Fixed incorrect calculation of TLS negotiation time in
+performance metrics (#1156).
+
 ## 1.17.1
 
 - Fix (`@grafana/faro-web-tracing`): Fixed an issue with HTTP request sidecar events not being

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -58,7 +58,7 @@ describe('performanceUtils', () => {
       duration: '370',
       tcpHandshakeTime: '0',
       dnsLookupTime: '0',
-      tlsNegotiationTime: '11',
+      tlsNegotiationTime: '178',
       redirectTime: '0',
       requestTime: '359',
       responseTime: '0',

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -100,7 +100,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
     duration: toFaroPerformanceTimingString(duration),
     tcpHandshakeTime: toFaroPerformanceTimingString(connectEnd - connectStart),
     dnsLookupTime: toFaroPerformanceTimingString(domainLookupEnd - domainLookupStart),
-    tlsNegotiationTime: toFaroPerformanceTimingString(requestStart - secureConnectionStart),
+    tlsNegotiationTime: toFaroPerformanceTimingString(connectEnd - secureConnectionStart),
     responseStatus: toFaroPerformanceTimingString(responseStatus),
     redirectTime: toFaroPerformanceTimingString(redirectEnd - redirectStart),
     requestTime: toFaroPerformanceTimingString(responseStart - requestStart),

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtilsTestData.ts
@@ -56,7 +56,7 @@ export const performanceResourceEntry = {
   domainLookupEnd: 778,
   connectStart: 778,
   connectEnd: 778,
-  secureConnectionStart: 778,
+  secureConnectionStart: 600,
   requestStart: 789,
   responseStart: 1148,
   responseStatus: '200',


### PR DESCRIPTION
## Why

Fixed a bug in the calculation of teh TLS negotiation time.

`tslNegotiationTime = connectEnd - secureConnectionStart;`

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
