### PR TITLE
fix: don't assume a window when testing for k6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fix (`@grafana/faro-web-sdk`): Fixed an issue where custom severity and custom trigger properties
   were not being included in user action attributes (#1551)
+- Fix (`@grafana/faro-web-sdk`): Fixed an error when `initializeFaro` is called without any window
+  object present (#1643)
 
 ## 2.0.0.beta-2
 

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -126,7 +126,7 @@ function createDefaultMetas(browserConfig: BrowserConfig): MetaItem[] {
     ...(browserConfig.metas ?? []),
   ];
 
-  const isK6BrowserSession = isObject((window as any).k6);
+  const isK6BrowserSession = isObject((window as any)?.k6);
   if (isK6BrowserSession) {
     return [...initialMetas, k6Meta];
   }


### PR DESCRIPTION
## Why

`window` might be `undefined` (inside a chrome extension context, for example), in which case `isK6BrowserSession` crashes instead of just returning `false`.

## What

Check for `undefined` before dereferencing `window`.

## Links

fixes #1644 

## Checklist

- ~Tests added~
- [x] Changelog updated
- ~Documentation updated~
