### PR TITLE
fix(user-actions): custom severity wasn't added to user action attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): Fixed an issue where custom severity and custom trigger properties
+  were not being included in user action attributes (#1551)
+
 ## 2.0.0.beta-2
 
 - Fix (`@grafana/faro-web-tracing`): fixed error with the web-tracing CDN bundle related to

--- a/cypress/e2e/demo/events.cy.ts
+++ b/cypress/e2e/demo/events.cy.ts
@@ -6,7 +6,6 @@ context('Events', () => {
       title: 'an event',
       btnName: 'event-with-attrs',
       aliasGenerator: (body: TransportBody) => {
-        console.log('body :>> ', { body });
         const item = body.events?.find?.((e: EventEvent) => e.name === 'click_button_with_attributes');
 
         return item?.attributes?.['foo'] === 'bar' && item?.attributes?.['baz'] === 'bad' ? 'event' : undefined;

--- a/demo/src/client/pages/Features/TracingInstrumentation.tsx
+++ b/demo/src/client/pages/Features/TracingInstrumentation.tsx
@@ -18,7 +18,7 @@ export function TracingInstrumentation() {
   };
 
   const xhrSuccess = () => {
-    faro.api.startUserAction('xhr-success');
+    faro.api.startUserAction('xhr-success', undefined, { severity: UserActionSeverity.Critical, triggerName: 'foo' });
     const xhr = new XMLHttpRequest();
     xhr.open('GET', '/');
     xhr.send();

--- a/packages/core/src/api/userActions/initialize.test.ts
+++ b/packages/core/src/api/userActions/initialize.test.ts
@@ -1,3 +1,4 @@
+import { faro, UserActionSeverity } from '../..';
 import { mockConfig, mockInternalLogger } from '../../testUtils';
 import { mockTransports } from '../apiTestHelpers';
 
@@ -37,6 +38,27 @@ describe('initializeUserActionsAPI', () => {
     const action = api.startUserAction('first');
     expect(action).toBeInstanceOf(UserAction);
     expect(api.getActiveUserAction()).toBe(action);
+  });
+
+  it('startUserAction has custom severity and trigger set', () => {
+    const action = api.startUserAction('first', undefined, {
+      severity: UserActionSeverity.Critical,
+      triggerName: 'foo',
+    });
+    expect(action).toBeInstanceOf(UserAction);
+
+    const activeAction = api.getActiveUserAction();
+    expect(activeAction).toBe(action);
+
+    activeAction?.end();
+
+    expect(faro.api.pushEvent).toHaveBeenCalledTimes(1);
+    expect(faro.api.pushEvent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ userActionSeverity: 'critical', userActionTrigger: 'foo' }),
+      undefined,
+      expect.any(Object)
+    );
   });
 
   it('subsequent startUserAction calls will return undefined as long as there is an action running', () => {

--- a/packages/core/src/api/userActions/initialize.ts
+++ b/packages/core/src/api/userActions/initialize.ts
@@ -2,7 +2,7 @@ import { type InternalLogger, type Transports } from '../..';
 import type { Config } from '../../config';
 import { Observable } from '../../utils/reactive';
 
-import { userActionStart, userActionStartByApiCallEventName } from './const';
+import { UserActionSeverity, userActionStart, userActionStartByApiCallEventName } from './const';
 import {
   type StartUserActionOptions,
   type UserActionInterface,
@@ -44,6 +44,7 @@ export function initializeUserActionsAPI({
         transports,
         attributes,
         trigger: options?.triggerName || userActionStartByApiCallEventName,
+        severity: options?.severity || UserActionSeverity.Normal,
         trackUserActionsExcludeItem,
       });
       userAction

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -193,4 +193,5 @@ export type {
   Transports,
   UnpatchedConsole,
   ExceptionEventExtended,
+  UserActionSeverity,
 } from '@grafana/faro-web-sdk';

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -161,6 +161,7 @@ export type {
   TransportItemPayload,
   Transports,
   UnpatchedConsole,
+  UserActionSeverity,
 } from '@grafana/faro-core';
 
 export {


### PR DESCRIPTION
## Why

Custom triggers and severity weren't were missing in user action attributes.

## What

* Ensure trigger and severity are added
* Export `UserActionSeverity` from web-sdk and faro-react so users can import and use it more easy

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Screenshots

## Before
_Action attributes contain the default values for trigger and severity_
<img width="335" height="304" alt="Screenshot 2025-09-05 at 16 41 34" src="https://github.com/user-attachments/assets/ffbac531-a706-4c9c-8f16-e4e56cad20a5" />


## After
_Action attributes contain the custom values for trigger and severity_
<img width="345" height="291" alt=" " src="https://github.com/user-attachments/assets/9f1e9cbf-14b7-4cb7-9667-ba23c7823852" />

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
