### PR TITLE
chore(deps): pin protobufjs to ^8.0.1 to remediate CVE-2026-41242

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "react-dom": "^19.1.0",
     "systeminformation": "^5.31.0",
     "@isaacs/brace-expansion": "^5.0.1",
+    "protobufjs": "^8.0.1",
     "tar": "^7.5.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13922,27 +13922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^8.0.0, protobufjs@npm:^8.0.1":
+"protobufjs@npm:^8.0.1":
   version: 8.0.1
   resolution: "protobufjs@npm:8.0.1"
   dependencies:


### PR DESCRIPTION
## Summary

Pin `protobufjs` to `^8.0.1` via `resolutions` to remediate CVE-2026-41242. Collapses the `protobufjs@7.5.4` copy pulled by `@grpc/proto-loader@0.8.0` into the `8.0.1` copy already in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)