### PR TITLE
feat(instrumentation-replay): add optional @rrweb/packer support

### DIFF
--- a/experimental/instrumentation-replay/package.json
+++ b/experimental/instrumentation-replay/package.json
@@ -55,6 +55,14 @@
     "@grafana/faro-core": "^2.4.0",
     "rrweb": "^2.0.0-alpha.18"
   },
+  "peerDependencies": {
+    "@rrweb/packer": "^2.0.0-alpha.18"
+  },
+  "peerDependenciesMeta": {
+    "@rrweb/packer": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/experimental/instrumentation-replay/src/const.ts
+++ b/experimental/instrumentation-replay/src/const.ts
@@ -16,5 +16,6 @@ export const defaultReplayInstrumentationOptions: ReplayInstrumentationOptions =
   recordCrossOriginIframes: false,
   beforeSend: undefined,
   recordAfter: 'load',
+  pack: false,
   samplingRate: 1,
 };

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -69,6 +69,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: undefined,
         ignoreSelector: undefined,
         beforeSend: undefined,
+        pack: false,
         samplingRate: 1,
       };
 
@@ -95,6 +96,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: '.block-me',
         ignoreSelector: '.ignore-me',
         beforeSend: beforeSendFn,
+        pack: false,
         samplingRate: 1,
       };
 
@@ -132,6 +134,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: undefined,
         ignoreSelector: undefined,
         beforeSend: undefined,
+        pack: false,
         samplingRate: 1,
       };
 
@@ -420,6 +423,116 @@ describe('ReplayInstrumentation', () => {
 
       expect(() => emitCallback({ type: 1, data: {}, timestamp: Date.now() })).not.toThrow();
       expect(logWarnSpy).toHaveBeenCalledWith('Failed to push faro.session_recording.event event', expect.any(Error));
+    });
+  });
+
+  describe('pack', () => {
+    let emitCallback: (event: any, isCheckout?: boolean) => void;
+
+    beforeEach(() => {
+      mockRecord.mockImplementation((opts) => {
+        emitCallback = opts.emit;
+        return jest.fn();
+      });
+    });
+
+    it('should use packFn to serialize events when packFn is set', () => {
+      const mockPack = jest.fn((event) => `packed:${JSON.stringify(event)}`);
+      instrumentation = new ReplayInstrumentation({ pack: true });
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['packFn'] = mockPack;
+
+      instrumentation.initialize();
+
+      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
+      emitCallback(testEvent);
+
+      expect(mockPack).toHaveBeenCalledWith(testEvent);
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
+        event: `packed:${JSON.stringify(testEvent)}`,
+      });
+    });
+
+    it('should warn and fall back to JSON.stringify when @rrweb/packer is not installed', async () => {
+      instrumentation = new ReplayInstrumentation({ pack: true });
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
+
+      instrumentation.initialize();
+      // startRecording is async when pack:true — wait for the dynamic import to resolve/reject
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(logWarnSpy).toHaveBeenCalledWith(
+        '@rrweb/packer is not installed. Install it to enable replay event compression.'
+      );
+
+      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
+      emitCallback(testEvent);
+
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
+        event: JSON.stringify(testEvent),
+      });
+    });
+
+    it('should apply beforeSend before packing', () => {
+      const mockPack = jest.fn((event) => `packed:${JSON.stringify(event)}`);
+      const beforeSend = jest.fn((event) => ({ ...event, modified: true }));
+      instrumentation = new ReplayInstrumentation({ pack: true, beforeSend });
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['packFn'] = mockPack;
+
+      instrumentation.initialize();
+
+      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
+      emitCallback(testEvent);
+
+      expect(beforeSend).toHaveBeenCalledWith(testEvent);
+      expect(mockPack).toHaveBeenCalledWith({ ...testEvent, modified: true });
+    });
+
+    it('should not send event when beforeSend returns null with pack enabled', () => {
+      const mockPack = jest.fn((event) => `packed:${JSON.stringify(event)}`);
+      const beforeSend = jest.fn(() => null);
+      instrumentation = new ReplayInstrumentation({ pack: true, beforeSend });
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['packFn'] = mockPack;
+
+      instrumentation.initialize();
+
+      emitCallback({ type: 1, data: {}, timestamp: Date.now() });
+
+      expect(mockPack).not.toHaveBeenCalled();
+      expect(mockPushEvent).not.toHaveBeenCalledWith('faro.session_recording.event', expect.anything());
+    });
+
+    it('should use JSON.stringify when pack is false (default)', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
+      emitCallback(testEvent);
+
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
+        event: JSON.stringify(testEvent),
+      });
     });
   });
 

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -16,6 +16,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   private stopFn: { (): void } | null = null;
   private isRecording: boolean = false;
   private options: ReplayInstrumentationOptions = defaultReplayInstrumentationOptions;
+  private packFn: ((event: eventWithTime) => string) | null = null;
 
   constructor(options: ReplayInstrumentationOptions = {}) {
     super();
@@ -110,8 +111,16 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     this.logDebug('Session replay stopped');
   }
 
-  private startRecording(): void {
+  private async startRecording(): Promise<void> {
     try {
+      if (this.options.pack && !this.packFn) {
+        try {
+          const { pack } = await import('@rrweb/packer');
+          this.packFn = pack;
+        } catch {
+          this.logWarn('@rrweb/packer is not installed. Install it to enable replay event compression.');
+        }
+      }
       const opts: recordOptions<eventWithTime> = {
         emit: (event: eventWithTime, isCheckout?: boolean): void => {
           this.handleEvent(event, isCheckout);
@@ -159,8 +168,10 @@ export class ReplayInstrumentation extends BaseInstrumentation {
         }
       }
 
+      const serialized = this.packFn ? this.packFn(processedEvent) : JSON.stringify(processedEvent);
+
       this.api.pushEvent(faroSessionReplayEventName, {
-        event: JSON.stringify(processedEvent),
+        event: serialized,
       });
     } catch (err) {
       this.logWarn(`Failed to push ${faroSessionReplayEventName} event`, err);

--- a/experimental/instrumentation-replay/src/rrweb-packer.d.ts
+++ b/experimental/instrumentation-replay/src/rrweb-packer.d.ts
@@ -1,0 +1,5 @@
+declare module '@rrweb/packer' {
+  import type { eventWithTime } from '@rrweb/types';
+  export function pack(event: eventWithTime): string;
+  export function unpack(raw: string): eventWithTime;
+}

--- a/experimental/instrumentation-replay/src/types.ts
+++ b/experimental/instrumentation-replay/src/types.ts
@@ -81,6 +81,13 @@ export interface ReplayInstrumentationOptions {
   recordAfter?: 'DOMContentLoaded' | 'load';
 
   /**
+   * Whether to compress replay events using @rrweb/packer before sending.
+   * Requires @rrweb/packer to be installed as a peer dependency.
+   * @default false
+   */
+  pack?: boolean;
+
+  /**
    * The fraction of globally-sampled sessions that should also record a session replay.
    * Expressed as a number between 0 and 1.
    *

--- a/experimental/instrumentation-replay/tsconfig.esm.json
+++ b/experimental/instrumentation-replay/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.esm.json",
   "compilerOptions": {
+    "module": "ES2022",
     "declarationDir": "./dist/types",
     "outDir": "./dist/esm",
     "rootDir": "./src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,6 +958,11 @@ __metadata:
   dependencies:
     "@grafana/faro-core": "npm:^2.4.0"
     rrweb: "npm:^2.0.0-alpha.18"
+  peerDependencies:
+    "@rrweb/packer": ^2.0.0-alpha.18
+  peerDependenciesMeta:
+    "@rrweb/packer":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Adds `pack: boolean` option to `ReplayInstrumentationOptions` (default `false`)
- When enabled, dynamically imports `@rrweb/packer` to compress individual replay events before sending
- Falls back to `JSON.stringify` with a warning if the optional peer dependency is not installed
- Packing is applied **after** `beforeSend` in `handleEvent()`, not via rrweb's built-in `packFn` (which would compress before the emit callback and break the `beforeSend` transform/filter API)
- `@rrweb/packer` is declared as an optional peer dependency — zero bundle cost when unused

Closes #1992

### Usage

```bash
npm install @rrweb/packer@^2.0.0-alpha.18
```

```typescript
new ReplayInstrumentation({ pack: true })
```

### Note

This is an alternative to transport-level gzip compression (#2028). We're evaluating both approaches to compare payload size reduction. See #2028 for context on why transport-level gzip may be the better solution for most use cases.

## Test plan

- [x] Existing tests pass (34 total)
- [x] Build succeeds (CJS, ESM, bundle)
- [ ] Compare payload sizes: no compression vs packer vs transport gzip vs both combined
- [ ] Verify `beforeSend` still works correctly with packing enabled
- [ ] Test graceful fallback when `@rrweb/packer` is not installed