### PR TITLE
chore(release): prepare 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## Next
 
+## 2.2.1
+
 - Fix (`@grafana/faro-core`): Buffered items are now correctly sent when a user action is cancelled
   (#1861).
+
+- Chore (`@grafana/faro-*`): Updated multiple dependencies to address security vulnerabilities
+  (#1855).
+
+- Chore (`@grafana/faro-*`): Updated multiple otel dependencies (#1856).
 
 ## 2.2.0
 


### PR DESCRIPTION
## Why


To push to the branch of the same name on the remote, use
• Maintencance release security updates for some dependencies ([#1856](https://github.com/grafana/faro-web-sdk/pull/1856)).
• Updates OTel depenencies ([#1855](https://github.com/grafana/faro-web-sdk/pull/1855)).
## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
