### PR TITLE
chore: updating the README to reflect that Faro v2 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ You can find a [release schedule on nodejs.org](https://nodejs.org/en/about/prev
 
 ---
 
-### 📢 Faro v2 Pre-release is Live! 🎉
+### 📢 Faro v2 is Live! 🎉
 
-We’re excited to announce that Faro v2 is now available in pre-release.
+We’re excited to announce that Faro v2 is now available.
 This version modernizes Faro, simplifies setup, and removes legacy code, to give users a cleaner and better performing experience.
 
 #### ✨ What’s New
@@ -92,11 +92,6 @@ This version modernizes Faro, simplifies setup, and removes legacy code, to give
 - Simplified Setup – Simplified the console instrumentation configuration.
 
 - Leaner Core – Deprecated packages and legacy internals were removed for improved stability.
-
-#### ⚠️ Pre-release Note
-
-- Please install using this version range **@^2.0.0-beta**
-- 👉 **@latest** will continue to point to **v1.19.0** until v2 reaches GA.
 
 ##### Follow the upgrade guides for more information
 


### PR DESCRIPTION
## Why
README was outdated since we released v2 a few weeks ago.

## What
 Updating the README to reflect that Faro v2 is not in pre-release anymore.

## Checklist
- [ ] Tests added
- [ ] Changelog updated
- [X] Documentation updated
