### PR TITLE
chore(release): 1.19.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 1.19.0
+
 - Feature (`@grafana/faro-web-sdk`): Add CSP instrumentation (#1312)
 
 - Improvement (`@grafana/faro-*`): Rename `userActionEventType` to `userActionTrigger` for improved clarity (#1298)


### PR DESCRIPTION
## 1.19.0

- Feature (`@grafana/faro-web-sdk`): Add CSP instrumentation (#1312)

- Improvement (`@grafana/faro-*`): Rename `userActionEventType` to `userActionTrigger` for improved clarity (#1298)

- Chore (`@grafana/faro-web-sdk`): Prevent tracking of custom collector URLs that don't match the Faro collector
  URL structure (#1297)
- Chore (`@grafana/faro-core`): Ensure first instrumentation gets properly removed (#1312)
- Chore (`@grafana/faro-*`): Remove Node.js 23 from build and test matrix as it's EoL (#1343)
- Chore (`@grafana/faro-*`): upgrade to yarn 4