### PR TITLE
chore(deps): remove node 18 support, add node 24 support

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18.x, 20.x, 22.x, 23.x]
+        node: [20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ Faro releases follow the [Semantic Versioning](https://semver.org/) naming schem
   > NOTE: Our goal is to provide regular releases that are as stable as possible,
   > and we take backwards-compatibility seriously. As with any software, always read the release notes
   > and the upgrade guide whenever choosing a new version of Faro to install.
+
+## Supported Node versions
+
+Faro supports all active LTS (Long Term Support) and current Node versions. When Node.js versions
+reach end-of-life, we remove them from our test matrix and add new versions as they are released.
+You can find a [release schedule on nodejs.org](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch)

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-demo",
   "version": "1.18.1",
   "description": "Demo of Faro",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "license": "Apache-2.0",
   "author": "Grafana Labs",
   "homepage": "https://github.com/grafana/faro-web-sdk",

--- a/experimental/instrumentation-fetch/package.json
+++ b/experimental/instrumentation-fetch/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-instrumentation-fetch",
   "version": "1.18.1",
   "description": "Faro fetch auto-instrumentation package",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/instrumentation-performance-timeline/package.json
+++ b/experimental/instrumentation-performance-timeline/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-instrumentation-performance-timeline",
   "version": "1.18.1",
   "description": "Faro instrumentation to capture Browser Performance Timeline data.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/instrumentation-xhr/package.json
+++ b/experimental/instrumentation-xhr/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-instrumentation-xhr",
   "version": "1.18.1",
   "description": "Faro XHR auto-instrumentation package",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-transport-otlp-http",
   "version": "1.18.1",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "faro-web-sdk",
   "version": "0.0.0",
   "description": "Monorepo for Faro Web SDK",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "license": "Apache-2.0",
   "author": "Grafana Labs",
   "homepage": "https://github.com/grafana/faro-web-sdk#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-core",
   "version": "1.18.1",
   "description": "Core package of Faro.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-react",
   "version": "1.18.1",
   "description": "Faro package that enables easier integration in projects built with React.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-web-sdk",
   "version": "1.18.1",
   "description": "Faro instrumentations, metas, transports for web.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -2,9 +2,6 @@
   "name": "@grafana/faro-web-tracing",
   "version": "1.18.1",
   "description": "Faro web tracing implementation.",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "keywords": [
     "observability",
     "apm",


### PR DESCRIPTION
## Why

Remove the node engine object and update the supported node versions in the test matrix. 

## What

See above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
