### PR TITLE
fix: prevent filename from being badly extracted when no function name is resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next
 
 - Chore (`@grafana/faro-*`): set default node version to lts/jod
+- Fix (`@grafana/faro-web-sdk`): Update `webkitLineRegex` to prevent the
+  function name capture group from matching URLs
 
 ### Breaking
 

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/const.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/const.ts
@@ -4,7 +4,7 @@ export const unknownSymbolString = '?';
 export const atString = '@';
 
 export const webkitLineRegex =
-  /^\s*at (?:(.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
+  /^\s*at (?:(?![a-z]+:\/\/)([^(]+?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
 export const webkitEvalRegex = /\((\S*)(?::(\d+))(?::(\d+))\)/;
 export const webkitEvalString = 'eval';
 export const webkitAddressAtString = 'address at ';

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
@@ -25,8 +25,8 @@ describe('getStackFramesFromError', () => {
   it('should handle Chrome v36 traces with parentheses in URL', () => {
     const result = getStackFramesFromError(CapturedExceptions.CHROME_36_PARENTHESES_URL);
     expect(result).toEqual([
-      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'dumpExceptionError', 41, 27),
-      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'HTMLButtonElement.onclick', 107, 146),
+      buildStackFrame('http://localhost:8080/[brackets]/(parentheses)/file.js', 'dumpExceptionError', 41, 27),
+      buildStackFrame('http://localhost:8080/[brackets]/(parentheses)/file.js', 'HTMLButtonElement.onclick', 107, 146),
     ]);
   });
 
@@ -41,17 +41,8 @@ describe('getStackFramesFromError', () => {
   it('should handle Chrome v36 traces when no function name is resolved and parentheses in URL', () => {
     const result = getStackFramesFromError(CapturedExceptions.CHROME_36_NO_FUNCTION_NAME_PARENTHESES_URL);
     expect(result).toEqual([
-      /*     This wrongly givees:
-       {
-          "colno": 27,
-    -     "filename": "http://localhost:8080/[brackets]/(paranthesis)/file.js",
-    -     "func": undefined,
-    +     "filename": "paranthesis)/file.js",
-    +     "func": "http://localhost:8080/[brackets]/",
-          "lineno": 41,
-        }, */
-      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', undefined, 41, 27),
-      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'HTMLButtonElement.onclick', 107, 146),
+      buildStackFrame('http://localhost:8080/[brackets]/(parentheses)/file.js', undefined, 41, 27),
+      buildStackFrame('http://localhost:8080/[brackets]/(parentheses)/file.js', 'HTMLButtonElement.onclick', 107, 146),
     ]);
   });
 
@@ -219,8 +210,8 @@ CapturedExceptions.CHROME_36_PARENTHESES_URL = {
   name: 'Error',
   stack:
     'Error: Default error\n' +
-    '    at dumpExceptionError (http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27)\n' +
-    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
+    '    at dumpExceptionError (http://localhost:8080/[brackets]/(parentheses)/file.js:41:27)\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(parentheses)/file.js:107:146)',
 };
 
 CapturedExceptions.CHROME_36_NO_FUNCTION_NAME = {
@@ -237,8 +228,8 @@ CapturedExceptions.CHROME_36_NO_FUNCTION_NAME_PARENTHESES_URL = {
   name: 'Error',
   stack:
     'Error: Default error\n' +
-    '    at http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27\n' +
-    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
+    '    at http://localhost:8080/[brackets]/(parentheses)/file.js:41:27\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(parentheses)/file.js:107:146)',
 };
 
 CapturedExceptions.CHROME_46 = {
@@ -248,15 +239,6 @@ CapturedExceptions.CHROME_46 = {
     'Error: Default error\n' +
     '    at new CustomError (http://localhost:8080/file.js:41:27)\n' +
     '    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)',
-};
-
-CapturedExceptions.CHROME_46_BRACKETS_PARANTHESIS = {
-  message: 'Default error',
-  name: 'Error',
-  stack:
-    'Error: Default error\n' +
-    '    at new CustomError (http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27)\n' +
-    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
 };
 
 CapturedExceptions.CHROME_48_NESTED_EVAL = {

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
@@ -22,6 +22,39 @@ describe('getStackFramesFromError', () => {
     ]);
   });
 
+  it('should handle Chrome v36 traces with parentheses in URL', () => {
+    const result = getStackFramesFromError(CapturedExceptions.CHROME_36_PARENTHESES_URL);
+    expect(result).toEqual([
+      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'dumpExceptionError', 41, 27),
+      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'HTMLButtonElement.onclick', 107, 146),
+    ]);
+  });
+
+  it('should handle Chrome v36 traces when no function name is resolved', () => {
+    const result = getStackFramesFromError(CapturedExceptions.CHROME_36_NO_FUNCTION_NAME);
+    expect(result).toEqual([
+      buildStackFrame('http://localhost:8080/file.js', undefined, 41, 27),
+      buildStackFrame('http://localhost:8080/file.js', 'HTMLButtonElement.onclick', 107, 146),
+    ]);
+  });
+
+  it('should handle Chrome v36 traces when no function name is resolved and parentheses in URL', () => {
+    const result = getStackFramesFromError(CapturedExceptions.CHROME_36_NO_FUNCTION_NAME_PARENTHESES_URL);
+    expect(result).toEqual([
+      /*     This wrongly givees:
+       {
+          "colno": 27,
+    -     "filename": "http://localhost:8080/[brackets]/(paranthesis)/file.js",
+    -     "func": undefined,
+    +     "filename": "paranthesis)/file.js",
+    +     "func": "http://localhost:8080/[brackets]/",
+          "lineno": 41,
+        }, */
+      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', undefined, 41, 27),
+      buildStackFrame('http://localhost:8080/[brackets]/(paranthesis)/file.js', 'HTMLButtonElement.onclick', 107, 146),
+    ]);
+  });
+
   it('should handle Chrome v48 traces', () => {
     const result = getStackFramesFromError(CapturedExceptions.CHROME_48_NESTED_EVAL);
     expect(result).toEqual([
@@ -181,6 +214,33 @@ CapturedExceptions.CHROME_36 = {
     '    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)',
 };
 
+CapturedExceptions.CHROME_36_PARENTHESES_URL = {
+  message: 'Default error',
+  name: 'Error',
+  stack:
+    'Error: Default error\n' +
+    '    at dumpExceptionError (http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27)\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
+};
+
+CapturedExceptions.CHROME_36_NO_FUNCTION_NAME = {
+  message: 'Default error',
+  name: 'Error',
+  stack:
+    'Error: Default error\n' +
+    '    at http://localhost:8080/file.js:41:27\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)',
+};
+
+CapturedExceptions.CHROME_36_NO_FUNCTION_NAME_PARENTHESES_URL = {
+  message: 'Default error',
+  name: 'Error',
+  stack:
+    'Error: Default error\n' +
+    '    at http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
+};
+
 CapturedExceptions.CHROME_46 = {
   message: 'Default error',
   name: 'Error',
@@ -188,6 +248,15 @@ CapturedExceptions.CHROME_46 = {
     'Error: Default error\n' +
     '    at new CustomError (http://localhost:8080/file.js:41:27)\n' +
     '    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)',
+};
+
+CapturedExceptions.CHROME_46_BRACKETS_PARANTHESIS = {
+  message: 'Default error',
+  name: 'Error',
+  stack:
+    'Error: Default error\n' +
+    '    at new CustomError (http://localhost:8080/[brackets]/(paranthesis)/file.js:41:27)\n' +
+    '    at HTMLButtonElement.onclick (http://localhost:8080/[brackets]/(paranthesis)/file.js:107:146)',
 };
 
 CapturedExceptions.CHROME_48_NESTED_EVAL = {


### PR DESCRIPTION
## Why

`filename` is not being extracted properly when no function name or method is provided on chrome, and the URL includes parentheses, causing the filename to be wrongly resolved, as shown in this test snapshot

```
       {
          "colno": 27,
    -     "filename": "http://localhost:8080/[brackets]/(paranthesis)/file.js",
    -     "func": undefined,
    +     "filename": "paranthesis)/file.js",
    +     "func": "http://localhost:8080/[brackets]/",
          "lineno": 41,
        }, 
```
## What

To fix this, the `webkitLineRegex` was changed to have a negative lookahead for function name capture group preventing it from matching URLs


## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated
