### PR TITLE
chore(user actions): don't attach user action context to http request when in halt mode

### DIFF
--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -169,7 +169,7 @@ export type {
   UserActionStartMessage,
   UserActionEndMessage,
   UserActionCancelMessage,
-  UserAction,
+  UserActionHaltMessage,
 } from '@grafana/faro-core';
 
 export {

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -98,6 +98,7 @@ export {
   Observable,
   USER_ACTION_CANCEL,
   USER_ACTION_END,
+  USER_ACTION_HALT,
   USER_ACTION_START,
   unknownString,
 } from '@grafana/faro-core';

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -102,7 +102,6 @@ export function getUserEventHandler(faro: Faro) {
           runningRequests.set(msg.request.requestId, msg.request);
         }
         if (isRequestEndMessage(msg)) {
-          // console.log('request end msg :>> ', msg);
           runningRequests.delete(msg.request.requestId);
         }
 

--- a/packages/web-tracing/src/faroUserActionSpanProcessor.ts
+++ b/packages/web-tracing/src/faroUserActionSpanProcessor.ts
@@ -1,7 +1,13 @@
 import { type Context, SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import { apiMessageBus, USER_ACTION_CANCEL, USER_ACTION_END, USER_ACTION_START } from '@grafana/faro-web-sdk';
+import {
+  apiMessageBus,
+  USER_ACTION_CANCEL,
+  USER_ACTION_END,
+  USER_ACTION_HALT,
+  USER_ACTION_START,
+} from '@grafana/faro-web-sdk';
 import type { UserActionStartMessage } from '@grafana/faro-web-sdk';
 
 export class FaroUserActionSpanProcessor implements SpanProcessor {
@@ -14,7 +20,7 @@ export class FaroUserActionSpanProcessor implements SpanProcessor {
         return;
       }
 
-      if ([USER_ACTION_END, USER_ACTION_CANCEL].includes(msg.type)) {
+      if ([USER_ACTION_END, USER_ACTION_HALT, USER_ACTION_CANCEL].includes(msg.type)) {
         this.message = undefined;
       }
     });


### PR DESCRIPTION
## Why

When a action has long pending http requests it starts an extended timer if the regular action timeout is reached while waiting for the pending requests to resolve and the action goes in `halt` state .

The `halt` state indicates that the regular action has been finished bc no further eligible event happened within the respective timeframes and it waits for the pending requests to finish.

This can already happen on slow connection (can be tested with throttling in the browser).

Because we forgot to respect the `halt` state in the web tracing package it could happen that any requests sent during the `halt` phase (remember they don't belong to the action anymore) were still mapped to the action.

Note:
As long as the action is in `halt` state no new action can be started. 

## What

* add the missing `halt` state to the [FaroUserActionSpanProcessor](https://github.com/grafana/faro-web-sdk/blob/447907eb87781a86c68b53e1ad0a43de0e681cb1/packages/web-tracing/src/faroUserActionSpanProcessor.ts#L23)

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
