### PR TITLE
chore(deps): pin version of ua-parser-js

### DIFF
--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@grafana/faro-core": "^2.2.1",
-    "ua-parser-js": "^1.0.32",
+    "ua-parser-js": "1.0.41",
     "web-vitals": "^5.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,7 +992,7 @@ __metadata:
     "@grafana/faro-core": "npm:^2.2.1"
     "@types/node": "npm:24.10.9"
     "@types/ua-parser-js": "npm:0.7.39"
-    ua-parser-js: "npm:^1.0.32"
+    ua-parser-js: "npm:1.0.41"
     user-agent-data-types: "npm:0.4.2"
     web-vitals: "npm:^5.1.0"
   languageName: unknown
@@ -16140,7 +16140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.32":
+"ua-parser-js@npm:1.0.41":
   version: 1.0.41
   resolution: "ua-parser-js@npm:1.0.41"
   bin:


### PR DESCRIPTION
This PR pins `ua-parser-js` to a specific v1.x version.

`ua-parser-js` v1.x is MIT-licensed and compatible with our Apache license. Starting with v2.0, the project switched to AGPL-3.0-or-later, which is not suitable for a customer-installed library.

Pinning the version prevents accidental upgrades to AGPL-licensed releases and makes the licensing intent explicit.