### PR TITLE
feat(web-sdk): add gzip request compression to FetchTransport

### DIFF
--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -39,6 +39,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
       new FetchTransport({
         url: browserConfig.url,
         apiKey: browserConfig.apiKey,
+        requestCompression: browserConfig.requestCompression,
       })
     );
   } else {

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -3,6 +3,7 @@ import type { Config } from '@grafana/faro-core';
 export interface BrowserConfig extends Partial<Omit<Config, 'app' | 'parseStacktrace'>>, Pick<Config, 'app'> {
   url?: string;
   apiKey?: string;
+  requestCompression?: boolean;
 }
 
 export interface GetWebInstrumentationsOptions {

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -502,7 +502,7 @@ describe('FetchTransport', () => {
       expect((requestInit.headers as Record<string, string>)['Content-Type']).toBe('application/json');
     });
 
-    it('is disabled by default', async () => {
+    it('is enabled by default', async () => {
       const transport = new FetchTransport({
         url: 'http://example.com/collect',
       });
@@ -515,8 +515,8 @@ describe('FetchTransport', () => {
       const callArgs = fetch.mock.calls[0] as unknown[];
       const requestInit = callArgs[1] as RequestInit;
 
-      expect(typeof requestInit.body).toBe('string');
-      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBeUndefined();
+      expect(requestInit.body).toBeInstanceOf(Blob);
+      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBe('gzip');
     });
 
     it('sends uncompressed body when disabled', async () => {

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -502,7 +502,7 @@ describe('FetchTransport', () => {
       expect((requestInit.headers as Record<string, string>)['Content-Type']).toBe('application/json');
     });
 
-    it('is enabled by default', async () => {
+    it('is disabled by default', async () => {
       const transport = new FetchTransport({
         url: 'http://example.com/collect',
       });
@@ -515,8 +515,8 @@ describe('FetchTransport', () => {
       const callArgs = fetch.mock.calls[0] as unknown[];
       const requestInit = callArgs[1] as RequestInit;
 
-      expect(requestInit.body).toBeInstanceOf(Blob);
-      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBe('gzip');
+      expect(typeof requestInit.body).toBe('string');
+      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBeUndefined();
     });
 
     it('sends uncompressed body when disabled', async () => {

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -24,6 +24,40 @@ const fetch = jest.fn(() =>
 
 (global as any).fetch = fetch;
 
+// jsdom doesn't provide web stream globals — use Node's implementations
+const { ReadableStream: NodeReadableStream, WritableStream: NodeWritableStream } = require('node:stream/web');
+
+if (typeof globalThis.ReadableStream === 'undefined') {
+  (globalThis as any).ReadableStream = NodeReadableStream;
+}
+if (typeof globalThis.WritableStream === 'undefined') {
+  (globalThis as any).WritableStream = NodeWritableStream;
+}
+
+class MockCompressionStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+
+  constructor(_format: string) {
+    let controller: ReadableStreamDefaultController;
+    this.readable = new ReadableStream({
+      start(c) {
+        controller = c;
+      },
+    });
+    this.writable = new WritableStream({
+      write(chunk) {
+        controller.enqueue(chunk);
+      },
+      close() {
+        controller.close();
+      },
+    });
+  }
+}
+
+(global as any).CompressionStream = MockCompressionStream;
+
 const mockSessionId = '123';
 
 const item: TransportItem<LogEvent> = {
@@ -66,6 +100,7 @@ describe('FetchTransport', () => {
   it('will send event over fetch', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -90,6 +125,7 @@ describe('FetchTransport', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
       bufferSize: 3,
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -110,6 +146,7 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -144,6 +181,7 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -179,6 +217,7 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -210,6 +249,7 @@ describe('FetchTransport', () => {
   it('will turn off keepalive if the payload length is over 60_000', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -255,6 +295,7 @@ describe('FetchTransport', () => {
   it('will add static header values', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: 'Bearer static-token',
@@ -284,6 +325,7 @@ describe('FetchTransport', () => {
   it('will add dynamic header values from sync callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: () => `Bearer ${mockSessionId}-token`,
@@ -313,6 +355,7 @@ describe('FetchTransport', () => {
   it('will add static header values and dynamic header values from sync callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: () => `Bearer ${mockSessionId}-token`,
@@ -342,6 +385,7 @@ describe('FetchTransport', () => {
   it('will add dynamic header values from async callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: async () => Promise.resolve('Bearer async-token'),
@@ -386,6 +430,7 @@ describe('FetchTransport', () => {
 
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -414,6 +459,7 @@ describe('FetchTransport', () => {
 
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
+      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -432,5 +478,122 @@ describe('FetchTransport', () => {
     await transport.send([item]);
 
     expect(mockGetUserSessionUpdater).not.toHaveBeenCalled();
+  });
+
+  describe('requestCompression', () => {
+    it('sends compressed body with Content-Encoding header when enabled', async () => {
+      const transport = new FetchTransport({
+        url: 'http://example.com/collect',
+        requestCompression: true,
+      });
+
+      transport.metas.value = { session: { id: mockSessionId } };
+      transport.internalLogger = mockInternalLogger;
+
+      await transport.send([item]);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      const callArgs = fetch.mock.calls[0] as unknown[];
+      const requestInit = callArgs[1] as RequestInit;
+
+      expect(requestInit.body).toBeInstanceOf(Blob);
+      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBe('gzip');
+      expect((requestInit.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
+
+    it('is enabled by default', async () => {
+      const transport = new FetchTransport({
+        url: 'http://example.com/collect',
+      });
+
+      transport.metas.value = { session: { id: mockSessionId } };
+      transport.internalLogger = mockInternalLogger;
+
+      await transport.send([item]);
+
+      const callArgs = fetch.mock.calls[0] as unknown[];
+      const requestInit = callArgs[1] as RequestInit;
+
+      expect(requestInit.body).toBeInstanceOf(Blob);
+      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBe('gzip');
+    });
+
+    it('sends uncompressed body when disabled', async () => {
+      const transport = new FetchTransport({
+        url: 'http://example.com/collect',
+        requestCompression: false,
+      });
+
+      transport.metas.value = { session: { id: mockSessionId } };
+      transport.internalLogger = mockInternalLogger;
+
+      await transport.send([item]);
+
+      const callArgs = fetch.mock.calls[0] as unknown[];
+      const requestInit = callArgs[1] as RequestInit;
+
+      expect(typeof requestInit.body).toBe('string');
+      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBeUndefined();
+    });
+
+    it('falls back to uncompressed when CompressionStream is unavailable', async () => {
+      const original = (global as any).CompressionStream;
+      delete (global as any).CompressionStream;
+
+      try {
+        const transport = new FetchTransport({
+          url: 'http://example.com/collect',
+          requestCompression: true,
+        });
+
+        transport.metas.value = { session: { id: mockSessionId } };
+        transport.internalLogger = mockInternalLogger;
+
+        await transport.send([item]);
+
+        const callArgs = fetch.mock.calls[0] as unknown[];
+        const requestInit = callArgs[1] as RequestInit;
+
+        expect(typeof requestInit.body).toBe('string');
+        expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBeUndefined();
+      } finally {
+        (global as any).CompressionStream = original;
+      }
+    });
+
+    it('disables compression when CompressionStream is unavailable', () => {
+      const original = (global as any).CompressionStream;
+      delete (global as any).CompressionStream;
+
+      try {
+        const transport = new FetchTransport({
+          url: 'http://example.com/collect',
+          requestCompression: true,
+        });
+
+        expect((transport as any).compressionEnabled).toBe(false);
+      } finally {
+        (global as any).CompressionStream = original;
+      }
+    });
+
+    it('uses blob size for keepalive threshold when compressed', async () => {
+      const transport = new FetchTransport({
+        url: 'http://example.com/collect',
+        requestCompression: true,
+      });
+
+      transport.metas.value = { session: { id: mockSessionId } };
+      transport.internalLogger = mockInternalLogger;
+
+      await transport.send([largeItem]);
+
+      const callArgs = fetch.mock.calls[0] as unknown[];
+      const requestInit = callArgs[1] as RequestInit;
+      const blob = requestInit.body as Blob;
+
+      expect(requestInit.keepalive).toBe(blob.size <= 60000);
+    });
   });
 });

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -24,8 +24,12 @@ const fetch = jest.fn(() =>
 
 (global as any).fetch = fetch;
 
-// jsdom doesn't provide web stream globals — use Node's implementations
-const { ReadableStream: NodeReadableStream, WritableStream: NodeWritableStream } = require('node:stream/web');
+// jsdom doesn't provide web stream globals or Response — use Node's implementations
+const {
+  ReadableStream: NodeReadableStream,
+  WritableStream: NodeWritableStream,
+  CompressionStream: NodeCompressionStream,
+} = require('node:stream/web');
 
 if (typeof globalThis.ReadableStream === 'undefined') {
   (globalThis as any).ReadableStream = NodeReadableStream;
@@ -33,30 +37,9 @@ if (typeof globalThis.ReadableStream === 'undefined') {
 if (typeof globalThis.WritableStream === 'undefined') {
   (globalThis as any).WritableStream = NodeWritableStream;
 }
-
-class MockCompressionStream {
-  readable: ReadableStream;
-  writable: WritableStream;
-
-  constructor(_format: string) {
-    let controller: ReadableStreamDefaultController;
-    this.readable = new ReadableStream({
-      start(c) {
-        controller = c;
-      },
-    });
-    this.writable = new WritableStream({
-      write(chunk) {
-        controller.enqueue(chunk);
-      },
-      close() {
-        controller.close();
-      },
-    });
-  }
+if (typeof globalThis.CompressionStream === 'undefined') {
+  (globalThis as any).CompressionStream = NodeCompressionStream;
 }
-
-(global as any).CompressionStream = MockCompressionStream;
 
 const mockSessionId = '123';
 
@@ -100,7 +83,6 @@ describe('FetchTransport', () => {
   it('will send event over fetch', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -125,7 +107,6 @@ describe('FetchTransport', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
       bufferSize: 3,
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -146,7 +127,6 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -181,7 +161,6 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -217,7 +196,6 @@ describe('FetchTransport', () => {
       url: 'http://example.com/collect',
       defaultRateLimitBackoffMs: 1000,
       getNow: () => now,
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -249,7 +227,6 @@ describe('FetchTransport', () => {
   it('will turn off keepalive if the payload length is over 60_000', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -295,7 +272,6 @@ describe('FetchTransport', () => {
   it('will add static header values', () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: 'Bearer static-token',
@@ -325,7 +301,6 @@ describe('FetchTransport', () => {
   it('will add dynamic header values from sync callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: () => `Bearer ${mockSessionId}-token`,
@@ -355,7 +330,6 @@ describe('FetchTransport', () => {
   it('will add static header values and dynamic header values from sync callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: () => `Bearer ${mockSessionId}-token`,
@@ -385,7 +359,6 @@ describe('FetchTransport', () => {
   it('will add dynamic header values from async callbacks', async () => {
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
       requestOptions: {
         headers: {
           Authorization: async () => Promise.resolve('Bearer async-token'),
@@ -430,7 +403,6 @@ describe('FetchTransport', () => {
 
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -459,7 +431,6 @@ describe('FetchTransport', () => {
 
     const transport = new FetchTransport({
       url: 'http://example.com/collect',
-      requestCompression: false,
     });
 
     transport.metas.value = { session: { id: mockSessionId } };
@@ -502,27 +473,31 @@ describe('FetchTransport', () => {
       expect((requestInit.headers as Record<string, string>)['Content-Type']).toBe('application/json');
     });
 
+    it('produces valid gzip that decompresses to the original JSON', async () => {
+      const zlib = require('node:zlib');
+
+      const transport = new FetchTransport({
+        url: 'http://example.com/collect',
+        requestCompression: true,
+      });
+
+      const jsonBody = JSON.stringify(getTransportBody([item]));
+      const blob = await (transport as any).compress(jsonBody);
+
+      // jsdom's Blob lacks arrayBuffer/stream — use FileReader to extract bytes
+      const compressed = await new Promise<Buffer>((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(Buffer.from(reader.result as ArrayBuffer));
+        reader.readAsArrayBuffer(blob);
+      });
+      const decompressed = zlib.gunzipSync(compressed).toString('utf-8');
+
+      expect(JSON.parse(decompressed)).toEqual(getTransportBody([item]));
+    });
+
     it('is disabled by default', async () => {
       const transport = new FetchTransport({
         url: 'http://example.com/collect',
-      });
-
-      transport.metas.value = { session: { id: mockSessionId } };
-      transport.internalLogger = mockInternalLogger;
-
-      await transport.send([item]);
-
-      const callArgs = fetch.mock.calls[0] as unknown[];
-      const requestInit = callArgs[1] as RequestInit;
-
-      expect(typeof requestInit.body).toBe('string');
-      expect((requestInit.headers as Record<string, string>)['Content-Encoding']).toBeUndefined();
-    });
-
-    it('sends uncompressed body when disabled', async () => {
-      const transport = new FetchTransport({
-        url: 'http://example.com/collect',
-        requestCompression: false,
       });
 
       transport.metas.value = { session: { id: mockSessionId } };
@@ -578,7 +553,7 @@ describe('FetchTransport', () => {
       }
     });
 
-    it('uses blob size for keepalive threshold when compressed', async () => {
+    it('enables keepalive for large payloads that compress below the threshold', async () => {
       const transport = new FetchTransport({
         url: 'http://example.com/collect',
         requestCompression: true,
@@ -593,7 +568,8 @@ describe('FetchTransport', () => {
       const requestInit = callArgs[1] as RequestInit;
       const blob = requestInit.body as Blob;
 
-      expect(requestInit.keepalive).toBe(blob.size <= 60000);
+      expect(blob.size).toBeLessThan(60000);
+      expect(requestInit.keepalive).toBe(true);
     });
   });
 });

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -31,7 +31,7 @@ export class FetchTransport extends BaseTransport {
     this.rateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
     this.getNow = options.getNow ?? (() => Date.now());
 
-    const requestCompression = options.requestCompression ?? true;
+    const requestCompression = options.requestCompression ?? false;
 
     if (requestCompression && typeof CompressionStream === 'undefined') {
       this.compressionEnabled = false;

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -35,7 +35,9 @@ export class FetchTransport extends BaseTransport {
 
     if (requestCompression && typeof CompressionStream === 'undefined') {
       this.compressionEnabled = false;
-      this.logWarn('requestCompression is enabled but CompressionStream is not available. Falling back to uncompressed.');
+      this.logWarn(
+        'requestCompression is enabled but CompressionStream is not available. Falling back to uncompressed.'
+      );
     } else {
       this.compressionEnabled = requestCompression;
     }

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -31,7 +31,7 @@ export class FetchTransport extends BaseTransport {
     this.rateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
     this.getNow = options.getNow ?? (() => Date.now());
 
-    const requestCompression = options.requestCompression ?? false;
+    const requestCompression = options.requestCompression ?? true;
 
     if (requestCompression && typeof CompressionStream === 'undefined') {
       this.compressionEnabled = false;

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -22,6 +22,7 @@ export class FetchTransport extends BaseTransport {
 
   private readonly rateLimitBackoffMs: number;
   private readonly getNow: () => number;
+  private readonly compressionEnabled: boolean;
   private disabledUntil: Date = new Date(0);
 
   constructor(private options: FetchTransportOptions) {
@@ -29,6 +30,15 @@ export class FetchTransport extends BaseTransport {
 
     this.rateLimitBackoffMs = options.defaultRateLimitBackoffMs ?? DEFAULT_RATE_LIMIT_BACKOFF_MS;
     this.getNow = options.getNow ?? (() => Date.now());
+
+    const requestCompression = options.requestCompression ?? true;
+
+    if (requestCompression && typeof CompressionStream === 'undefined') {
+      this.compressionEnabled = false;
+      this.logWarn('requestCompression is enabled but CompressionStream is not available. Falling back to uncompressed.');
+    } else {
+      this.compressionEnabled = requestCompression;
+    }
 
     this.promiseBuffer = createPromiseBuffer({
       size: options.bufferSize ?? DEFAULT_BUFFER_SIZE,
@@ -45,7 +55,7 @@ export class FetchTransport extends BaseTransport {
       }
 
       await this.promiseBuffer.add(async () => {
-        const body = JSON.stringify(getTransportBody(items));
+        const jsonBody = JSON.stringify(getTransportBody(items));
 
         const { url, requestOptions, apiKey } = this.options;
 
@@ -62,16 +72,27 @@ export class FetchTransport extends BaseTransport {
           resolvedHeaders[key] = typeof value === 'function' ? await Promise.resolve(value()) : value;
         }
 
+        let body: string | Blob = jsonBody;
+        let bodySize = jsonBody.length;
+        const compressionHeaders: Record<string, string> = {};
+
+        if (this.compressionEnabled) {
+          body = await this.compress(jsonBody);
+          bodySize = body.size;
+          compressionHeaders['Content-Encoding'] = 'gzip';
+        }
+
         return fetch(url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...compressionHeaders,
             ...resolvedHeaders,
             ...(apiKey ? { 'x-api-key': apiKey } : {}),
             ...(sessionId ? { 'x-faro-session-id': sessionId } : {}),
           },
           body,
-          keepalive: body.length <= BEACON_BODY_SIZE_LIMIT,
+          keepalive: bodySize <= BEACON_BODY_SIZE_LIMIT,
           ...(restOfRequestOptions ?? {}),
         })
           .then(async (response) => {
@@ -93,7 +114,7 @@ export class FetchTransport extends BaseTransport {
             return response;
           })
           .catch((err) => {
-            this.logError('Failed sending payload to the receiver\n', JSON.parse(body), err);
+            this.logError('Failed sending payload to the receiver\n', JSON.parse(jsonBody), err);
           });
       });
     } catch (err) {
@@ -128,6 +149,31 @@ export class FetchTransport extends BaseTransport {
     }
 
     return new Date(now + this.rateLimitBackoffMs);
+  }
+
+  private async compress(body: string): Promise<Blob> {
+    const encoder = new TextEncoder();
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+    const compressedStream = inputStream.pipeThrough(new CompressionStream('gzip'));
+    const reader = compressedStream.getReader();
+    const chunks: BlobPart[] = [];
+
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      chunks.push(value);
+    }
+
+    return new Blob(chunks);
   }
 
   private extendFaroSession(config: Config, logDebug: BaseExtension['logDebug']) {

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -154,27 +154,22 @@ export class FetchTransport extends BaseTransport {
   }
 
   private async compress(body: string): Promise<Blob> {
-    const encoder = new TextEncoder();
-    const inputStream = new ReadableStream({
+    const stream = new ReadableStream({
       start(controller) {
-        controller.enqueue(encoder.encode(body));
+        controller.enqueue(new TextEncoder().encode(body));
         controller.close();
       },
-    });
-    const compressedStream = inputStream.pipeThrough(new CompressionStream('gzip'));
-    const reader = compressedStream.getReader();
-    const chunks: BlobPart[] = [];
+    }).pipeThrough(new CompressionStream('gzip'));
 
+    const reader = stream.getReader();
+    const chunks: BlobPart[] = [];
     for (;;) {
       const { done, value } = await reader.read();
-
       if (done) {
         break;
       }
-
       chunks.push(value);
     }
-
     return new Blob(chunks);
   }
 

--- a/packages/web-sdk/src/transports/fetch/types.ts
+++ b/packages/web-sdk/src/transports/fetch/types.ts
@@ -27,6 +27,9 @@ export interface FetchTransportOptions {
   getNow?: ClockFn;
   // addition options for global.Fetch
   requestOptions?: FetchTransportRequestOptions;
+  // compress request bodies with gzip using the native CompressionStream API.
+  // falls back to uncompressed if CompressionStream is not available.
+  requestCompression?: boolean;
 }
 
 export type ClockFn = () => number;


### PR DESCRIPTION
## Summary

- Adds `requestCompression` option to `FetchTransport` that gzip-compresses request bodies using the native `CompressionStream` API
- Defaults to `false` — opt-in to avoid breaking self-hosted collectors or custom endpoints that don't handle gzip request bodies
- Falls back to uncompressed with a warning when `CompressionStream` is unavailable (older browsers)
- Zero bundle size cost — uses native browser API, no new dependencies

## Compression results

Tested across 17 example sites spanning Angular, React, Vue, Svelte, Next.js, Nuxt, Remix, and Lit. Each site ran identical 60-second deterministic browsing sessions — once with `CompressionStream` disabled (baseline) and once with gzip enabled. A logging proxy captured every `/collect/` payload to compare sizes.

**78% median payload reduction (range: 55–86%)**

Most frameworks clustered around 75–82% savings. Sites with larger DOM trees (e.g. Ant Design) saw up to 86%. The lowest was 55% (Vuetify). Canvas-heavy sites with base64 rrweb snapshots saw 93%+ reduction but were excluded as outliers.

> **Note:** This testing was with session replay enabled, which produces the largest Faro payloads. Regular Faro payloads (logs, errors, measurements, traces) will also benefit from compression but are much smaller, so the absolute savings will be less significant.

## How to enable

The Grafana Cloud Faro collector already supports `Content-Encoding: gzip` on incoming requests, so cloud users can enable this immediately:

```ts
initializeFaro({
  url: '...',
  requestCompression: true,
});
```

Self-hosted collectors or custom endpoints should verify they handle gzip request bodies before enabling.

## How it works

After `JSON.stringify()` produces the body, if compression is enabled the body is piped through `CompressionStream('gzip')` and sent as a `Blob` with `Content-Encoding: gzip`. The `Blob.size` is used for the keepalive threshold check (60KB), meaning compressed payloads are more likely to qualify for keepalive — a side benefit for page-unload reliability.