### PR TITLE
ci: drop EOL Node 20 from test matrix

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [latest, 20.x, 22.x, 24.x]
+        node: [22.x, 24.x, latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/jod
+lts/krypton


### PR DESCRIPTION
## Summary

Per the [Node.js release schedule](https://nodejs.org/en/about/previous-releases), Node 20 (Iron) reached end-of-life on **2026-03-24**. This PR updates CI and the repo's pinned Node version to test only the currently supported lines, matching the policy stated in the [`README.md`](../blob/main/README.md#supported-node-versions):

> Faro supports all active LTS (Long Term Support) and current Node versions. When Node.js versions reach end-of-life, we remove them from our test matrix and add new versions as they are released.

### Currently supported Node lines (as of 2026-05-05)

- **v22 (Jod)** — Maintenance LTS
- **v24 (Krypton)** — Active LTS
- **v25** — Current (covered via `latest`)

### Changes

- `.github/workflows/pull-request.yml`
  - Unit test matrix: `[latest, 20.x, 22.x, 24.x]` → `[22.x, 24.x, latest]`
  - E2E `node-version`: `lts/iron` (v20, EOL) → `lts/*` (resolves to Active LTS)
- `.nvmrc`: `lts/jod` (v22, Maintenance LTS) → `lts/krypton` (v24, Active LTS)

