### PR TITLE
chore(readme): updated transport-otlp-http package name in readme to match npm name

### DIFF
--- a/experimental/transport-otlp-http/README.md
+++ b/experimental/transport-otlp-http/README.md
@@ -1,4 +1,4 @@
-# @grafana/transport-otlp-http
+# @grafana/faro-transport-otlp-http
 
 Faro transport which converts the Faro model to the Open Telemetry model.
 


### PR DESCRIPTION
## Why

The npm published name and the name in readme do not currently match, which is confusing in npm.
<img width="694" height="399" alt="image" src="https://github.com/user-attachments/assets/bf4ddf2b-bfd1-4439-8741-386351b08f79" />

## What

Updated the name :)

## Links

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
