### PR TITLE
chore(web-tracing): add resource attrs. for browser and distribution

### DIFF
--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -77,15 +77,15 @@ export class TracingInstrumentation extends BaseInstrumentation {
       attributes[ATTR_BROWSER_BRANDS] = browserMeta.brands.map((entry) => entry.brand);
     }
 
-    if (browserMeta?.userAgent) {
+    if (browserMeta?.language) {
       attributes[ATTR_BROWSER_LANGUAGE] = browserMeta.language;
     }
 
-    if (browserMeta?.mobile != null) {
+    if (typeof browserMeta?.mobile === 'boolean') {
       attributes[ATTR_BROWSER_MOBILE] = Boolean(browserMeta.mobile);
     }
 
-    if (browserMeta?.os != null) {
+    if (browserMeta?.os) {
       attributes[ATTR_BROWSER_PLATFORM] = browserMeta.os;
     }
 

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -10,7 +10,7 @@ import {
   SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
 } from '@opentelemetry/semantic-conventions';
 
-import { BaseInstrumentation, VERSION } from '@grafana/faro-web-sdk';
+import { BaseInstrumentation, unknownString, VERSION } from '@grafana/faro-web-sdk';
 import type { Transport } from '@grafana/faro-web-sdk';
 
 import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
@@ -18,7 +18,14 @@ import { FaroTraceExporter } from './faroTraceExporter';
 import { FaroUserActionSpanProcessor } from './faroUserActionSpanProcessor';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 import { getSamplingDecision } from './sampler';
-import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME, ATTR_SERVICE_NAMESPACE } from './semconv';
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_PROCESS_RUNTIME_NAME,
+  ATTR_PROCESS_RUNTIME_VERSION,
+  ATTR_SERVICE_NAMESPACE,
+  ATTR_TELEMETRY_DISTRO_NAME,
+  ATTR_TELEMETRY_DISTRO_VERSION,
+} from './semconv';
 import type { TracingInstrumentationOptions } from './types';
 
 // the providing of app name here is not great
@@ -58,6 +65,12 @@ export class TracingInstrumentation extends BaseInstrumentation {
        */
       attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT] = this.config.app.environment;
     }
+
+    attributes[ATTR_PROCESS_RUNTIME_NAME] = 'browser';
+    attributes[ATTR_PROCESS_RUNTIME_VERSION] = this.metas.value.browser?.userAgent ?? unknownString;
+
+    attributes[ATTR_TELEMETRY_DISTRO_NAME] = 'faro-web-tracing';
+    attributes[ATTR_TELEMETRY_DISTRO_VERSION] = VERSION;
 
     Object.assign(attributes, options.resourceAttributes);
 

--- a/packages/web-tracing/src/semconv.ts
+++ b/packages/web-tracing/src/semconv.ts
@@ -18,3 +18,9 @@ export const ATTR_PROCESS_RUNTIME_VERSION = 'process.runtime.version';
 // https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/#telemetry-attributes
 export const ATTR_TELEMETRY_DISTRO_NAME = 'telemetry.distro.name';
 export const ATTR_TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version';
+
+// https://opentelemetry.io/docs/specs/semconv/resource/browser/
+export const ATTR_BROWSER_BRANDS = 'browser.brands';
+export const ATTR_BROWSER_LANGUAGE = 'browser.language';
+export const ATTR_BROWSER_MOBILE = 'browser.mobile';
+export const ATTR_BROWSER_PLATFORM = 'browser.platform';

--- a/packages/web-tracing/src/semconv.ts
+++ b/packages/web-tracing/src/semconv.ts
@@ -10,3 +10,11 @@
 export const ATTR_SESSION_ID = 'session.id';
 export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name';
 export const ATTR_SERVICE_NAMESPACE = 'service.namespace';
+
+// https://opentelemetry.io/docs/specs/semconv/resource/process/#javascript-runtimes
+export const ATTR_PROCESS_RUNTIME_NAME = 'process.runtime.name';
+export const ATTR_PROCESS_RUNTIME_VERSION = 'process.runtime.version';
+
+// https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/#telemetry-attributes
+export const ATTR_TELEMETRY_DISTRO_NAME = 'telemetry.distro.name';
+export const ATTR_TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version';


### PR DESCRIPTION
## Why

Add resource attributes for runtime and distro yo make it more staright forward to query respective spans.

## What

Add above attr. 

Note:
They are not stable and the OTEL suggested way is to create own files to hold the attributes to prevent breakage.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Screenshots

<img width="1340" alt="Screenshot 2025-05-05 at 17 35 32" src="https://github.com/user-attachments/assets/e78c35e7-5327-4ed5-98c3-e8a73b2689ed" />


## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
