### PR TITLE
chore: updated readme with beta version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This version modernizes Faro, simplifies setup, and removes legacy code, to give
 
 #### ⚠️ Pre-release Note
 
-- Please install using the explicit version tag **@2.0.0-beta**
+- Please install using this version range **@^2.0.0-beta**
 - 👉 **@latest** will continue to point to **v1.19.0** until v2 reaches GA.
 
 ##### Follow the upgrade guides for more information


### PR DESCRIPTION
## Why

The latest beta version is `2.0.0-beta-2`. The README has instructions to specifically install `2.0.0-beta`.

## What

This changes the single version to a range, so that the latest beta version is installed.

## Links

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
