### PR TITLE
feat(web-sdk): add Content Security Policy Instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- fix(core): Ensure first instrumentation gets properly removed (#1312)
+- feat(web-sdk): Add CSP instrumentation (#1312)
 - chore(ignored URLs): Prevent tracking of custom collector URLs that don't match the Faro collector
   URL structure (#1297)
 - chore(user actions): Rename `userActionEventType` to `userActionTrigger` for improved clarity (#1298)

--- a/packages/core/src/instrumentations/initialize.ts
+++ b/packages/core/src/instrumentations/initialize.ts
@@ -65,7 +65,7 @@ export function initializeInstrumentations(
         null
       );
 
-      if (!existingInstrumentationIndex) {
+      if (existingInstrumentationIndex === null) {
         internalLogger.warn(`Instrumentation "${instrumentationToRemove.name}" is not added`);
 
         return;

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -2,6 +2,7 @@ import type { Instrumentation } from '@grafana/faro-core';
 
 import {
   ConsoleInstrumentation,
+  CSPInstrumentation,
   ErrorsInstrumentation,
   PerformanceInstrumentation,
   SessionInstrumentation,
@@ -24,6 +25,10 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
   if (options.enablePerformanceInstrumentation !== false) {
     // unshift to ensure that initialization starts before the other instrumentations
     instrumentations.unshift(new PerformanceInstrumentation());
+  }
+
+  if (options.enableContentSecurityPolicyInstrumentation !== false) {
+    instrumentations.push(new CSPInstrumentation());
   }
 
   if (options.captureConsole !== false) {

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -9,4 +9,5 @@ export interface GetWebInstrumentationsOptions {
   captureConsole?: boolean;
   captureConsoleDisabledLevels?: LogLevel[];
   enablePerformanceInstrumentation?: boolean;
+  enableContentSecurityPolicyInstrumentation?: boolean;
 }

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
   WebVitalsInstrumentation,
   SessionInstrumentation,
   PerformanceInstrumentation,
+  CSPInstrumentation,
   UserActionInstrumentation,
 } from './instrumentations';
 export type { ConsoleInstrumentationOptions, ErrorEvent, ExtendedPromiseRejectionEvent } from './instrumentations';

--- a/packages/web-sdk/src/instrumentations/csp/index.ts
+++ b/packages/web-sdk/src/instrumentations/csp/index.ts
@@ -1,0 +1,1 @@
+export { CSPInstrumentation } from './instrumentation';

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
@@ -1,0 +1,71 @@
+import { initializeFaro, TransportItem } from '@grafana/faro-core';
+import type { EventEvent } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+
+import { makeCoreConfig } from '../../config';
+
+import { CSPInstrumentation } from './instrumentation';
+
+describe('CSPInstrumentation', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('sends a faro event when securitypolicyviolation event is fired', () => {
+    const mockTransport = new MockTransport();
+
+    const instrumentation = new CSPInstrumentation();
+    initializeFaro(
+      makeCoreConfig(
+        mockConfig({
+          transports: [mockTransport],
+          instrumentations: [instrumentation],
+        })
+      )!
+    );
+
+    const fakeEvent = {
+      blockedURI: 'https://evil.com/script.js',
+      documentURI: 'https://my.app/',
+      sourceFile: 'https://my.app/index.js',
+      statusCode: 200,
+      lineNumber: 10,
+      columnNumber: 5,
+      disposition: 'enforce',
+      effectiveDirective: 'script-src',
+      violatedDirective: 'script-src-elem',
+      originalPolicy: "default-src 'self'; script-src 'self'",
+      referrer: 'https://referrer.app/',
+      sample: 'alert("xss")',
+    } as SecurityPolicyViolationEvent;
+
+    // Note: We can't simulate real `securitypolicyviolation` events in Jest/jsdom,
+    // because `SecurityPolicyViolationEvent` is not implemented and CSP is not enforced.
+    // Instead, we manually call the handler with a mocked object that matches the shape.
+    // This ensures the instrumentation logic is tested even without full browser support.
+    instrumentation.securitypolicyviolationHandler(fakeEvent);
+    expect(mockTransport.items).toHaveLength(1);
+
+    expect((mockTransport.items[0] as TransportItem<EventEvent>)?.payload.attributes?.['lineNumber']).toBe('10');
+  });
+
+  it('ensures listener gets removed on teardown', () => {
+    const mockTransport = new MockTransport();
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+    const instrumentation = new CSPInstrumentation();
+    const faro = initializeFaro(
+      makeCoreConfig(
+        mockConfig({
+          transports: [mockTransport],
+          instrumentations: [instrumentation],
+        })
+      )!
+    );
+    faro.internalLogger.warn = jest.fn();
+
+    faro.instrumentations.remove(instrumentation);
+    expect(removeSpy).toHaveBeenCalledWith('securitypolicyviolation', instrumentation.securitypolicyviolationHandler);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
@@ -1,0 +1,23 @@
+import { BaseInstrumentation, stringifyObjectValues, VERSION } from '@grafana/faro-core';
+import type { Instrumentation } from '@grafana/faro-core';
+
+export class CSPInstrumentation extends BaseInstrumentation implements Instrumentation {
+  readonly name = '@grafana/faro-web-sdk:instrumentation-csp';
+  readonly version = VERSION;
+
+  constructor() {
+    super();
+  }
+
+  initialize() {
+    document.addEventListener('securitypolicyviolation', this.securitypolicyviolationHandler.bind(this));
+  }
+
+  destroy() {
+    document.removeEventListener('securitypolicyviolation', this.securitypolicyviolationHandler);
+  }
+
+  public securitypolicyviolationHandler(ev: SecurityPolicyViolationEvent) {
+    this.api.pushEvent('securitypolicyviolation', stringifyObjectValues(ev as Record<string, any>));
+  }
+}

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -29,3 +29,5 @@ export {
 export { PerformanceInstrumentation } from './performance';
 
 export { UserActionInstrumentation, userActionDataAttribute, startUserAction } from './userActions';
+
+export { CSPInstrumentation } from './csp';


### PR DESCRIPTION
## Why

In order to support Content Security Policy violation payloads

## What

Create a new CSPInstrumenetation that registers to the `securitypolicyviolation` event and forwards the payload as a Faro event. Although this is not pedantic in terms of using the `Report-To` header etc, it is a way of getting this event into the pipeline and utilising all the metadata Faro SDK provides.

## Links

https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP

## Checklist

- [X] Tests added
- [X] Changelog updated
- [ ] Documentation updated
