### PR TITLE
chore(ci): renovate can open PRs 3 times a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["before 5am on Monday"],
+  "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"],
   "semanticCommits": "enabled",
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
@@ -12,13 +12,13 @@
       "description": "Group npm dependencies",
       "matchManagers": ["npm"],
       "groupName": "npm-dependencies",
-      "schedule": ["before 5am on Monday"]
+      "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"]
     },
     {
       "description": "Group GitHub Actions dependencies",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
-      "schedule": ["before 5am on Monday"]
+      "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"]
     },
     {
       "description": "Group patch updates together",


### PR DESCRIPTION
## Why

Renovate can open PRs three times a week so we can faster include security fixes.

## What

<!-- Add a clear and concise description of what you changed. -->

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
