### PR TITLE
chore(actions): pin images

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,12 +49,12 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers
+      image: cypress/browsers:22.12.0
       options: --user 1001
 
     services:
       database:
-        image: postgres:latest
+        image: postgres:17.5
         env:
           POSTGRES_DB: demo
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
     services:
       database:
-        image: postgres:latest
+        image: postgres:17.5
         env:
           POSTGRES_DB: demo
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Why

Zizmor failed because soem images weren't pinned.

```
error[unpinned-images]: unpinned image references
  --> ./.github/workflows/pull-request.yml:52:7
   |
52 |       image: cypress/browsers
   |       ^^^^^^^^^^^^^^^^^^^^^^^ container image is unpinned
   |
   = note: audit confidence → High

error[unpinned-images]: unpinned image references
  --> ./.github/workflows/pull-request.yml:57:9
   |
57 |         image: postgres:latest
   |         ^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
   |
   = note: audit confidence → High

error[unpinned-images]: unpinned image references
  --> ./.github/workflows/release.yml:54:9
   |
54 |         image: postgres:latest
   |         ^^^^^^^^^^^^^^^^^^^^^^ container image is pinned to latest
   |
   = note: audit confidence → High

14 findings (11 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 3 high
```

## What

Pin aforementioned images 

## Links

Affected PRs
* https://github.com/grafana/faro-web-sdk/pull/1480
* https://github.com/grafana/faro-web-sdk/pull/1479


## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
