### PR TITLE
fix(ignoreErrors): ensure to match on the original error and not on the parsed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): Fixed the ignored errors matching logic to properly identify
+  errors based on stack trace content (#1168).
+
 ## 1.17.2
 
 - Fix (`@grafana/faro-web-sdk`): Fixed incorrect calculation of TLS negotiation time in

--- a/packages/core/src/api/exceptions/initialize.test.ts
+++ b/packages/core/src/api/exceptions/initialize.test.ts
@@ -112,7 +112,7 @@ describe('api.exceptions', () => {
       const { api } = initializeFaro(config);
 
       const error = new Error('test');
-      api.pushError(error);
+      api.pushError(error, { originalError: error });
 
       expect(transport.items).toHaveLength(1);
       expect((transport.items[0]?.payload as ExceptionEventExtended).originalError).toEqual(error);

--- a/packages/core/src/api/exceptions/initialize.ts
+++ b/packages/core/src/api/exceptions/initialize.ts
@@ -63,14 +63,14 @@ export function initializeExceptionsAPI({
 
   const pushError: ExceptionsAPI['pushError'] = (
     error,
-    { skipDedupe, stackFrames, type, context, spanContext, timestampOverwriteMs } = {}
+    { skipDedupe, stackFrames, type, context, spanContext, timestampOverwriteMs, originalError } = {}
   ) => {
-    if (isErrorIgnored(ignoreErrors, error)) {
+    if (isErrorIgnored(ignoreErrors, originalError ?? error)) {
       return;
     }
     try {
       const ctx = stringifyObjectValues({
-        ...parseCause(error),
+        ...parseCause(originalError ?? error),
         ...(context ?? {}),
       });
 
@@ -87,7 +87,7 @@ export function initializeExceptionsAPI({
               }
             : tracesApi.getTraceContext(),
           ...(isEmpty(ctx) ? {} : { context: ctx }),
-          ...(preserveOriginalError ? { originalError: error } : {}),
+          ...(preserveOriginalError ? { originalError } : {}),
         },
         type: TransportItemType.EXCEPTION,
       };

--- a/packages/core/src/api/exceptions/types.ts
+++ b/packages/core/src/api/exceptions/types.ts
@@ -58,6 +58,12 @@ export interface PushErrorOptions {
   context?: ExceptionContext;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
   timestampOverwriteMs?: number;
+  /**
+   * Retains the original error object in the payload after parsing.
+   * This is primarily for internal, advanced use cases.
+   * Faro users should not need to use this option.
+   */
+  originalError?: Error;
 }
 
 // ts type is missing the cause property

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -183,7 +183,7 @@ describe('transports', () => {
       );
 
       const myError = new Error('Kaboom');
-      api.pushError(myError);
+      api.pushError(myError, { originalError: myError });
 
       expect(mockBeforeSend).toHaveBeenCalledTimes(1);
       expect(mockBeforeSend.mock.calls[0][0]).toHaveProperty('payload.originalError', myError);

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.test.ts
@@ -1,3 +1,4 @@
+import type { ExceptionEventExtended, TransportItem } from '@grafana/faro-core';
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 
 import { initializeFaro } from '../../initialize';
@@ -24,5 +25,50 @@ describe('registerOnerror', () => {
     window.onerror('boo', 'some file', 10, 10, new Error('boo'));
     expect(called).toBe(true);
     expect(transport.items).toHaveLength(1);
+  });
+
+  it('In case of an error, the original error is not lost', () => {
+    const originalError = new Error('original error');
+    const transport = new MockTransport();
+    const { api } = initializeFaro(
+      mockConfig({
+        transports: [transport],
+        preserveOriginalError: true,
+      })
+    );
+
+    registerOnerror(api);
+
+    window.onerror?.('boo', 'some file', 10, 10, originalError);
+    expect(transport.items).toHaveLength(1);
+
+    expect((transport.items[0] as TransportItem<ExceptionEventExtended>).payload.originalError).toBe(originalError);
+  });
+
+  // Integration test for to test if errors are correctly ignored.
+  // This is needed because of issue: https://github.com/grafana/faro-web-sdk/issues/1160
+  it('will filter out errors by string or regex', () => {
+    const transport = new MockTransport();
+
+    const { api } = initializeFaro(
+      mockConfig({
+        transports: [transport],
+        ignoreErrors: ['chrome-extension'],
+        preserveOriginalError: true,
+      })
+    );
+
+    registerOnerror(api);
+
+    window.onerror?.('boo', 'some file', 10, 10, new Error('Tracked error'));
+
+    const mockErrorWithStacktrace = new Error('Extension error');
+    mockErrorWithStacktrace.name = 'MockError';
+    mockErrorWithStacktrace.stack = `at chrome-extension://<extension-id>/path/to/script.js:1:1";`;
+
+    window.onerror?.('boo', 'some file', 10, 10, mockErrorWithStacktrace);
+
+    expect(transport.items).toHaveLength(1);
+    expect((transport.items[0]?.payload as ExceptionEventExtended).value).toEqual('Tracked error');
   });
 });

--- a/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
+++ b/packages/web-sdk/src/instrumentations/errors/registerOnerror.ts
@@ -1,4 +1,4 @@
-import type { API } from '@grafana/faro-core';
+import type { API, PushErrorOptions } from '@grafana/faro-core';
 
 import { getDetailsFromErrorArgs } from './getErrorDetails';
 
@@ -8,9 +8,16 @@ export function registerOnerror(api: API): void {
   window.onerror = (...args) => {
     try {
       const { value, type, stackFrames } = getDetailsFromErrorArgs(args);
+      const originalError = args[4];
 
       if (value) {
-        api.pushError(new Error(value), { type, stackFrames });
+        const options: PushErrorOptions = { type, stackFrames };
+
+        if (originalError != null) {
+          options.originalError = originalError;
+        }
+
+        api.pushError(new Error(value), options);
       }
     } finally {
       oldOnerror?.apply(window, args);


### PR DESCRIPTION
## Why

Ignoring errors didn't work properly when matching stack only strings.
This was because the parsed error was used which contains parsed stack frames and not the original stack string anymore. 

## What
Open up the options object of the `pushError` API to inject the original error as well.
The original error is then used to check if the error has a match in the `ignoreErrors` list.

Additionally we no (correctly) assign original error to the  `originalError` object in the exception signal payload.
This is used if [preserveOriginalError](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/error-tracking/#handle-other-edge-cases) is enabled.

## Links
Fixes: #1160 

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
