### PR TITLE
chore(build): disable scripts in .yarnrc configuration

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -3,3 +3,4 @@
 
 
 yarn-path ".yarn/releases/yarn-1.22.19.cjs"
+enableScripts: false


### PR DESCRIPTION
protect against supply chain vulnerabilities, see: https://yarnpkg.com/configuration/yarnrc#enableScripts
grafana uses it: https://github.com/grafana/grafana/blob/main/.yarnrc.yml#L30

It is a response to this: https://socket.dev/blog/tinycolor-supply-chain-attack-affects-40-packages