### PR TITLE
fix(fetch-transport): fix flaky 429 backoff tests by initializing disabledUntil to epoch

### DIFF
--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -22,7 +22,7 @@ export class FetchTransport extends BaseTransport {
 
   private readonly rateLimitBackoffMs: number;
   private readonly getNow: () => number;
-  private disabledUntil: Date = new Date();
+  private disabledUntil: Date = new Date(0);
 
   constructor(private options: FetchTransportOptions) {
     super();


### PR DESCRIPTION
## Why

The `FetchTransport` 429 backoff tests are flaky on CI. `disabledUntil` was initialized to `new Date()` (real wall clock), but the rate-limit guard compared it against `getNow()` which could return a timestamp captured slightly before construction. On slow CI machines this 1ms gap caused the guard to incorrectly block the very first `send()`, making two tests fail intermittently.

## What

Initialize `disabledUntil` to `new Date(0)` (epoch) instead of `new Date()`. A freshly constructed transport should never be rate-limited — rate limiting only activates after receiving an actual 429 response.

## Links

- Failing CI run: https://github.com/grafana/faro-web-sdk/actions/runs/24435779289/job/71389606165?pr=1987

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated