### PR TITLE
chore(ci): widen dependency-review license allow-list

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,27 @@ jobs:
           # Allow only Apache-2.0 compatible licenses (Apache Category A)
           # Based on https://www.apache.org/legal/resolved.html
           # Common licenses in JavaScript/TypeScript npm ecosystem
-          allow-licenses: Apache-2.0, MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, BlueOak-1.0.0, Unlicense, CC0-1.0
-          # Exception for internal Grafana shared workflows (AGPL-3.0)
-          allow-dependencies-licenses: 'pkg:githubactions/grafana/shared-workflows/actions/lint-pr-title'
+          allow-licenses: >-
+            Apache-2.0, MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD,
+            BlueOak-1.0.0, Unlicense, CC0-1.0,
+            CC-BY-4.0,
+            Artistic-2.0
+          # Per-package exceptions for Category B or internal licenses:
+          # - grafana/shared-workflows: AGPL-3.0, internal Grafana action
+          # - @ltd/j-toml: LGPL-3.0, dev-only transitive dep via lerna -> nx >=22.6.0
+          # - lightningcss: MPL-2.0, transitive dep via vite 8 (was optional peer in vite 7)
+          allow-dependencies-licenses: >-
+            pkg:githubactions/grafana/shared-workflows/actions/lint-pr-title,
+            pkg:npm/@ltd/j-toml,
+            pkg:npm/lightningcss,
+            pkg:npm/lightningcss-android-arm64,
+            pkg:npm/lightningcss-darwin-arm64,
+            pkg:npm/lightningcss-darwin-x64,
+            pkg:npm/lightningcss-freebsd-x64,
+            pkg:npm/lightningcss-linux-arm-gnueabihf,
+            pkg:npm/lightningcss-linux-arm64-gnu,
+            pkg:npm/lightningcss-linux-arm64-musl,
+            pkg:npm/lightningcss-linux-x64-gnu,
+            pkg:npm/lightningcss-linux-x64-musl,
+            pkg:npm/lightningcss-win32-arm64-msvc,
+            pkg:npm/lightningcss-win32-x64-msvc


### PR DESCRIPTION
## Why

Multiple Renovate/Dependabot PRs are blocked by the dependency-review action due to license violations. The initial allow-list was intentionally strict (Category A only) with the plan to widen as needed. We now have enough data from four failing PRs (#1913, #1921, #1952, #1958) to make informed additions.

## What

**Global `allow-licenses` additions** (Apache Category A — safe for any dependency):
- `CC-BY-4.0` — data-only license used by `caniuse-lite` (browser compat tables). Explicitly listed as Category A in [apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html). Near-universal transitive dep via browserslist.
- `Artistic-2.0` — permissive Category A license. Covers a GitHub license-detection false positive on `flatted` (npm and GitHub repo both report ISC, but the dependency graph API reports "Artistic-2.0 AND ISC").

**Per-package `allow-dependencies-licenses` additions** (Apache Category B — case-by-case):
- `pkg:npm/@ltd/j-toml` — LGPL-3.0. Dev-only transitive dep via `lerna` → `nx >=22.6.0`. No copyleft propagation through npm consumption.
- `pkg:npm/lightningcss` + 11 platform binaries — MPL-2.0. Transitive dep via Vite 8, which promoted `lightningcss` from optional peer to hard dependency. Weak copyleft with no obligation on consuming code.

## Links

- Failing runs:
  - #1913: https://github.com/grafana/faro-web-sdk/actions/runs/22332029380/job/64616302739
  - #1921: https://github.com/grafana/faro-web-sdk/actions/runs/23565874097/job/68617155331
  - #1952: https://github.com/grafana/faro-web-sdk/actions/runs/24221165174/job/70712767028
  - #1958: https://github.com/grafana/faro-web-sdk/actions/runs/23334363606/job/67872455121
- Apache license categories: https://www.apache.org/legal/resolved.html

## Checklist

- [ ] Tests added
- [x] Changelog updated — N/A (CI config only)
- [x] Documentation updated — N/A (comments in workflow file serve as documentation)