### PR TITLE
fix(web-sdk): capture all CSP violation event attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+- Fix (`@grafana/faro-web-sdk`): CSP violation events now correctly capture all SecurityPolicyViolationEvent
+  attributes. Previously, properties like `blockedURI`, `documentURI`, and others were missing because
+  native browser event properties are getters on the prototype chain, not own enumerable properties (#1491)
+
 ## 2.0.2
 
 - Breaking (`@grafana/faro-web-sdk`): User action events now have a standardized event name

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
@@ -47,7 +47,21 @@ describe('CSPInstrumentation', () => {
     instrumentation.securitypolicyviolationHandler(fakeEvent);
     expect(mockTransport.items).toHaveLength(1);
 
-    expect((mockTransport.items[0] as TransportItem<EventEvent>)?.payload.attributes?.['lineNumber']).toBe('10');
+    const attributes = (mockTransport.items[0] as TransportItem<EventEvent>)?.payload.attributes;
+
+    // Verify all CSP attributes are captured
+    expect(attributes?.['blockedURI']).toBe('https://evil.com/script.js');
+    expect(attributes?.['documentURI']).toBe('https://my.app/');
+    expect(attributes?.['sourceFile']).toBe('https://my.app/index.js');
+    expect(attributes?.['statusCode']).toBe('200');
+    expect(attributes?.['lineNumber']).toBe('10');
+    expect(attributes?.['columnNumber']).toBe('5');
+    expect(attributes?.['disposition']).toBe('enforce');
+    expect(attributes?.['effectiveDirective']).toBe('script-src');
+    expect(attributes?.['violatedDirective']).toBe('script-src-elem');
+    expect(attributes?.['originalPolicy']).toBe("default-src 'self'; script-src 'self'");
+    expect(attributes?.['referrer']).toBe('https://referrer.app/');
+    expect(attributes?.['sample']).toBe('alert("xss")');
   });
 
   it('ensures listener gets removed on teardown', () => {

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
@@ -18,6 +18,24 @@ export class CSPInstrumentation extends BaseInstrumentation implements Instrumen
   }
 
   public securitypolicyviolationHandler(ev: SecurityPolicyViolationEvent) {
-    this.api.pushEvent('securitypolicyviolation', stringifyObjectValues(ev as Record<string, any>));
+    // We must explicitly extract properties because SecurityPolicyViolationEvent
+    // properties are getters on the prototype chain, not own enumerable properties.
+    // Object.entries() would not capture them.
+    const attributes = {
+      blockedURI: ev.blockedURI,
+      columnNumber: ev.columnNumber,
+      disposition: ev.disposition,
+      documentURI: ev.documentURI,
+      effectiveDirective: ev.effectiveDirective,
+      lineNumber: ev.lineNumber,
+      originalPolicy: ev.originalPolicy,
+      referrer: ev.referrer,
+      sample: ev.sample,
+      sourceFile: ev.sourceFile,
+      statusCode: ev.statusCode,
+      violatedDirective: ev.violatedDirective,
+    };
+
+    this.api.pushEvent('securitypolicyviolation', stringifyObjectValues(attributes));
   }
 }


### PR DESCRIPTION
The `securitypolicyviolationHandler` uses `stringifyObjectValues()` which internally calls `Object.entries()` to extract event properties. However, `SecurityPolicyViolationEvent` is a native browser event object, and its properties (`blockedURI`, `documentURI`, `sourceFile`, etc.) are defined as **getters on the prototype chain**, not as own enumerable properties.

`Object.entries()` only returns own enumerable properties, so all CSP-specific fields were silently lost.

**Reference:** [MDN SecurityPolicyViolationEvent](https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent)

## Why

<!-- Add a clear and concise description of why that changes are needed. -->

## What

- Explicitly extract all known CSP properties from the `SecurityPolicyViolationEvent` object
- Updated tests to verify all 12 CSP attributes are captured:
  - `blockedURI`, `columnNumber`, `disposition`, `documentURI`, `effectiveDirective`, `lineNumber`, `originalPolicy`, `referrer`, `sample`, `sourceFile`, `statusCode`, `violatedDirective`

## Links

Fixes #1491

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
