### PR TITLE
chore(ci): add exception for Grafana shared workflows in license check

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,3 +23,5 @@ jobs:
           # Based on https://www.apache.org/legal/resolved.html
           # Common licenses in JavaScript/TypeScript npm ecosystem
           allow-licenses: Apache-2.0, MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, Unlicense, CC0-1.0
+          # Exception for internal Grafana shared workflows (AGPL-3.0)
+          allow-dependencies-licenses: 'pkg:githubactions/grafana/shared-workflows'


### PR DESCRIPTION
## Why

Exclude Grafana shared Github actions form license check

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
