### PR TITLE
chore(user actions): rename event type to event trigger to better reflect what it is about

### DIFF
--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
@@ -126,7 +126,7 @@ describe('UserActionsInstrumentation', () => {
         userActionStartTime: expect.any(String),
         userActionEndTime: expect.any(String),
         userActionDuration: expect.any(String),
-        userActionEventType: expect.any(String),
+        userActionEventTrigger: expect.any(String),
       }),
       undefined,
       expect.anything()
@@ -242,7 +242,7 @@ describe('UserActionsInstrumentation', () => {
         userActionStartTime: expect.any(String),
         userActionEndTime: expect.any(String),
         userActionDuration: expect.any(String),
-        userActionEventType: expect.any(String),
+        userActionEventTrigger: expect.any(String),
       }),
       undefined,
       expect.anything()
@@ -330,7 +330,7 @@ describe('UserActionsInstrumentation', () => {
         userActionStartTime: expect.any(String),
         userActionEndTime: expect.any(String),
         userActionDuration: expect.any(String),
-        userActionEventType: expect.any(String),
+        userActionEventTrigger: expect.any(String),
       }),
       undefined,
       expect.anything()

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -200,7 +200,7 @@ function endUserAction(props: {
       userActionStartTime: startTime.toString(),
       userActionEndTime: endTime.toString(),
       userActionDuration: duration.toString(),
-      userActionEventType: eventType,
+      userActionEventTrigger: eventType,
       ...stringifyObjectValues(attributes),
     },
     undefined,


### PR DESCRIPTION
## Why

A user action contained a filed called `userActionType` which had values like `pointerdown` etc.

These values describe the thing which triggered the event but not the type of action.

Since we do not have different action types yet, we renamed the field to `userActionTrigger` to better reflect what it is about and to preserve the type filed for later when we may have different action types. 

## What

see above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
