### PR TITLE
chore: add eslint rule to not allow importing core from web-tracing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,4 +43,21 @@ module.exports = {
     project: 'tsconfig.base.json',
     tsconfigRootDir: __dirname,
   },
+  overrides: [
+    {
+      files: ["packages/web-tracing/**/*.ts"],
+      excludedFiles: ["packages/web-tracing/**/*.test.ts"],
+      rules: {
+        // Disallow importing core from web tracing
+        "no-restricted-imports": ["error", {        
+          paths: [
+            { name: "@grafana/faro-core", message: "Import from @grafana/faro-web-sdk instead of @grafana/faro-core." }
+          ],          
+          patterns: [
+            "@grafana/faro-core/*"
+          ]
+        }]
+      }
+    }
+  ]
 };


### PR DESCRIPTION
## Why

Importing from core in the web-tracing package can result in duplicated code between the web-sdk and web-tracing bundles. This was specifically an issue when importing the `faro` global singleton.

## What

Since this is easy to introduce and hard to detect, we can disallow any import from core. This change adds an eslint rule for this purpose. 

## Links

Fixes https://github.com/grafana/faro-web-sdk/issues/1506

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
