### PR TITLE
fix(core,web-sdk,react): use monotonic clock for duration measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Next
 
+- Fix (`@grafana/faro-core`, `@grafana/faro-web-sdk`, `@grafana/faro-react`): Duration
+  measurements now use the monotonic clock (`performance.now()`) instead of the wall
+  clock (`Date.now()`), making them immune to system clock adjustments (NTP step,
+  manual clock change, daylight-savings transitions) that previously could produce
+  negative or grossly inflated values. Affects:
+  - `userActionDuration` on `userActionEventName` events. Note: `userActionStartTime`
+    and `userActionEndTime` remain wall-clock Unix-epoch ms strings (unchanged for
+    backwards compatibility) and may disagree with `userActionDuration` if the system
+    clock is adjusted during the action — `userActionDuration` is authoritative.
+  - `duration` on `faro.navigation` events (soft-navigation activity windows).
+  - OTel spans emitted by `FaroProfiler` (`componentMount`, `componentRender`):
+    boundaries are now stamped from OTel's hrTime helper instead of mixing wall-clock
+    `Date.now()` with monotonic span starts.
+
+  New `monoNow()` helper exported from `@grafana/faro-core` for downstream code that
+  needs monotonic time.
+
 - Fix (`@grafana/faro-core`): `faro.api` is now a no-op implementation before
   `initializeFaro()` runs, preventing `TypeError: faro.api is undefined` errors
   when the singleton is accessed pre-initialization or when a bundler produces

--- a/packages/core/src/api/userActions/userAction.test.ts
+++ b/packages/core/src/api/userActions/userAction.test.ts
@@ -92,4 +92,52 @@ describe('UserAction', () => {
     const result = userAction.addItem(item);
     expect(result).toBe(false);
   });
+
+  describe('duration is monotonic-clock based', () => {
+    let dateNowSpy: jest.SpiedFunction<typeof Date.now>;
+    let perfNowSpy: jest.SpiedFunction<typeof performance.now>;
+
+    afterEach(() => {
+      dateNowSpy?.mockRestore();
+      perfNowSpy?.mockRestore();
+    });
+
+    it('computes userActionDuration from performance.now(), independent of wall-clock', () => {
+      // Wall clock advances normally during the action.
+      dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      // Monotonic clock at start.
+      perfNowSpy = jest.spyOn(performance, 'now').mockReturnValue(500);
+
+      const ua = new UserAction({ name: 'foo', transports, trigger: 'foo', pushEvent: mockPushEvent });
+
+      // Advance both clocks by the same amount; monotonic delta should be 250 ms.
+      dateNowSpy.mockReturnValue(1_000_250);
+      perfNowSpy.mockReturnValue(750);
+
+      ua.end();
+
+      const [, payload] = mockPushEvent.mock.calls[0] as [string, Record<string, string>];
+      expect(payload['userActionDuration']).toBe('250');
+    });
+
+    it('produces a non-negative duration even if Date.now() jumps backward mid-action (NTP step / DST)', () => {
+      // Start: wall=1_000_000, mono=500.
+      dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      perfNowSpy = jest.spyOn(performance, 'now').mockReturnValue(500);
+
+      const ua = new UserAction({ name: 'foo', transports, trigger: 'foo', pushEvent: mockPushEvent });
+
+      // Wall clock jumps BACKWARD by 5 s (e.g., NTP correction). Monotonic clock continues forward by 100 ms.
+      dateNowSpy.mockReturnValue(995_000);
+      perfNowSpy.mockReturnValue(600);
+
+      ua.end();
+
+      const [, payload] = mockPushEvent.mock.calls[0] as [string, Record<string, string>];
+      // Wall-clock-based code would emit "-5000" here. Monotonic-based code emits "100".
+      const duration = Number(payload['userActionDuration']);
+      expect(duration).toBeGreaterThanOrEqual(0);
+      expect(duration).toBe(100);
+    });
+  });
 });

--- a/packages/core/src/api/userActions/userAction.ts
+++ b/packages/core/src/api/userActions/userAction.ts
@@ -1,5 +1,5 @@
 import { type TransportItem, TransportItemType, type Transports } from '../../transports';
-import { dateNow, genShortID, Observable, stringifyObjectValues } from '../../utils';
+import { dateNow, genShortID, monoNow, Observable, stringifyObjectValues } from '../../utils';
 import type { EventsAPI } from '../events/types';
 import { ItemBuffer } from '../ItemBuffer';
 import { type MeasurementEvent } from '../measurements/types';
@@ -19,6 +19,9 @@ export default class UserAction
   trigger: string;
   importance: UserActionImportanceType;
   startTime?: number;
+  // Monotonic counterpart to `startTime`, used to compute `duration` immune to wall-clock
+  // adjustments (NTP step, manual clock change, DST). Not exposed in telemetry — see `end()`.
+  private _startTimeMono?: number;
   trackUserActionsExcludeItem?: (item: TransportItem<APIEvent>) => boolean;
 
   private _state: UserActionState;
@@ -72,7 +75,12 @@ export default class UserAction
   private _start(): void {
     this._state = UserActionState.Started;
     if (this._state === UserActionState.Started) {
+      // `startTime` is wall-clock (Unix-epoch ms) so it can be used as the event's
+      // `timestampOverwriteMs` and emitted as `userActionStartTime` for consumers that
+      // correlate with other systems. `_startTimeMono` is the monotonic anchor used
+      // for the duration calculation in `end()`.
       this.startTime = dateNow();
+      this._startTimeMono = monoNow();
     }
   }
 
@@ -102,7 +110,11 @@ export default class UserAction
     }
 
     const endTime = dateNow();
-    const duration = endTime - this.startTime!;
+    // Compute duration from the monotonic clock so it is unaffected by wall-clock
+    // adjustments during the action. Note: `endTime - startTime` (both wall-clock) may
+    // disagree with `duration` if the system clock was adjusted between start and end;
+    // `duration` is authoritative.
+    const duration = monoNow() - this._startTimeMono!;
     this._state = UserActionState.Ended;
     this._itemBuffer.flushBuffer((item) => {
       if (isExcludeFromUserAction(item, this.trackUserActionsExcludeItem)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,6 +140,7 @@ export {
   LogLevel,
   noop,
   dateNow,
+  monoNow,
   isEmpty,
   getCircularDependencyReplacer,
   stringifyExternalJson,

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -2,6 +2,30 @@ export function dateNow(): number {
   return Date.now();
 }
 
+/**
+ * Returns a high-resolution, monotonic timestamp in milliseconds.
+ *
+ * Use this for measuring elapsed time / durations. Unlike {@link dateNow} (which is
+ * derived from the system wall clock and is therefore subject to NTP adjustments,
+ * manual clock changes, daylight-savings transitions, etc.), `monoNow` is backed by
+ * `performance.now()`, which is guaranteed never to decrease and is unaffected by
+ * such adjustments.
+ *
+ * Do NOT use this for absolute event timestamps that need to be correlated with
+ * other systems or persisted across page loads — use {@link dateNow} or
+ * {@link getCurrentTimestamp} for that.
+ *
+ * Falls back to {@link dateNow} in environments where `performance.now` is
+ * unavailable (very old runtimes, unusual SSR setups). The fallback re-introduces
+ * wall-clock susceptibility but preserves the API contract.
+ */
+export function monoNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
 export function getCurrentTimestamp(): string {
   return new Date().toISOString();
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -50,7 +50,7 @@ export { genShortID } from './shortId';
 
 export { getBundleId } from './sourceMaps';
 
-export { dateNow } from './date';
+export { dateNow, monoNow } from './date';
 
 export { getCircularDependencyReplacer, stringifyExternalJson, stringifyObjectValues } from './json';
 

--- a/packages/react/src/profiler/FaroProfiler.test.tsx
+++ b/packages/react/src/profiler/FaroProfiler.test.tsx
@@ -1,0 +1,92 @@
+import { setDependencies } from '../dependencies';
+
+import { FaroProfiler } from './FaroProfiler';
+
+describe('FaroProfiler', () => {
+  let mockSpan: { end: jest.Mock };
+  let mockChildSpan: { end: jest.Mock };
+  let startSpanCalls: Array<{ name: string; options: any }>;
+  let setSpanMock: jest.Mock;
+  let activeContextMock: jest.Mock;
+  let withMock: jest.Mock;
+
+  beforeEach(() => {
+    mockSpan = { end: jest.fn() };
+    mockChildSpan = { end: jest.fn() };
+    startSpanCalls = [];
+
+    let callIdx = 0;
+    const startSpan = jest.fn((name: string, options: any) => {
+      startSpanCalls.push({ name, options });
+      // First call is the mount span (from constructor); subsequent calls are children.
+      return callIdx++ === 0 ? mockSpan : mockChildSpan;
+    });
+
+    setSpanMock = jest.fn();
+    activeContextMock = jest.fn(() => ({}) as any);
+    withMock = jest.fn((_ctx: any, fn: () => void) => fn());
+
+    const otelMock: any = {
+      trace: {
+        getTracer: () => ({ startSpan }),
+        setSpan: setSpanMock,
+      },
+      context: {
+        active: activeContextMock,
+        with: withMock,
+      },
+    };
+
+    const apiMock: any = {
+      isOTELInitialized: () => true,
+      getOTEL: () => otelMock,
+    };
+
+    const internalLoggerMock: any = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+
+    setDependencies(internalLoggerMock, apiMock);
+  });
+
+  it('does not pass Date.now() to span.end on mount (lets OTel stamp via monotonic hrTime)', () => {
+    const dateNowSpy = jest.spyOn(Date, 'now');
+
+    const profiler = new FaroProfiler({ name: 'C', updateProps: {}, children: null as any });
+    profiler.componentDidMount();
+
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    // Critical assertion: span.end was called with no wall-clock timestamp argument.
+    // OTel's web SDK stamps the end time via its hrTime helper (performance.timeOrigin +
+    // performance.now()), which is monotonic. Passing Date.now() here would mix clocks
+    // with the mount span's start (auto-stamped by OTel from hrTime).
+    expect(mockSpan.end).toHaveBeenCalledWith();
+    expect(dateNowSpy).not.toHaveBeenCalled();
+
+    dateNowSpy.mockRestore();
+  });
+
+  it('does not pass Date.now() to componentRender child span on unmount', () => {
+    const dateNowSpy = jest.spyOn(Date, 'now');
+
+    const profiler = new FaroProfiler({ name: 'C', updateProps: {}, children: null as any });
+    profiler.componentDidMount();
+
+    dateNowSpy.mockClear();
+    profiler.componentWillUnmount();
+
+    // A componentRender child span should have been created.
+    const renderCall = startSpanCalls.find((c) => c.name === 'componentRender');
+    expect(renderCall).toBeTruthy();
+
+    // Critical: neither startTime nor endTime should be sourced from Date.now() (wall clock).
+    expect(dateNowSpy).not.toHaveBeenCalled();
+
+    // Both timestamps should be undefined (let OTel stamp from hrTime) or, if explicitly
+    // provided, derived from a monotonic source. The simplest fix uses undefined.
+    if (renderCall!.options) {
+      expect(renderCall!.options.startTime).toBeUndefined();
+      expect(renderCall!.options.endTime).toBeUndefined();
+    }
+
+    dateNowSpy.mockRestore();
+  });
+});

--- a/packages/react/src/profiler/FaroProfiler.tsx
+++ b/packages/react/src/profiler/FaroProfiler.tsx
@@ -18,7 +18,7 @@ export interface FaroProfilerProps {
 
 export class FaroProfiler extends Component<FaroProfilerProps> {
   protected mountSpan: Span | undefined = undefined;
-  protected mountSpanEndTime: number | undefined = undefined;
+  protected renderSpan: Span | undefined = undefined;
   protected updateSpan: Span | undefined = undefined;
 
   private get isOtelInitialized(): boolean {
@@ -82,8 +82,20 @@ export class FaroProfiler extends Component<FaroProfilerProps> {
 
   override componentDidMount(): void {
     if (this.isOtelInitialized && this.mountSpan) {
-      this.mountSpanEndTime = Date.now();
-      this.mountSpan.end(this.mountSpanEndTime);
+      // Let OTel stamp the end via its hrTime helper (`performance.timeOrigin +
+      // performance.now()`), which is monotonic. Passing `Date.now()` here would mix the
+      // wall clock with the mount span's start time (auto-stamped by OTel from hrTime),
+      // making `endTime - startTime` drift with NTP / DST / manual clock changes.
+      this.mountSpan.end();
+
+      // Start the `componentRender` span immediately. It covers the live, mounted lifetime
+      // of the component and is ended in `componentWillUnmount`. By starting and ending it
+      // without explicit timestamps, both boundaries are stamped from OTel hrTime
+      // (monotonic). This avoids the wall-clock issues of the previous implementation
+      // which captured `Date.now()` here and subtracted it from another `Date.now()` at
+      // unmount — a problem that compounded over a long-lived component (router/app
+      // shells can live for the entire session).
+      this.renderSpan = this.createChildSpan('componentRender', this.mountSpan);
     }
   }
 
@@ -111,11 +123,10 @@ export class FaroProfiler extends Component<FaroProfilerProps> {
   }
 
   override componentWillUnmount(): void {
-    if (this.isOtelInitialized && this.mountSpan) {
-      this.createChildSpan('componentRender', this.mountSpan, {
-        startTime: this.mountSpanEndTime,
-        endTime: Date.now(),
-      });
+    if (this.isOtelInitialized && this.renderSpan) {
+      // End via OTel hrTime (monotonic). See `componentDidMount` for rationale.
+      this.renderSpan.end();
+      this.renderSpan = undefined;
     }
   }
 

--- a/packages/web-sdk/src/instrumentations/_internal/activityWindowTracker.test.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/activityWindowTracker.test.ts
@@ -187,6 +187,38 @@ describe('ActivityWindowTracker', () => {
     expect(end.events).toEqual(expect.arrayContaining([domEvent]));
   });
 
+  it('duration is monotonic-clock based and not corrupted by wall-clock jumps', () => {
+    const events$ = new Observable<any>();
+    const tracker = new ActivityWindowTracker(events$, { inactivityMs: 10, drainTimeoutMs: 100 });
+    const notifications: any[] = [];
+    tracker.subscribe((n) => notifications.push(n));
+
+    tracker.startTracking();
+
+    // Advance fake timers by 5 ms (monotonic + wall both advance).
+    jest.advanceTimersByTime(5);
+
+    // Simulate the wall-clock jumping BACKWARD by 1 hour mid-window (NTP step / DST).
+    // `jest.setSystemTime` only affects Date.now() under modern fake timers; performance.now()
+    // continues forward.
+    jest.setSystemTime(-3600 * 1000);
+
+    // Emit an event AFTER the jump so `_lastEventTime` reflects the corrupted wall clock
+    // under the buggy implementation, but the correct monotonic +5 ms under the fix.
+    events$.notify({ id: 1 });
+
+    // Let the inactivity window elapse to trigger stop.
+    jest.advanceTimersByTime(10);
+
+    const end = notifications.find((n) => n.message === 'tracking-ended');
+    expect(end).toBeTruthy();
+    // Wall-clock-based code would emit a large negative number here
+    // (`_lastEventTime` ≈ -3_600_000 minus `_startTime` 0 = ~-3_600_000).
+    expect(end.duration).toBeGreaterThanOrEqual(0);
+    // Monotonic delta from start to last-event-time ≈ 5 ms.
+    expect(end.duration).toBe(5);
+  });
+
   it('type guards return correct booleans', () => {
     const startMsg = { type: MESSAGE_TYPE_HTTP_REQUEST_START } as any;
     const endMsg = { type: MESSAGE_TYPE_HTTP_REQUEST_END } as any;

--- a/packages/web-sdk/src/instrumentations/_internal/activityWindowTracker.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/activityWindowTracker.ts
@@ -1,4 +1,4 @@
-import { Observable } from '@grafana/faro-core';
+import { monoNow, Observable } from '@grafana/faro-core';
 
 import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './monitors/const';
 import type { HttpRequestEndMessage, HttpRequestStartMessage } from './monitors/types';
@@ -55,7 +55,9 @@ export class ActivityWindowTracker extends Observable {
         return this._tracking;
       })
       .subscribe((event) => {
-        this._lastEventTime = Date.now();
+        // Monotonic clock — used only for the duration delta in `stopTracking()`.
+        // Not exposed as an absolute timestamp anywhere.
+        this._lastEventTime = monoNow();
         this._currentEvents?.push(event);
 
         const startKey = this._options.isOperationStart(event as any);
@@ -78,8 +80,11 @@ export class ActivityWindowTracker extends Observable {
     }
 
     this._tracking = true;
-    this._startTime = Date.now();
-    this._lastEventTime = Date.now();
+    // Use a monotonic clock so the resulting `duration` (computed in `stopTracking()`)
+    // is immune to wall-clock adjustments (NTP step, manual change, DST) that may
+    // occur during the tracking window.
+    this._startTime = monoNow();
+    this._lastEventTime = this._startTime;
 
     this.notify({
       message: 'tracking-started',
@@ -97,7 +102,7 @@ export class ActivityWindowTracker extends Observable {
 
     let duration;
     if (this.hasActiveOperations()) {
-      duration = Date.now() - this._startTime!;
+      duration = monoNow() - this._startTime!;
     } else {
       duration = this._lastEventTime ? this._lastEventTime - this._startTime! : 0;
     }


### PR DESCRIPTION
## Why

Several duration measurements in the SDK were computed by subtracting two `Date.now()` values. `Date.now()` is wall-clock based and subject to NTP corrections, manual clock changes, and DST transitions, so the resulting durations could be negative or grossly inflated when the system clock was adjusted during the measured window. Per MDN, `performance.now()` is the appropriate clock for elapsed-time measurement because it is monotonic and unaffected by such adjustments.

Three sites were affected:

1. `userActionDuration` on user-action events (`packages/core`).
2. `duration` on `faro.navigation` events emitted by the soft-navigation activity-window tracker (`packages/web-sdk`).
3. OTel `componentMount` and `componentRender` spans from `FaroProfiler` (`packages/react`), which additionally mixed clocks: span starts were auto-stamped by OTel from the monotonic hrTime helper while ends were `Date.now()`. Long-lived components (router/app shells) were the most exposed.

## What

- Added `monoNow()` to `@grafana/faro-core` (`performance.now()` with a `Date.now()` fallback for environments without `performance`).
- `UserAction`: duration now derived from a monotonic anchor captured alongside the existing wall-clock `startTime`. `userActionStartTime` and `userActionEndTime` retain their Unix-epoch ms string format (no breaking change).
- `ActivityWindowTracker`: `_startTime` and `_lastEventTime` switched to `monoNow()`; `duration` is now a monotonic delta.
- `FaroProfiler`: removed `Date.now()` from `componentDidMount` and `componentWillUnmount`. The `componentRender` span is now started immediately after the mount span ends and ended on unmount, with both boundaries stamped by OTel's hrTime helper.

Tests added for each site:
- Two unit tests in `userAction.test.ts` covering normal advance and a wall-clock backward jump.
- One unit test in `activityWindowTracker.test.ts` covering a wall-clock backward jump mid-window.
- A new `FaroProfiler.test.tsx` asserting `Date.now()` is not called for span boundaries.

All existing tests continue to pass: `@grafana/faro-core` 153/153, `@grafana/faro-web-sdk` 242/242, `@grafana/faro-react` 6/6, `@grafana/faro-web-tracing` 31/31.

Note for consumers: under wall-clock adjustments, `userActionStartTime` and `userActionEndTime` may disagree with `userActionDuration`. `userActionDuration` is authoritative.

## Links

n/a

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated