### PR TITLE
feat(web-sdk): add `httpHost` to `faro.performance.resource` events

### DIFF
--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -33,6 +33,7 @@ describe('performanceUtils', () => {
       type: 'navigate',
 
       name: 'http://example.com',
+      'http.host': 'example.com',
       tcpHandshakeTime: '53',
       dnsLookupTime: '139',
       tlsNegotiationTime: '33',
@@ -56,6 +57,7 @@ describe('performanceUtils', () => {
     const faroResourceTiming = createFaroResourceTiming(performanceResourceEntry);
     expect(faroResourceTiming).toStrictEqual({
       name: 'http://example.com/awesome-image',
+      'http.host': 'example.com',
       duration: '370',
       tcpHandshakeTime: '0',
       dnsLookupTime: '0',
@@ -76,6 +78,15 @@ describe('performanceUtils', () => {
       visibilityState: 'visible',
       transferSize: '11459',
     } as FaroResourceTiming);
+  });
+
+  it(`extracts http.host from the resource name`, () => {
+    expect(createFaroResourceTiming({ name: 'http://example.com/path' } as any)['http.host']).toBe('example.com');
+    expect(createFaroResourceTiming({ name: 'http://example.com:8080/path' } as any)['http.host']).toBe(
+      'example.com:8080'
+    );
+    expect(createFaroResourceTiming({ name: 'not a url' } as any)['http.host']).toBe('unknown');
+    expect(createFaroResourceTiming({} as any)['http.host']).toBe('unknown');
   });
 
   it(`calculates cacheHitStatus`, () => {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -33,7 +33,7 @@ describe('performanceUtils', () => {
       type: 'navigate',
 
       name: 'http://example.com',
-      'http.host': 'example.com',
+      httpHost: 'example.com',
       tcpHandshakeTime: '53',
       dnsLookupTime: '139',
       tlsNegotiationTime: '33',
@@ -57,7 +57,7 @@ describe('performanceUtils', () => {
     const faroResourceTiming = createFaroResourceTiming(performanceResourceEntry);
     expect(faroResourceTiming).toStrictEqual({
       name: 'http://example.com/awesome-image',
-      'http.host': 'example.com',
+      httpHost: 'example.com',
       duration: '370',
       tcpHandshakeTime: '0',
       dnsLookupTime: '0',
@@ -80,13 +80,17 @@ describe('performanceUtils', () => {
     } as FaroResourceTiming);
   });
 
-  it(`extracts http.host from the resource name`, () => {
-    expect(createFaroResourceTiming({ name: 'http://example.com/path' } as any)['http.host']).toBe('example.com');
-    expect(createFaroResourceTiming({ name: 'http://example.com:8080/path' } as any)['http.host']).toBe(
-      'example.com:8080'
-    );
-    expect(createFaroResourceTiming({ name: 'not a url' } as any)['http.host']).toBe('unknown');
-    expect(createFaroResourceTiming({} as any)['http.host']).toBe('unknown');
+  it(`extracts httpHost from the resource name`, () => {
+    expect(createFaroResourceTiming({ name: 'http://example.com/path' } as any).httpHost).toBe('example.com');
+    expect(createFaroResourceTiming({ name: 'http://example.com:8080/path' } as any).httpHost).toBe('example.com:8080');
+    expect(createFaroResourceTiming({ name: 'not a url' } as any).httpHost).toBe('unknown');
+    expect(createFaroResourceTiming({} as any).httpHost).toBe('unknown');
+    expect(createFaroResourceTiming({ name: 'data:text/plain;base64,SGVsbG8=' } as any).httpHost).toBe('unknown');
+    expect(
+      createFaroResourceTiming({
+        name: 'blob:https://example.com/550e8400-e29b-41d4-a716-446655440000',
+      } as any).httpHost
+    ).toBe('unknown');
   });
 
   it(`calculates cacheHitStatus`, () => {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -97,6 +97,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
 
   return {
     name: name,
+    'http.host': getHostFromUrl(name),
     duration: toFaroPerformanceTimingString(duration),
     tcpHandshakeTime: toFaroPerformanceTimingString(connectEnd - connectStart),
     dnsLookupTime: toFaroPerformanceTimingString(domainLookupEnd - domainLookupStart),
@@ -181,6 +182,14 @@ function getDocumentParsingTime(): number | null {
   }
 
   return null;
+}
+
+function getHostFromUrl(url: string): string {
+  try {
+    return new URL(url).host || unknownString;
+  } catch {
+    return unknownString;
+  }
 }
 
 function toFaroPerformanceTimingString(v: unknown): string {

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -97,7 +97,7 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
 
   return {
     name: name,
-    'http.host': getHostFromUrl(name),
+    httpHost: getHostFromUrl(name),
     duration: toFaroPerformanceTimingString(duration),
     tcpHandshakeTime: toFaroPerformanceTimingString(connectEnd - connectStart),
     dnsLookupTime: toFaroPerformanceTimingString(domainLookupEnd - domainLookupStart),

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -16,7 +16,7 @@ export type FaroNavigationTiming = Readonly<
 
 export type FaroResourceTiming = Readonly<{
   name: string;
-  'http.host': string;
+  httpHost: string;
   duration: string;
   protocol: string;
   tcpHandshakeTime: string;

--- a/packages/web-sdk/src/instrumentations/performance/types.ts
+++ b/packages/web-sdk/src/instrumentations/performance/types.ts
@@ -16,6 +16,7 @@ export type FaroNavigationTiming = Readonly<
 
 export type FaroResourceTiming = Readonly<{
   name: string;
+  'http.host': string;
   duration: string;
   protocol: string;
   tcpHandshakeTime: string;


### PR DESCRIPTION
## Summary
- Adds an `httpHost` attribute to `faro.performance.resource` events so consumers can group/filter by destination host without re-parsing the URL.
- Mirrors the `http.host` attribute already emitted on `faro.tracing.fetch` events (sourced from OpenTelemetry's fetch instrumentation), giving the two event types a consistent dimension.
- `faro.performance.navigation` events inherit `httpHost` via `createFaroResourceTiming`.

The host is extracted using `new URL(name).host`, with an `unknown` fallback for unparseable URLs (e.g., `data:` / `blob:` / malformed entries).

## Test plan
- [x] `cd packages/web-sdk && npx jest --testPathPatterns=performance` — 30 passed
- [x] `cd packages/web-sdk && npx jest` — 242 passed, 1 skipped (pre-existing)
- [x] Prettier check on changed files passes
- [ ] Manual: load the demo app, confirm `faro.performance.resource` and `faro.tracing.fetch` events for the same fetch carry matching `http.host` values
- [ ] Manual: trigger a `data:`/`blob:` resource load and confirm the event has `http.host: 'unknown'` rather than throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)