### PR TITLE
feat(docs): smoke-test release-please workflow

### DIFF
--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -53,6 +53,13 @@ Review and merge it when you're ready to ship.
   do not hand-edit unless recovering from a broken state).
 - `.github/workflows/release-please.yml` — the workflow itself.
 
+## Verifying the workflow
+
+After landing a `feat:` or `fix:` commit on `main`, the Release PR should
+appear or update within a couple of minutes. If it does not, check the
+`release-please.yml` run on the merge commit for token-mint or permission
+errors.
+
 ## Skipping a release
 
 If you want to merge changes without ever publishing them, use commit types that


### PR DESCRIPTION
## Summary

Smoke test for the release-please workflow introduced in #2023.

This PR uses a `feat(docs):` conventional commit so that, once merged, release-please should:

1. Run `.github/workflows/release-please.yml` on the merge commit
2. Open (or update) a Release PR proposing a minor version bump (2.5.0 → 2.6.0) across all 6 publishable packages
3. Update root `CHANGELOG.md` with this commit's message

## Validation steps after merge

- [ ] `release-please.yml` run succeeds (no token-mint / permission errors)
- [ ] Release PR appears proposing 2.6.0
- [ ] Release PR updates `.release-please-manifest.json`, all `package.json` files, and root `CHANGELOG.md`

## Note

This is intentionally a doc-only change labelled `feat:` purely to exercise the minor-bump path. The CHANGELOG entry can be cleaned up (or this PR reverted post-validation) before any real release goes out.