### PR TITLE
feat(replay): pause recording after user inactivity

### DIFF
--- a/experimental/instrumentation-replay/src/const.ts
+++ b/experimental/instrumentation-replay/src/const.ts
@@ -17,4 +17,5 @@ export const defaultReplayInstrumentationOptions: ReplayInstrumentationOptions =
   beforeSend: undefined,
   recordAfter: 'load',
   samplingRate: 1,
+  inactivityThresholdMs: 60_000,
 };

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -70,6 +70,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: undefined,
         beforeSend: undefined,
         samplingRate: 1,
+        inactivityThresholdMs: 60_000,
       };
 
       expect(instrumentation['options']).toEqual(expectedDefaults);
@@ -96,6 +97,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: '.ignore-me',
         beforeSend: beforeSendFn,
         samplingRate: 1,
+        inactivityThresholdMs: 30_000,
       };
 
       instrumentation = new ReplayInstrumentation(customOptions);
@@ -133,6 +135,7 @@ describe('ReplayInstrumentation', () => {
         ignoreSelector: undefined,
         beforeSend: undefined,
         samplingRate: 1,
+        inactivityThresholdMs: 60_000,
       };
 
       expect(instrumentation['options']).toEqual(expected);

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -460,6 +460,130 @@ describe('ReplayInstrumentation', () => {
     });
   });
 
+  describe('inactivity tracking', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function initSampledInstrumentation(options: ReplayInstrumentationOptions = {}): ReplayInstrumentation {
+      const inst = new ReplayInstrumentation(options);
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      inst['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      inst['metas'] = { addListener: mockAddListener } as any;
+      inst.initialize();
+      return inst;
+    }
+
+    it('should pause recording after inactivity threshold elapses', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      expect(instrumentation['isPaused']).toBe(false);
+
+      jest.advanceTimersByTime(5_000);
+
+      expect(stopFn).toHaveBeenCalled();
+      expect(instrumentation['isPaused']).toBe(true);
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.paused', {});
+    });
+
+    it('should resume recording with a fresh checkpoint when user interacts after pause', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+
+      jest.advanceTimersByTime(5_000);
+      expect(instrumentation['isPaused']).toBe(true);
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+
+      mockRecord.mockReturnValue(jest.fn());
+      document.dispatchEvent(new Event('pointerdown'));
+
+      expect(instrumentation['isPaused']).toBe(false);
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.resumed', {});
+    });
+
+    it('should not pause when inactivityThresholdMs is 0', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 0 });
+
+      jest.advanceTimersByTime(120_000);
+
+      expect(instrumentation['isPaused']).toBe(false);
+      expect(stopFn).not.toHaveBeenCalled();
+    });
+
+    it('should not pause when inactivityThresholdMs is undefined', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: undefined });
+
+      jest.advanceTimersByTime(120_000);
+
+      expect(instrumentation['isPaused']).toBe(false);
+      expect(stopFn).not.toHaveBeenCalled();
+    });
+
+    it('should remove DOM listeners on stopRecording', () => {
+      const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation.destroy();
+
+      const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
+      expect(removedEvents).toContain('pointermove');
+      expect(removedEvents).toContain('pointerdown');
+      expect(removedEvents).toContain('scroll');
+      expect(removedEvents).toContain('keydown');
+      expect(removedEvents).toContain('input');
+    });
+
+    it('should keep DOM listeners attached across pauseRecording', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+      const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+
+      jest.advanceTimersByTime(5_000);
+      expect(instrumentation['isPaused']).toBe(true);
+
+      const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
+      expect(removedEvents).not.toContain('pointermove');
+      expect(removedEvents).not.toContain('pointerdown');
+
+      mockRecord.mockReturnValue(jest.fn());
+      document.dispatchEvent(new Event('scroll'));
+      expect(instrumentation['isPaused']).toBe(false);
+    });
+
+    it('should reset the inactivity timer on user interaction', () => {
+      const stopFn = jest.fn();
+      mockRecord.mockReturnValue(stopFn);
+
+      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+
+      jest.advanceTimersByTime(4_000);
+      document.dispatchEvent(new Event('keydown'));
+
+      jest.advanceTimersByTime(4_000);
+      expect(instrumentation['isPaused']).toBe(false);
+
+      jest.advanceTimersByTime(1_000);
+      expect(instrumentation['isPaused']).toBe(true);
+    });
+  });
+
   describe('samplingRate', () => {
     // session-1 hashes to ≈ 0.142 — falls below 0.2 (included) and above 0.1 (excluded)
     // session-100 hashes to ≈ 0.827 — falls above 0.5 (excluded)

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -8,6 +8,20 @@ import type { ReplayInstrumentationOptions } from './types';
 
 const faroSessionReplayEventName = 'faro.session_recording.event';
 const faroSessionReplayStartedEventName = 'faro.session_recording.started';
+const faroSessionReplayPausedEventName = 'faro.session_recording.paused';
+const faroSessionReplayResumedEventName = 'faro.session_recording.resumed';
+
+// DOM events that signal a human is present.  Aligned with rrweb's
+// IncrementalSource 1-5 (MouseMove, MouseInteraction, Scroll,
+// ViewportResize, Input).  We use pointer* instead of mouse*/touch*
+// because modern browsers fire PointerEvents for all input devices.
+const USER_INTERACTION_EVENTS: readonly string[] = [
+  'pointermove', // MouseMove / TouchMove
+  'pointerdown', // MouseInteraction (click, dblclick, etc.)
+  'scroll', // Scroll
+  'keydown', // Input
+  'input', // Input (covers typing without keydown, e.g. autofill)
+];
 
 export class ReplayInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-instrumentation-replay';
@@ -15,7 +29,10 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   private stopFn: { (): void } | null = null;
   private isRecording: boolean = false;
+  private isPaused: boolean = false;
   private options: ReplayInstrumentationOptions = defaultReplayInstrumentationOptions;
+  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+  private boundOnUserInteraction: (() => void) | null = null;
 
   constructor(options: ReplayInstrumentationOptions = {}) {
     super();
@@ -102,50 +119,149 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   }
 
   private stopRecording(): void {
+    this.teardownInactivityTracking();
     if (this.stopFn) {
       this.stopFn();
       this.stopFn = null;
     }
     this.isRecording = false;
+    this.isPaused = false;
     this.logDebug('Session replay stopped');
+  }
+
+  private buildRecordOptions(): recordOptions<eventWithTime> {
+    return {
+      emit: (event: eventWithTime, isCheckout?: boolean): void => {
+        this.handleEvent(event, isCheckout);
+      },
+      checkoutEveryNms: 300_000, // 5 minutes
+      recordCrossOriginIframes: this.options.recordCrossOriginIframes,
+      maskAllInputs: this.options.maskAllInputs,
+      maskInputOptions: this.options.maskInputOptions,
+      maskInputFn: this.options.maskInputFn,
+      maskTextSelector: this.options.maskTextSelector,
+      blockSelector: this.options.blockSelector,
+      ignoreSelector: this.options.ignoreSelector,
+      recordCanvas: this.options.recordCanvas,
+      collectFonts: this.options.collectFonts,
+      inlineImages: this.options.inlineImages,
+      recordDOM: true,
+      inlineStylesheet: this.options.inlineStylesheet,
+      recordAfter: this.options.recordAfter,
+      errorHandler: (err) => {
+        this.logError('Error occurred during session replay', err);
+      },
+    };
+  }
+
+  private startRrweb(): boolean {
+    const stop = record(this.buildRecordOptions());
+    if (stop) {
+      this.stopFn = stop;
+      return true;
+    }
+    return false;
+  }
+
+  private stopRrweb(): void {
+    if (this.stopFn) {
+      this.stopFn();
+      this.stopFn = null;
+    }
   }
 
   private startRecording(): void {
     try {
-      const opts: recordOptions<eventWithTime> = {
-        emit: (event: eventWithTime, isCheckout?: boolean): void => {
-          this.handleEvent(event, isCheckout);
-        },
-        checkoutEveryNms: 300_000, // 5 minutes
-        recordCrossOriginIframes: this.options.recordCrossOriginIframes,
-        maskAllInputs: this.options.maskAllInputs,
-        maskInputOptions: this.options.maskInputOptions,
-        maskInputFn: this.options.maskInputFn,
-        maskTextSelector: this.options.maskTextSelector,
-        blockSelector: this.options.blockSelector,
-        ignoreSelector: this.options.ignoreSelector,
-        recordCanvas: this.options.recordCanvas,
-        collectFonts: this.options.collectFonts,
-        inlineImages: this.options.inlineImages,
-        recordDOM: true,
-        inlineStylesheet: this.options.inlineStylesheet,
-        recordAfter: this.options.recordAfter,
-        errorHandler: (err) => {
-          this.logError('Error occurred during session replay', err);
-        },
-      };
-
-      const stop = record(opts);
-      if (stop) {
-        this.stopFn = stop;
-      }
+      this.startRrweb();
 
       this.isRecording = true;
+      this.isPaused = false;
       this.logDebug('Session replay started');
       this.api.pushEvent(faroSessionReplayStartedEventName, {});
+
+      this.setupInactivityTracking();
     } catch (err) {
       this.logWarn('Failed to start session replay', err);
     }
+  }
+
+  private pauseRecording(): void {
+    if (!this.isRecording || this.isPaused) {
+      return;
+    }
+
+    this.stopRrweb();
+    this.isPaused = true;
+    this.logDebug('Session replay paused due to inactivity');
+    this.api.pushEvent(faroSessionReplayPausedEventName, {});
+  }
+
+  private resumeRecording(): void {
+    if (!this.isPaused) {
+      return;
+    }
+
+    try {
+      this.startRrweb();
+
+      this.isPaused = false;
+      this.logDebug('Session replay resumed after user interaction');
+      this.api.pushEvent(faroSessionReplayResumedEventName, {});
+
+      this.resetInactivityTimer();
+    } catch (err) {
+      this.logWarn('Failed to resume session replay', err);
+    }
+  }
+
+  private setupInactivityTracking(): void {
+    const threshold = this.options.inactivityThresholdMs;
+    if (!threshold || threshold <= 0) {
+      return;
+    }
+
+    this.boundOnUserInteraction = () => {
+      if (this.isPaused) {
+        this.resumeRecording();
+      } else {
+        this.resetInactivityTimer();
+      }
+    };
+
+    for (const eventName of USER_INTERACTION_EVENTS) {
+      document.addEventListener(eventName, this.boundOnUserInteraction, { capture: true, passive: true });
+    }
+
+    this.resetInactivityTimer();
+  }
+
+  private teardownInactivityTracking(): void {
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+
+    if (this.boundOnUserInteraction) {
+      for (const eventName of USER_INTERACTION_EVENTS) {
+        document.removeEventListener(eventName, this.boundOnUserInteraction, { capture: true });
+      }
+      this.boundOnUserInteraction = null;
+    }
+  }
+
+  private resetInactivityTimer(): void {
+    const threshold = this.options.inactivityThresholdMs;
+    if (!threshold || threshold <= 0) {
+      return;
+    }
+
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+    }
+
+    this.inactivityTimer = setTimeout(() => {
+      this.pauseRecording();
+    }, threshold);
   }
 
   private handleEvent(event: eventWithTime, _isCheckout?: boolean): void {

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -190,6 +190,11 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
 
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+
     this.stopRrweb();
     this.isPaused = true;
     this.logDebug('Session replay paused due to inactivity');

--- a/experimental/instrumentation-replay/src/types.ts
+++ b/experimental/instrumentation-replay/src/types.ts
@@ -89,7 +89,7 @@ export interface ReplayInstrumentationOptions {
    *
    * Set to 0 or undefined to disable (record continuously).
    *
-   * @default undefined (disabled)
+   * @default 60000 (1 minute)
    */
   inactivityThresholdMs?: number;
 

--- a/experimental/instrumentation-replay/src/types.ts
+++ b/experimental/instrumentation-replay/src/types.ts
@@ -81,6 +81,19 @@ export interface ReplayInstrumentationOptions {
   recordAfter?: 'DOMContentLoaded' | 'load';
 
   /**
+   * Stop recording after this many milliseconds of no user interaction
+   * (mouse moves, clicks, scrolls, viewport resizes, or input).
+   *
+   * When the user interacts again, recording resumes automatically with a
+   * fresh rrweb checkpoint so the player has a complete DOM snapshot.
+   *
+   * Set to 0 or undefined to disable (record continuously).
+   *
+   * @default undefined (disabled)
+   */
+  inactivityThresholdMs?: number;
+
+  /**
    * The fraction of globally-sampled sessions that should also record a session replay.
    * Expressed as a number between 0 and 1.
    *


### PR DESCRIPTION
## Summary

- Adds an `inactivityThresholdMs` option to `ReplayInstrumentation` that pauses rrweb recording when no user interaction is detected for the configured duration (default: **60 seconds**).
- Recording resumes automatically with a fresh rrweb checkpoint (full DOM snapshot) when the user interacts again, so the player has complete state to resume from.
- Prevents long idle browser tabs from generating hours of empty DOM-mutation-only recordings that have no replay value and waste bandwidth/storage.

## Motivation

The existing rrweb `getInactivePeriods` algorithm only records gaps *between* user interactions — it never detects trailing inactivity. When a user stops interacting but leaves a tab open, the browser continues generating DOM mutations (IncrementalSnapshot source=0) indefinitely with zero replay value. This fix stops recording during those idle periods and resumes with a fresh checkpoint when the user returns.

## How it works

1. When recording starts, DOM event listeners are registered for `pointermove`, `pointerdown`, `scroll`, `keydown`, and `input` (capture phase, passive).
2. A `setTimeout` fires after `inactivityThresholdMs` of no interaction → calls rrweb `stop()`.
3. DOM listeners stay active. When the user interacts → calls rrweb `record()` again (fresh checkpoint), resets timer.
4. Emits `faro.session_recording.paused` / `faro.session_recording.resumed` events for observability.

## Usage

```ts
// Default: pauses after 60 seconds of no interaction
new ReplayInstrumentation()

// Custom threshold
new ReplayInstrumentation({
  inactivityThresholdMs: 120_000, // 2 minutes
})

// Disable inactivity pausing (record continuously)
new ReplayInstrumentation({
  inactivityThresholdMs: 0,
})
```

## Test plan

- [x] All 29 existing tests pass
- [ ] Manual test: verify recording pauses after threshold with no interaction
- [ ] Manual test: verify recording resumes with fresh checkpoint on interaction
- [ ] Verify paused/resumed events appear in Faro telemetry

## Related

- Companion backend PR: [feat(replay): detect trailing inactivity in manifest](https://github.com/grafana/app-o11y-kwl-endpoint/pull/1367)