### PR TITLE
chore(deps): update Node version support to satisfy EoL of Node18

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.x, 22.x, 23.x, 24.x]
+        node: [20.x, 22.x, 23.x]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18.x, 20.x, 22.x, 23.x]
+        node: [20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/Jod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix (`@grafana/faro-web-sdk`): Fixed the ignored errors matching logic to properly identify
   errors based on stack trace content (#1168).
+- Chore(deps): Changed Node.js version support by removing Node.js 18 (EOL) and adding support
+  for Node.js 24 (#1180).
 
 ## 1.17.2
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Demo of Faro",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "license": "Apache-2.0",
   "author": "Grafana Labs",

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro fetch auto-instrumentation package",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro instrumentation to capture Browser Performance Timeline data.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/instrumentation-xhr/package.json
+++ b/experimental/instrumentation-xhr/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro XHR auto-instrumentation package",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Monorepo for Faro Web SDK",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "license": "Apache-2.0",
   "author": "Grafana Labs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Core package of Faro.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro package that enables easier integration in projects built with React.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro instrumentations, metas, transports for web.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.2",
   "description": "Faro web tracing implementation.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "observability",


### PR DESCRIPTION
## Why

Faro supports only maintained Node versions.
[Node 18 went EoL on Mar 27, 2025](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch) 

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
