### PR TITLE
chore: report resource item emitted before doing ignore url check

### DIFF
--- a/packages/web-sdk/src/instrumentations/performance/resource.ts
+++ b/packages/web-sdk/src/instrumentations/performance/resource.ts
@@ -22,6 +22,12 @@ export function observeResourceTimings(
     const entries = observedEntries.getEntries();
 
     for (const resourceEntryRaw of entries) {
+      if (faro.config.trackUserActionsPreview) {
+        observable?.notify({
+          type: RESOURCE_ENTRY,
+        });
+      }
+
       if (isUrlIgnored(resourceEntryRaw.name)) {
         return;
       }
@@ -40,11 +46,11 @@ export function observeResourceTimings(
           faroResourceId: genShortID(),
         };
 
-        if (faro.config.trackUserActionsPreview) {
-          observable?.notify({
-            type: RESOURCE_ENTRY,
-          });
-        }
+        // if (faro.config.trackUserActionsPreview) {
+        //   observable?.notify({
+        //     type: RESOURCE_ENTRY,
+        //   });
+        // }
 
         pushEvent('faro.performance.resource', faroResourceEntry, undefined, {
           spanContext,


### PR DESCRIPTION
## Why

The performance resource timline instrumentation emits a message if it detects a resource item being emiited by the performance timeline observer.

The user action monitors resource entries as part of it's action validation process.

The entry was emitted after the ignor-urls check which is not corrrect for the purpose of the notifier so we moved the reporter up to trigger before teh ignore-urls check.

## What

See above

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
