### PR TITLE
fix(web-tracing): Prevent web-tracing from importing faro from core

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@
 # App-specifics
 .cache
 .eslintcache
+**/.eslintrc.js
 .husky
 coverage
 cypress/videos

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: ['@grafana/eslint-config', 'plugin:import/errors', 'plugin:import/warnings', 'plugin:import/typescript'],
   plugins: ['eslint-plugin-no-only-tests'],
   settings: {

--- a/packages/web-tracing/.eslintrc.js
+++ b/packages/web-tracing/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@grafana/faro-core',
+            importNames: ['faro'],
+            message: 'web-tracing must import faro from web-sdk instead of core',
+          },
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Why

Importing `faro` from `core` in `web-tracing` will cause runtime failures when using the iife bundle due to the way minification works. The correct import should be from `web-sdk`.

## What

Added an ESLint rule that will cause the quality:lint check to fail if the wrong import is used.

A couple of notes:
1) The new rule will cause CI failures until #1500 is merged.
2) ESLint 9 does not support nested files like this uses, so this rule will need to be moved into the flat file if ESLint is upgraded. To make sure that won't get missed, I also wrote a test that validates the error is printed when running ESLint, but I kept it in [another branch](https://github.com/zackman0010/faro-web-sdk/commit/230c87f6f07436ca73e234f4ebdf77d1b462931b) due to it requiring some dependency changes to run ESLint in a Jest.

## Links

Resolves #1506 

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
