### PR TITLE
feat(instrumentation-replay): add optional rrweb packer support for replay events

### DIFF
--- a/experimental/instrumentation-replay/README.md
+++ b/experimental/instrumentation-replay/README.md
@@ -76,6 +76,7 @@ initializeFaro({
 | `collectFonts`             | `boolean`                      | `false`  | Whether to collect fonts used in the website                                                                                                    |
 | `inlineImages`             | `boolean`                      | `false`  | Whether to record image content                                                                                                                 |
 | `inlineStylesheet`         | `boolean`                      | `false`  | Whether to inline stylesheets in the recording events                                                                                           |
+| `pack`                     | `boolean`                      | `false`  | Whether to compress each replay event with `@rrweb/packer` before sending. Applied after `beforeSend` so hooks still receive raw rrweb events |
 
 #### Sub-sampling example
 

--- a/experimental/instrumentation-replay/package.json
+++ b/experimental/instrumentation-replay/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@grafana/faro-core": "^2.3.1",
+    "@rrweb/packer": "^2.0.0-alpha.18",
     "rrweb": "^2.0.0-alpha.18"
   },
   "publishConfig": {

--- a/experimental/instrumentation-replay/src/const.ts
+++ b/experimental/instrumentation-replay/src/const.ts
@@ -17,4 +17,5 @@ export const defaultReplayInstrumentationOptions: ReplayInstrumentationOptions =
   beforeSend: undefined,
   recordAfter: 'load',
   samplingRate: 1,
+  pack: false,
 };

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -8,6 +8,11 @@ jest.mock('rrweb', () => ({
   record: jest.fn(),
 }));
 
+// Mock @rrweb/packer
+jest.mock('@rrweb/packer', () => ({
+  pack: jest.fn(),
+}));
+
 function createSeededRandom(seed: number): () => number {
   let current = seed >>> 0;
 
@@ -24,10 +29,14 @@ describe('ReplayInstrumentation', () => {
   let mockAddListener: jest.Mock;
   let mockPushEvent: jest.Mock;
 
+  let mockPack: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockRecord = require('rrweb').record;
     mockRecord.mockReturnValue(jest.fn());
+    mockPack = require('@rrweb/packer').pack;
+    mockPack.mockImplementation((event: unknown) => `packed:${JSON.stringify(event)}`);
 
     // Mock API and metas
     mockGetSession = jest.fn();
@@ -70,6 +79,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: undefined,
         beforeSend: undefined,
         samplingRate: 1,
+        pack: false,
       };
 
       expect(instrumentation['options']).toEqual(expectedDefaults);
@@ -96,6 +106,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: '.ignore-me',
         beforeSend: beforeSendFn,
         samplingRate: 1,
+        pack: false,
       };
 
       instrumentation = new ReplayInstrumentation(customOptions);
@@ -133,6 +144,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: undefined,
         beforeSend: undefined,
         samplingRate: 1,
+        pack: false,
       };
 
       expect(instrumentation['options']).toEqual(expected);
@@ -304,17 +316,8 @@ describe('ReplayInstrumentation', () => {
   describe('handleEvent', () => {
     let emitCallback: (event: any, isCheckout?: boolean) => void;
 
-    beforeEach(() => {
-      mockRecord.mockImplementation((opts) => {
-        emitCallback = opts.emit;
-        return jest.fn();
-      });
-    });
-
-    it('should push events to the API', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
+    function startSampledRecording(options?: ReplayInstrumentationOptions): void {
+      instrumentation = new ReplayInstrumentation(options);
       mockGetSession.mockReturnValue({
         id: 'test-session',
         attributes: { isSampled: 'true' },
@@ -323,6 +326,17 @@ describe('ReplayInstrumentation', () => {
       instrumentation['metas'] = { addListener: mockAddListener } as any;
 
       instrumentation.initialize();
+    }
+
+    beforeEach(() => {
+      mockRecord.mockImplementation((opts) => {
+        emitCallback = opts.emit;
+        return jest.fn();
+      });
+    });
+
+    it('should push events to the API', () => {
+      startSampledRecording();
 
       const testEvent = { type: 1, data: {}, timestamp: Date.now() };
       emitCallback(testEvent);
@@ -334,18 +348,7 @@ describe('ReplayInstrumentation', () => {
 
     it('should apply beforeSend transformation to events', () => {
       const beforeSend = jest.fn((event) => ({ ...event, modified: true }));
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
-
-      instrumentation.initialize();
+      startSampledRecording({ beforeSend });
 
       const testEvent = { type: 1, data: {}, timestamp: Date.now() };
       emitCallback(testEvent);
@@ -358,18 +361,7 @@ describe('ReplayInstrumentation', () => {
 
     it('should skip sending event if beforeSend returns null', () => {
       const beforeSend = jest.fn(() => null);
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
-
-      instrumentation.initialize();
+      startSampledRecording({ beforeSend });
 
       emitCallback({ type: 1, data: {}, timestamp: Date.now() });
 
@@ -379,18 +371,7 @@ describe('ReplayInstrumentation', () => {
 
     it('should skip sending event if beforeSend returns undefined', () => {
       const beforeSend = jest.fn(() => undefined);
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
-
-      instrumentation.initialize();
+      startSampledRecording({ beforeSend });
 
       emitCallback({ type: 1, data: {}, timestamp: Date.now() });
 
@@ -404,22 +385,48 @@ describe('ReplayInstrumentation', () => {
           throw new Error('Push failed');
         }
       });
-
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
-
+      startSampledRecording();
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-      instrumentation.initialize();
 
       expect(() => emitCallback({ type: 1, data: {}, timestamp: Date.now() })).not.toThrow();
       expect(logWarnSpy).toHaveBeenCalledWith('Failed to push faro.session_recording.event event', expect.any(Error));
+    });
+
+    it('should use pack() when pack is true', () => {
+      startSampledRecording({ pack: true });
+
+      const testEvent = { type: 1, data: {}, timestamp: 1000 };
+      emitCallback(testEvent);
+
+      expect(mockPack).toHaveBeenCalledWith(testEvent);
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
+        event: `packed:${JSON.stringify(testEvent)}`,
+      });
+    });
+
+    it('should apply beforeSend before packing when both are set', () => {
+      const beforeSend = jest.fn((event: any) => ({ ...event, modified: true }));
+      startSampledRecording({ pack: true, beforeSend });
+
+      const testEvent = { type: 1, data: {}, timestamp: 1000 };
+      emitCallback(testEvent);
+
+      const transformedEvent = { ...testEvent, modified: true };
+      expect(beforeSend).toHaveBeenCalledWith(testEvent);
+      expect(mockPack).toHaveBeenCalledWith(transformedEvent);
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
+        event: `packed:${JSON.stringify(transformedEvent)}`,
+      });
+    });
+
+    it('should not call pack() when beforeSend drops the event', () => {
+      const beforeSend = jest.fn(() => null);
+      startSampledRecording({ pack: true, beforeSend });
+
+      emitCallback({ type: 1, data: {}, timestamp: 1000 });
+
+      expect(mockPack).not.toHaveBeenCalled();
+      expect(mockPushEvent).not.toHaveBeenCalledWith('faro.session_recording.event', expect.anything());
     });
   });
 

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -1,4 +1,5 @@
 import type { eventWithTime } from '@rrweb/types';
+import { pack as packEvent } from '@rrweb/packer';
 import { record, type recordOptions } from 'rrweb';
 
 import { BaseInstrumentation, clampSamplingRate, VERSION } from '@grafana/faro-core';
@@ -159,8 +160,12 @@ export class ReplayInstrumentation extends BaseInstrumentation {
         }
       }
 
+      // Pack (compress) the event after beforeSend so that beforeSend always
+      // receives the raw eventWithTime regardless of the pack setting.
+      const serialized = this.options.pack ? packEvent(processedEvent) : JSON.stringify(processedEvent);
+
       this.api.pushEvent(faroSessionReplayEventName, {
-        event: JSON.stringify(processedEvent),
+        event: serialized,
       });
     } catch (err) {
       this.logWarn(`Failed to push ${faroSessionReplayEventName} event`, err);

--- a/experimental/instrumentation-replay/src/types.ts
+++ b/experimental/instrumentation-replay/src/types.ts
@@ -81,6 +81,20 @@ export interface ReplayInstrumentationOptions {
   recordAfter?: 'DOMContentLoaded' | 'load';
 
   /**
+   * Whether to compress recorded events using @rrweb/packer (fflate/zlib) before sending.
+   *
+   * When enabled, each event is compressed individually after the optional `beforeSend`
+   * transform. The `event` field pushed to Faro will contain a compressed binary string
+   * instead of a JSON string.
+   *
+   * Compression is applied inside `handleEvent`, not via rrweb's built-in `packFn` option,
+   * so that `beforeSend` always receives the raw `eventWithTime` regardless of this setting.
+   *
+   * @default false
+   */
+  pack?: boolean;
+
+  /**
    * The fraction of globally-sampled sessions that should also record a session replay.
    * Expressed as a number between 0 and 1.
    *

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,6 +957,7 @@ __metadata:
   resolution: "@grafana/faro-instrumentation-replay@workspace:experimental/instrumentation-replay"
   dependencies:
     "@grafana/faro-core": "npm:^2.3.1"
+    "@rrweb/packer": "npm:^2.0.0-alpha.18"
     rrweb: "npm:^2.0.0-alpha.18"
   languageName: unknown
   linkType: soft
@@ -3545,6 +3546,16 @@ __metadata:
   version: 4.60.1
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.1"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rrweb/packer@npm:^2.0.0-alpha.18":
+  version: 2.0.0-alpha.20
+  resolution: "@rrweb/packer@npm:2.0.0-alpha.20"
+  dependencies:
+    "@rrweb/types": "npm:^2.0.0-alpha.20"
+    fflate: "npm:^0.4.4"
+  checksum: 10c0/a5d6b87239bd9a79b27280af081955c6832860bfdb2dbc3d29fd3a0a197df0c8bb8538db2f4144e0ac5bfe100397d7c73f56c296ff9f138352ebe659e9c726ff
   languageName: node
   linkType: hard
 
@@ -8381,6 +8392,13 @@ __metadata:
   version: 4.2.3
   resolution: "fecha@npm:4.2.3"
   checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.4.4":
+  version: 0.4.8
+  resolution: "fflate@npm:0.4.8"
+  checksum: 10c0/29d1eddaaa5deab61b1c6b0d21282adacadbc4d2c01e94d8b1ee784398151673b9c563e53f97a801bc410a1ae55e8de5378114a743430e643e7a0644ba8e5a42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Replay events are currently sent as plain JSON, which can increase payload size and Loki storage costs in high-volume scenarios.
This change adds an optional compression path without changing default behavior.

## What

- Add optional pack config to ReplayInstrumentation (default: false)
- Add @rrweb/packer dependency
- Keep current path when pack=false (JSON.stringify)
- Compress replay payload when pack=true
- Keep beforeSend behavior intact (compression happens after beforeSend)
- Add unit tests for packed/non-packed behavior and beforeSend interaction
- Update replay instrumentation README with the new option

## Links

Closes / Implements #1992 

## Checklist

- [ X ] Tests added
- [ ] Changelog updated
- [ X ] Documentation updated
