### PR TITLE
fix(release): remove yarn build from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-yarn build
 yarn git-hooks:pre-commit

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -10,8 +10,10 @@ and your dependencies are up to date.
 
 - Do `git pull` the main branch
 - Check `git status` to double check if you have any unpushed changes
-- Run `yarn install` to make sure `node_modules` is in sync with `yarn.lock`
-  (a stale install can cause confusing build errors during the release commit)
+- Run `yarn install --immutable` to make sure `node_modules` is in sync with `yarn.lock`
+  without mutating the lockfile (a stale install can cause confusing build errors during
+  the release commit). If the command fails because the lockfile is out of sync, resolve
+  that drift in a separate PR before releasing.
 
 **Note 2:**
 You need special access privileges to be able push to the protected main branch.

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -5,10 +5,13 @@ It will ask some questions, bump package versions, tag & push.
 CI will pick it up from there and publish to npm.
 
 **Note:**
-Before calling `npx lerna version --force-publish` always ensure that your local main branch is 1:1 with origin/main.
+Before calling `npx lerna version --force-publish` always ensure that your local main branch is 1:1 with origin/main
+and your dependencies are up to date.
 
 - Do `git pull` the main branch
 - Check `git status` to double check if you have any unpushed changes
+- Run `yarn install` to make sure `node_modules` is in sync with `yarn.lock`
+  (a stale install can cause confusing build errors during the release commit)
 
 **Note 2:**
 You need special access privileges to be able push to the protected main branch.

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -11,9 +11,6 @@ and your dependencies are up to date.
 - Do `git pull` the main branch
 - Check `git status` to double check if you have any unpushed changes
 - Run `yarn install --immutable` to make sure `node_modules` is in sync with `yarn.lock`
-  without mutating the lockfile (a stale install can cause confusing build errors during
-  the release commit). If the command fails because the lockfile is out of sync, resolve
-  that drift in a separate PR before releasing.
 
 **Note 2:**
 You need special access privileges to be able push to the protected main branch.


### PR DESCRIPTION
## Why

`npx lerna version --force-publish` aborted mid-release for 2.4.0 because the pre-commit hook ran `yarn build`, which failed with a misleading `command not found: rollup` when `node_modules` was stale. Local builds also duplicate what CI already checks on every PR and release.

## What

- Remove `yarn build` from `.husky/pre-commit`; `lint-staged` still runs.
- Add a `yarn install` pre-flight step to `docs/sources/developer/releasing.md`.

## Links

n/a

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated