### PR TITLE
chore(release): bump packages to v2.5.0

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-demo",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Demo of Faro",
   "license": "Apache-2.0",
   "author": "Grafana Labs",
@@ -38,10 +38,10 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^2.4.0",
-    "@grafana/faro-react": "^2.4.0",
-    "@grafana/faro-web-sdk": "^2.4.0",
-    "@grafana/faro-web-tracing": "^2.4.0",
+    "@grafana/faro-core": "^2.5.0",
+    "@grafana/faro-react": "^2.5.0",
+    "@grafana/faro-web-sdk": "^2.5.0",
+    "@grafana/faro-web-tracing": "^2.5.0",
     "@grpc/grpc-js": "^1.9.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",

--- a/experimental/instrumentation-replay/package.json
+++ b/experimental/instrumentation-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-instrumentation-replay",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Faro instrumentation for session replay with rrweb",
   "keywords": [
     "observability",
@@ -52,7 +52,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^2.4.0",
+    "@grafana/faro-core": "^2.5.0",
     "rrweb": "^2.0.0-alpha.18"
   },
   "publishConfig": {

--- a/experimental/transport-otlp-http/package.json
+++ b/experimental/transport-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-transport-otlp-http",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Faro transport which converts the Faro data model to the Otlp data model.",
   "keywords": [
     "observability",
@@ -53,7 +53,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "devDependencies": {
-    "@grafana/faro-core": "^2.4.0"
+    "@grafana/faro-core": "^2.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "experimental/*",
     "demo"
   ],
-  "version": "2.4.0",
+  "version": "2.5.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-core",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Core package of Faro.",
   "keywords": [
     "observability",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-react",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Faro package that enables easier integration in projects built with React.",
   "keywords": [
     "observability",
@@ -55,8 +55,8 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^2.4.0",
-    "@grafana/faro-web-tracing": "^2.4.0",
+    "@grafana/faro-web-sdk": "^2.5.0",
+    "@grafana/faro-web-tracing": "^2.5.0",
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Faro instrumentations, metas, transports for web.",
   "keywords": [
     "observability",
@@ -56,7 +56,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-core": "^2.4.0",
+    "@grafana/faro-core": "^2.5.0",
     "ua-parser-js": "1.0.41",
     "web-vitals": "^5.1.0"
   },

--- a/packages/web-tracing/package.json
+++ b/packages/web-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-web-tracing",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Faro web tracing implementation.",
   "keywords": [
     "observability",
@@ -55,7 +55,7 @@
     "quality:circular-deps": "madge --circular ."
   },
   "dependencies": {
-    "@grafana/faro-web-sdk": "^2.4.0",
+    "@grafana/faro-web-sdk": "^2.5.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,7 +874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-core@npm:^2.4.0, @grafana/faro-core@workspace:packages/core":
+"@grafana/faro-core@npm:^2.5.0, @grafana/faro-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-core@workspace:packages/core"
   dependencies:
@@ -888,10 +888,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/faro-demo@workspace:demo"
   dependencies:
-    "@grafana/faro-core": "npm:^2.4.0"
-    "@grafana/faro-react": "npm:^2.4.0"
-    "@grafana/faro-web-sdk": "npm:^2.4.0"
-    "@grafana/faro-web-tracing": "npm:^2.4.0"
+    "@grafana/faro-core": "npm:^2.5.0"
+    "@grafana/faro-react": "npm:^2.5.0"
+    "@grafana/faro-web-sdk": "npm:^2.5.0"
+    "@grafana/faro-web-tracing": "npm:^2.5.0"
     "@grpc/grpc-js": "npm:^1.9.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.0.0"
@@ -956,17 +956,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/faro-instrumentation-replay@workspace:experimental/instrumentation-replay"
   dependencies:
-    "@grafana/faro-core": "npm:^2.4.0"
+    "@grafana/faro-core": "npm:^2.5.0"
     rrweb: "npm:^2.0.0-alpha.18"
   languageName: unknown
   linkType: soft
 
-"@grafana/faro-react@npm:^2.4.0, @grafana/faro-react@workspace:packages/react":
+"@grafana/faro-react@npm:^2.5.0, @grafana/faro-react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-react@workspace:packages/react"
   dependencies:
-    "@grafana/faro-web-sdk": "npm:^2.4.0"
-    "@grafana/faro-web-tracing": "npm:^2.4.0"
+    "@grafana/faro-web-sdk": "npm:^2.5.0"
+    "@grafana/faro-web-tracing": "npm:^2.5.0"
     "@types/hoist-non-react-statics": "npm:3.3.7"
     "@types/react": "npm:19.2.14"
     hoist-non-react-statics: "npm:^3.3.2"
@@ -992,17 +992,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/faro-transport-otlp-http@workspace:experimental/transport-otlp-http"
   dependencies:
-    "@grafana/faro-core": "npm:^2.4.0"
+    "@grafana/faro-core": "npm:^2.5.0"
     "@opentelemetry/otlp-transformer": "npm:^0.216.0"
     "@opentelemetry/semantic-conventions": "npm:^1.28.0"
   languageName: unknown
   linkType: soft
 
-"@grafana/faro-web-sdk@npm:^2.4.0, @grafana/faro-web-sdk@workspace:packages/web-sdk":
+"@grafana/faro-web-sdk@npm:^2.5.0, @grafana/faro-web-sdk@workspace:packages/web-sdk":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-web-sdk@workspace:packages/web-sdk"
   dependencies:
-    "@grafana/faro-core": "npm:^2.4.0"
+    "@grafana/faro-core": "npm:^2.5.0"
     "@types/node": "npm:24.12.2"
     "@types/ua-parser-js": "npm:0.7.39"
     ua-parser-js: "npm:1.0.41"
@@ -1011,11 +1011,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/faro-web-tracing@npm:^2.4.0, @grafana/faro-web-tracing@workspace:packages/web-tracing":
+"@grafana/faro-web-tracing@npm:^2.5.0, @grafana/faro-web-tracing@workspace:packages/web-tracing":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-web-tracing@workspace:packages/web-tracing"
   dependencies:
-    "@grafana/faro-web-sdk": "npm:^2.4.0"
+    "@grafana/faro-web-sdk": "npm:^2.5.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.0.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.216.0"


### PR DESCRIPTION
Version bump from `lerna version` for v2.5.0.

The tag `v2.5.0` was already pushed to the remote (points to commit be774248). PR #2020 only updated CHANGELOG.md; this PR contains the package.json/lerna.json/yarn.lock version bumps that lerna generated.

After merge, run `lerna publish from-git` to publish to npm.