### PR TITLE
chore(build): don't build against node 23 anymore because it is EoL

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.x, 22.x, 23.x, 24.x]
+        node: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

Node 23 is EoL and we have first dependencies failing to build.

## What

Remove Node 23 from GH action 

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
