### PR TITLE
chore(release): switch release flow to release-please

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,7 +33,7 @@ jobs:
           # - lightningcss: MPL-2.0, transitive dep via vite 8 (was optional peer in vite 7)
           allow-dependencies-licenses: >-
             pkg:githubactions/grafana/shared-workflows/actions/lint-pr-title,
-            pkg:githubactions/grafana/shared-workflows/actions/get-vault-secrets,
+            pkg:githubactions/grafana/shared-workflows/actions/create-github-app-token,
             pkg:npm/@ltd/j-toml,
             pkg:npm/lightningcss,
             pkg:npm/lightningcss-android-arm64,

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,6 +33,7 @@ jobs:
           # - lightningcss: MPL-2.0, transitive dep via vite 8 (was optional peer in vite 7)
           allow-dependencies-licenses: >-
             pkg:githubactions/grafana/shared-workflows/actions/lint-pr-title,
+            pkg:githubactions/grafana/shared-workflows/actions/get-vault-secrets,
             pkg:npm/@ltd/j-toml,
             pkg:npm/lightningcss,
             pkg:npm/lightningcss-android-arm64,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,10 +9,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # All writes (commit, tag, release, PR) are performed using the dedicated
-    # FARO_WEB_SDK_CI GitHub App token, not GITHUB_TOKEN. The only permission
-    # the default GITHUB_TOKEN needs is `id-token: write` so that the
-    # get-vault-secrets step can authenticate to Vault via OIDC.
+    # All writes (commit, tag, release, PR) are performed using the
+    # `app-o11y-kwl-ci` GitHub App token (shared across the FE-Observability
+    # repos), not GITHUB_TOKEN. The only permission the default GITHUB_TOKEN
+    # needs is `id-token: write` so that the get-vault-secrets step can
+    # authenticate to Vault via OIDC.
     permissions:
       contents: read
       id-token: write
@@ -22,20 +23,24 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
+      # The `app-o11y-kwl-ci` GitHub App credentials are mirrored into this
+      # repo's Vault namespace at ci/repo/grafana/faro-web-sdk/github (fields
+      # `app-id` and `private-key`). The same credentials live under
+      # ci/repo/grafana/app-o11y-kwl/github for that repo's workflows.
       - id: get-secrets
         name: get secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
         with:
           repo_secrets: |
-            FARO_WEB_SDK_CI_APP_ID=github:app-id
-            FARO_WEB_SDK_CI_PRIVATE_KEY=github:private-key
+            APP_O11Y_KWL_CI_APP_ID=github:app-id
+            APP_O11Y_KWL_CI_PRIVATE_KEY=github:private-key
 
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         name: get github app token
         id: get-github-app-token
         with:
-          app-id: ${{ env.FARO_WEB_SDK_CI_APP_ID }}
-          private-key: ${{ env.FARO_WEB_SDK_CI_PRIVATE_KEY }}
+          app-id: ${{ env.APP_O11Y_KWL_CI_APP_ID }}
+          private-key: ${{ env.APP_O11Y_KWL_CI_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             faro-web-sdk

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,45 @@
+name: Release please
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - id: get-secrets
+        name: get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          repo_secrets: |
+            FARO_WEB_SDK_CI_APP_ID=github:app-id
+            FARO_WEB_SDK_CI_PRIVATE_KEY=github:private-key
+
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        name: get github app token
+        id: get-github-app-token
+        with:
+          app-id: ${{ env.FARO_WEB_SDK_CI_APP_ID }}
+          private-key: ${{ env.FARO_WEB_SDK_CI_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            faro-web-sdk
+
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
+        id: release
+        with:
+          token: ${{ steps.get-github-app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,11 +11,14 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     # All writes (commit, tag, release, PR) are performed using the
     # `app-o11y-kwl-ci` GitHub App token (shared across the FE-Observability
-    # repos), not GITHUB_TOKEN. The only permission the default GITHUB_TOKEN
-    # needs is `id-token: write` so that the get-vault-secrets step can
-    # authenticate to Vault via OIDC.
+    # repos), not GITHUB_TOKEN. `id-token: write` lets get-vault-secrets
+    # authenticate to Vault via OIDC; `contents: write` and
+    # `pull-requests: write` mirror the reference workflow in
+    # grafana/app-o11y-kwl so release-please-action's own permission
+    # checks pass.
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,7 @@ jobs:
     # deployment_tools at terraform/repositories/faro-web-sdk/github-app-configs/config.yaml.
     # `id-token: write` lets that action authenticate to Vault via OIDC.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,17 +5,19 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # All writes (commit, tag, release, PR) are performed using the
-    # `app-o11y-kwl-ci` GitHub App token (shared across the FE-Observability
-    # repos), not GITHUB_TOKEN. `id-token: write` lets get-vault-secrets
-    # authenticate to Vault via OIDC; `contents: write` and
-    # `pull-requests: write` mirror the reference workflow in
-    # grafana/app-o11y-kwl so release-please-action's own permission
-    # checks pass.
+    # release-please writes (commit, tag, release, PR) are performed using a
+    # token minted by `grafana/shared-workflows/actions/create-github-app-token`,
+    # which calls the Vault `vault-github-app-mount` permission set defined in
+    # deployment_tools at terraform/repositories/faro-web-sdk/github-app-configs/config.yaml.
+    # `id-token: write` lets that action authenticate to Vault via OIDC.
     permissions:
       contents: write
       pull-requests: write
@@ -26,31 +28,16 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
-      # The `app-o11y-kwl-ci` GitHub App credentials are mirrored into this
-      # repo's Vault namespace at ci/repo/grafana/faro-web-sdk/github (fields
-      # `app-id` and `private-key`). The same credentials live under
-      # ci/repo/grafana/app-o11y-kwl/github for that repo's workflows.
-      - id: get-secrets
-        name: get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Mint GitHub App token
+        id: app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          repo_secrets: |
-            APP_O11Y_KWL_CI_APP_ID=github:app-id
-            APP_O11Y_KWL_CI_PRIVATE_KEY=github:private-key
+          github_app: app-o11y-kwl-ci
 
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        name: get github app token
-        id: get-github-app-token
-        with:
-          app-id: ${{ env.APP_O11Y_KWL_CI_APP_ID }}
-          private-key: ${{ env.APP_O11Y_KWL_CI_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            faro-web-sdk
-
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,9 +9,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # All writes (commit, tag, release, PR) are performed using the dedicated
+    # FARO_WEB_SDK_CI GitHub App token, not GITHUB_TOKEN. The only permission
+    # the default GITHUB_TOKEN needs is `id-token: write` so that the
+    # get-vault-secrets step can authenticate to Vault via OIDC.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,8 @@
+{
+  "packages/core": "2.5.0",
+  "packages/web-sdk": "2.5.0",
+  "packages/web-tracing": "2.5.0",
+  "packages/react": "2.5.0",
+  "experimental/instrumentation-replay": "2.5.0",
+  "experimental/transport-otlp-http": "2.5.0"
+}

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -18,6 +18,22 @@ No manual `lerna version` runs and no direct pushes to `main` are required.
 All 6 publishable packages bump together (lockstep) via the `linked-versions`
 plugin in `release-please-config.json`.
 
+## Packages excluded from release-please
+
+The `demo/` workspace (`@grafana/faro-demo`) is **intentionally not listed** in
+`release-please-config.json` or `.release-please-manifest.json`. It is a private
+package (`"private": true` in `demo/package.json`) used only for local
+development and end-to-end tests; it is never published to npm.
+
+Demo's internal dependency ranges (e.g. on `@grafana/faro-web-sdk`) are still
+kept in sync automatically by the `node-workspace` plugin during every release
+bump, so the demo continues to build against the latest local versions.
+
+The legacy directories under `experimental/` (`instrumentation-fetch`,
+`instrumentation-xhr`, `instrumentation-performance-timeline`, `nextjs`, `vue`)
+have no `package.json` and are unmaintained. They are not part of the workspace
+set and are ignored.
+
 ## Triggering a release
 
 Land a PR with a conventional commit prefix:

--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -1,22 +1,44 @@
 # Releasing
 
-To release a new version, run `npx lerna version --force-publish` on the main branch.
-It will ask some questions, bump package versions, tag & push.
-CI will pick it up from there and publish to npm.
+Releases are automated via [release-please](https://github.com/googleapis/release-please).
+No manual `lerna version` runs and no direct pushes to `main` are required.
 
-**Note:**
-Before calling `npx lerna version --force-publish` always ensure that your local main branch is 1:1 with origin/main
-and your dependencies are up to date.
+## How it works
 
-- Do `git pull` the main branch
-- Check `git status` to double check if you have any unpushed changes
-- Run `yarn install --immutable` to make sure `node_modules` is in sync with `yarn.lock`
+1. Every push to `main` triggers `.github/workflows/release-please.yml`.
+2. release-please scans conventional commits since the last release and either:
+   - opens a new "Release please" PR, or
+   - updates an existing one with the next version, regenerated CHANGELOG entries,
+     and bumped `package.json` / `lerna.json` versions across all publishable packages.
+3. When a maintainer merges that Release PR, release-please creates the matching
+   `vX.Y.Z` git tag and a GitHub Release.
+4. The tag push triggers `.github/workflows/release.yml`, which runs the existing
+   test/e2e pipeline and publishes to npm via `lerna publish from-git` with provenance.
 
-**Note 2:**
-You need special access privileges to be able push to the protected main branch.
-It's recommended to protect the main branch with your local tooling.
+All 6 publishable packages bump together (lockstep) via the `linked-versions`
+plugin in `release-please-config.json`.
 
-For VsCode
+## Triggering a release
 
-- Add your branch to the `git.branchProtection` property
-- Set `git.branchProtectionPrompt` to `always prompt`
+Land a PR with a conventional commit prefix:
+
+- `feat:` → minor bump
+- `fix:` → patch bump
+- `feat!:` / `fix!:` / `BREAKING CHANGE:` footer → major bump
+- `chore:`, `docs:`, `refactor:`, etc. → no version bump
+
+The Release PR will appear (or update) within a few minutes of the merge to `main`.
+Review and merge it when you're ready to ship.
+
+## Configuration
+
+- `release-please-config.json` — package list, plugins, changelog path.
+- `.release-please-manifest.json` — current versions per package (managed by the bot;
+  do not hand-edit unless recovering from a broken state).
+- `.github/workflows/release-please.yml` — the workflow itself.
+
+## Skipping a release
+
+If you want to merge changes without ever publishing them, use commit types that
+don't trigger a bump (`chore:`, `docs:`, `refactor:`, `test:`, etc.) or annotate
+the message with `Release-As: <version>` to override.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "separate-pull-requests": false,
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": false,
+  "draft": false,
+  "prerelease": false,
+  "pull-request-header": "Faro Web SDK Release - ${version}",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "faro",
+      "components": [
+        "@grafana/faro-core",
+        "@grafana/faro-web-sdk",
+        "@grafana/faro-web-tracing",
+        "@grafana/faro-react",
+        "@grafana/faro-instrumentation-replay",
+        "@grafana/faro-transport-otlp-http"
+      ]
+    },
+    "node-workspace"
+  ],
+  "packages": {
+    "packages/core": {
+      "package-name": "@grafana/faro-core",
+      "component": "@grafana/faro-core",
+      "changelog-path": "../../CHANGELOG.md"
+    },
+    "packages/web-sdk": {
+      "package-name": "@grafana/faro-web-sdk",
+      "component": "@grafana/faro-web-sdk",
+      "changelog-path": "../../CHANGELOG.md"
+    },
+    "packages/web-tracing": {
+      "package-name": "@grafana/faro-web-tracing",
+      "component": "@grafana/faro-web-tracing",
+      "changelog-path": "../../CHANGELOG.md"
+    },
+    "packages/react": {
+      "package-name": "@grafana/faro-react",
+      "component": "@grafana/faro-react",
+      "changelog-path": "../../CHANGELOG.md"
+    },
+    "experimental/instrumentation-replay": {
+      "package-name": "@grafana/faro-instrumentation-replay",
+      "component": "@grafana/faro-instrumentation-replay",
+      "changelog-path": "../../CHANGELOG.md"
+    },
+    "experimental/transport-otlp-http": {
+      "package-name": "@grafana/faro-transport-otlp-http",
+      "component": "@grafana/faro-transport-otlp-http",
+      "changelog-path": "../../CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
Closes #2022 (or refs, depending on how the umbrella tracks).

## What

Replace `lerna version` + direct push to `main` with a PR-based [release-please](https://github.com/googleapis/release-please) flow that respects branch protection.

## Changes

- **`release-please-config.json`** — monorepo config with `linked-versions` + `node-workspace` plugins so all 6 publishable packages bump in lockstep, all writing to a single root `CHANGELOG.md`. Tags keep the `vX.Y.Z` prefix.
- **`.release-please-manifest.json`** — seeded at `2.5.0` for all 6 packages.
- **`.github/workflows/release-please.yml`** — new workflow modeled on `grafana/grafana-workflows` and `grafana/grafana-labelmanagement-app`. Mints an App token via `grafana/shared-workflows/actions/create-github-app-token`, which talks to the Vault `vault-github-app-mount` permission set declared in `deployment_tools`. The shared `app-o11y-kwl-ci` GitHub App is reused.
- **`.github/workflows/dependency-review.yml`** — added `grafana/shared-workflows/actions/create-github-app-token` to the AGPL-3.0 allow-list.
- **`docs/sources/developer/releasing.md`** — rewritten to describe the new flow.

## Out of scope

The existing tag-triggered `.github/workflows/release.yml` is unchanged; it continues to publish to npm via `lerna publish from-git` once release-please creates the version tag.

## Required before merge

This PR depends on a companion `deployment_tools` PR adding the Vault permission set so the shared-workflows action is authorized to mint a token for this workflow:

- [ ] `grafana/deployment_tools` PR https://github.com/grafana/deployment_tools/pull/575659 merged and applied via Atlantis. Adds `terraform/repositories/faro-web-sdk/github-app-configs/config.yaml` (app: `app-o11y-kwl-ci`, workflow path: `.github/workflows/release-please.yml`, repositories: `[faro-web-sdk]`, permissions: `contents: write`, `pull_requests: write`, `issues: write`).
- [ ] `app-o11y-kwl-ci` GitHub App installed on `grafana/faro-web-sdk` with the matching permissions (responder confirmed already added).
- [ ] App credentials loaded into the `app-o11y-kwl-ci` Vault mount (handled by the platform team — they confirmed the existing creds will be reused).

Without the deployment_tools config, the workflow will fail at the `Mint GitHub App token` step on first run.

## Validation plan post-merge

1. Confirm `release-please.yml` runs on the merge commit and opens an empty/valid Release PR.
2. Land a small `feat:` commit; confirm the Release PR updates to propose a minor bump.
3. Merge the Release PR; confirm tag triggers `release.yml` and `npm publish` succeeds with provenance.