### PR TITLE
chore(dependabot): add  3 days cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 3
     target-branch: 'main'
     open-pull-requests-limit: 30
     commit-message:


### PR DESCRIPTION
## Why

Do not include npm package releases younger than 3 days to help avoid pulling in compromised packages.

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

* [Slack discussion (internal)](https://raintank-corp.slack.com/archives/C05N7699TQ9/p1757668273319979)

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
