### PR TITLE
chore(license): allow blue oak license

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,6 @@ jobs:
           # Allow only Apache-2.0 compatible licenses (Apache Category A)
           # Based on https://www.apache.org/legal/resolved.html
           # Common licenses in JavaScript/TypeScript npm ecosystem
-          allow-licenses: Apache-2.0, MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, Unlicense, CC0-1.0
+          allow-licenses: Apache-2.0, MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, BlueOak-1.0.0, Unlicense, CC0-1.0
           # Exception for internal Grafana shared workflows (AGPL-3.0)
           allow-dependencies-licenses: 'pkg:githubactions/grafana/shared-workflows/actions/lint-pr-title'


### PR DESCRIPTION
## Why
Add the BlueOak license to the list of allowed licenses.

Some of our dependencies use the BlueOak-1.0.0. 
We recently introduced a license check using an allow list for licenses. It's expected it's not complete from the beginning on and that we have to add more compatible licenses to the allow list.

Key Points
* OSI Approved: The Open Source Initiative approved it on January 19, 2024
* Permissive License: It's more permissive than Apache-2.0, similar to MIT/BSD
* Compatible: It's compatible with Apache-2.0 and even GPL licenses, meaning it fits within Apache Category A
* Purpose: Designed to be simpler and clearer than Apache-2.0 while providing similar protections

## What

<!-- Add a clear and concise description of what you changed. -->

## Links
https://opensource.org/license/blue-oak-model-license
https://blueoakcouncil.org/license/1.0.0
https://blueoakcouncil.org/list

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
