### PR TITLE
chore(release): prepare 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+## 2.2.1
+
+- Chore (`@grafana/faro-*`): Updated multiple dependencies to address security vulnerabilities
+  (#1855).
+
+- Chore (`@grafana/faro-*`): Updated multiple otel dependencies (#1856).
+
 ## 2.2.0
 
 - Feature (`@grafana/faro-web-sdk`): Fetch transport now supports dynamic header values.


### PR DESCRIPTION
## Why

- Maintencance release security updates for some dependencies (https://github.com/grafana/faro-web-sdk/pull/1856).

- Updates OTel depenencies (https://github.com/grafana/faro-web-sdk/pull/1855). 

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [x] Changelog updated
- [ ] Documentation updated
