### PR TITLE
chore(PerformanceInstrumentation): track transfer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Improvement (`@grafana/faro-web-sdk`): Track transfer size for resource requests
+  (#1169).
+
 - Fix (`@grafana/faro-web-sdk`): Fixed the ignored errors matching logic to properly identify
   errors based on stack trace content (#1168).
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -73,6 +73,7 @@ describe('performanceUtils', () => {
       initiatorType: 'img',
       ttfb: '359',
       visibilityState: 'visible',
+      transferSize: '11459',
     } as FaroResourceTiming);
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -48,6 +48,7 @@ describe('performanceUtils', () => {
       renderBlockingStatus: 'unknown',
       protocol: 'h2',
       initiatorType: 'navigation',
+      transferSize: '127601',
     } as FaroNavigationTiming);
   });
 

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -115,6 +115,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
     initiatorType: initiatorType,
     visibilityState: document.visibilityState,
     ttfb: toFaroPerformanceTimingString(responseStart - requestStart),
+    transferSize: toFaroPerformanceTimingString(transferSize),
 
     // TODO: add in future iteration, ideally after nested objects are supported by the collector.
     // serverTiming: resourceEntryRaw.serverTiming,

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -35,6 +35,7 @@ export type FaroResourceTiming = Readonly<{
   // serverTiming: PerformanceServerTiming[];
   visibilityState: DocumentVisibilityState;
   ttfb: string;
+  transferSize: string;
 }>;
 
 export type FaroNavigationItem = {


### PR DESCRIPTION
## Why

In Faro we only tracked the body size which doesn't reflects the whole size of a request.

Transfer size shows thee size of the whole request including more data as the body only. Also, if a resource resource is loaded from cache it shows size `0` which refelcts the truth.

If e. gs a user wants to track the wheight of requests, transferSize would reflect teh real number while body size wouldn't becasue it also has a value > 0 when loaded from cache. 

## What

* Add transferSize to performance timings

## Links

* [Docs PR](https://github.com/grafana/website/pull/25499)

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
