### PR TITLE
feat(transport): support dynamic headers in transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next
 
+- Feature (`@grafana/faro-web-sdk`): Fetch transport now supports dynamic header values.
+  Each header can be a static string or a function returning a string, resolved at request
+  time (#1490).
+
+- Feature (`@grafana/faro-transport-otlp-http [experimental]`): OLTP HTTP transport now supports
+  dynamic header values. Each header can be a static string or a function returning a string,
+  resolved at request time (#1490).
+
 ## 2.1.0
 
 - Feature (`@grafana/faro-react`): support for React 19 and React Router 7

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+- Feature (`@grafana/faro-transport-otlp-http`): OLTP HTTP transport now supports
+  dynamic header values. Each header can be a static string or a function returning
+  a string, resolved at request time (#1490).
+
 ## 2.1.0
 
 - Added support for experimental `ReplayInstrumentation` (`@grafana/faro-instrumentation-replay`).

--- a/experimental/transport-otlp-http/src/transport.test.ts
+++ b/experimental/transport-otlp-http/src/transport.test.ts
@@ -420,6 +420,87 @@ describe('OtlpHttpTransport', () => {
     expect(mockResponseTextFn).toHaveBeenCalledTimes(1);
   });
 
+  it('will add static header values', () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'https://www.example.com/v1/logs',
+      requestOptions: {
+        headers: {
+          Authorization: 'Bearer static-token',
+          'X-Static': 'static-value',
+        },
+      },
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.example.com/v1/logs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer static-token',
+          'X-Static': 'static-value',
+        }),
+      })
+    );
+  });
+
+  it('will add dynamic header values from sync callbacks', () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'https://www.example.com/v1/logs',
+      requestOptions: {
+        headers: {
+          Authorization: () => 'Bearer dynamic-token',
+          'X-User': () => 'user-123',
+        },
+      },
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.example.com/v1/logs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer dynamic-token',
+          'X-User': 'user-123',
+        }),
+      })
+    );
+  });
+
+  it('will add static header values and dynamic header values from sync callbacks', () => {
+    const transport = new OtlpHttpTransport({
+      logsURL: 'https://www.example.com/v1/logs',
+      requestOptions: {
+        headers: {
+          Authorization: () => 'Bearer dynamic-token',
+          'X-Static': 'static-value',
+        },
+      },
+    });
+
+    transport.internalLogger = mockInternalLogger;
+
+    transport.send([logTransportItem]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.example.com/v1/logs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer dynamic-token',
+          'X-Static': 'static-value',
+        }),
+      })
+    );
+  });
+
   it('will not send traces data if traces URL is not set', () => {
     const transport = new OtlpHttpTransport({
       logsURL: 'www.example.com/v1/logs',

--- a/experimental/transport-otlp-http/src/transport.ts
+++ b/experimental/transport-otlp-http/src/transport.ts
@@ -89,10 +89,15 @@ export class OtlpHttpTransport extends BaseTransport {
         const body = JSON.stringify({ [key]: value });
 
         const { requestOptions, apiKey } = this.options;
-        const { headers, ...restOfRequestOptions } = requestOptions ?? {};
+        const { headers = {}, ...restOfRequestOptions } = requestOptions ?? {};
 
         if (!url) {
           continue;
+        }
+
+        const resolvedHeaders: Record<string, string> = {};
+        for (const [key, value] of Object.entries(headers)) {
+          resolvedHeaders[key] = typeof value === 'function' ? value() : value;
         }
 
         this.promiseBuffer.add(() => {
@@ -100,7 +105,7 @@ export class OtlpHttpTransport extends BaseTransport {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              ...(headers ?? {}),
+              ...resolvedHeaders,
               ...(apiKey ? { 'x-api-key': apiKey } : {}),
             },
             body,

--- a/experimental/transport-otlp-http/src/types.ts
+++ b/experimental/transport-otlp-http/src/types.ts
@@ -1,7 +1,13 @@
 import type { ExceptionEvent, MeasurementEvent, TransportItem } from '@grafana/faro-core';
 
 export interface OtlpTransportRequestOptions extends Omit<RequestInit, 'body' | 'headers'> {
-  headers?: Record<string, string>;
+  /**
+   * Headers to include in every request.
+   * Each value can be:
+   * - a string (static value)
+   * - a function returning a string (dynamic value)
+   */
+  headers?: Record<string, string | (() => string)>;
 }
 
 export interface OtlpHttpTransportOptions {

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -49,7 +49,7 @@ export class FetchTransport extends BaseTransport {
 
         const { url, requestOptions, apiKey } = this.options;
 
-        const { headers, ...restOfRequestOptions } = requestOptions ?? {};
+        const { headers = {}, ...restOfRequestOptions } = requestOptions ?? {};
 
         let sessionId;
         const sessionMeta = this.metas.value.session;
@@ -57,11 +57,16 @@ export class FetchTransport extends BaseTransport {
           sessionId = sessionMeta.id;
         }
 
+        const resolvedHeaders: Record<string, string> = {};
+        for (const [key, value] of Object.entries(headers)) {
+          resolvedHeaders[key] = typeof value === 'function' ? value() : value;
+        }
+
         return fetch(url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...(headers ?? {}),
+            ...resolvedHeaders,
             ...(apiKey ? { 'x-api-key': apiKey } : {}),
             ...(sessionId ? { 'x-faro-session-id': sessionId } : {}),
           },

--- a/packages/web-sdk/src/transports/fetch/types.ts
+++ b/packages/web-sdk/src/transports/fetch/types.ts
@@ -1,5 +1,11 @@
 export interface FetchTransportRequestOptions extends Omit<RequestInit, 'body' | 'headers'> {
-  headers?: Record<string, string>;
+  /**
+   * Headers to include in every request.
+   * Each value can be:
+   * - a string (static value)
+   * - a function returning a string (dynamic value)
+   */
+  headers?: Record<string, string | (() => string)>;
 }
 
 export interface FetchTransportOptions {


### PR DESCRIPTION
## Why

<!-- Add a clear and concise description of why that changes are needed. -->

Currently, the Faro Web SDK only allows to configure static headers for transport requests.

When sending data through a proxy it might require a valid authentication token (e.g. JWT). Since tokens can expire and need to be refreshed, we need a way to lookup dynamic header values for each request.

## What

<!-- Add a clear and concise description of what you changed. -->

Extended the RequestOptions `headers` to also support callback functions that return a header value. This change is implemented for the Fetch transport and to stay aligned also for the OLTP HTTP transport.

I've not opted to also implement a Promise based asynchronous lookup. That would have significantly increased the change set. It is expected that any token refreshes are done by the application. When building requests by Faro we can directly lookup the currently available token.

## Links

<!-- Add issues the PR solves or other useful links here. -->
Addresses feature request #1490.

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
