### PR TITLE
fix(demo): use `grafana server` subcommand for Grafana 13 image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,8 @@ services:
       - '${GRAFANA_PLUGINS_PATH_LOCAL}:${GRAFANA_PLUGINS_PATH}'
       - '${GRAFANA_PLUGINS_PROVISIONING_PATH_LOCAL}:${GRAFANA_PLUGINS_PROVISIONING_PATH}'
     entrypoint:
-      - '${GRAFANA_HOME_PATH}/bin/grafana-server'
+      - '${GRAFANA_HOME_PATH}/bin/grafana'
+      - 'server'
       - '--homepath=${GRAFANA_HOME_PATH}'
       - '--config=${GRAFANA_CONFIG_PATH}/${GRAFANA_CONFIG_FILE}'
     ports:


### PR DESCRIPTION
## Why

Since #2002 bumped the demo's Grafana image to `grafana/grafana:13.0.1`, the Grafana container fails to start because Grafana 13 dropped the `bin/grafana-server` binary in favour of `bin/grafana` with a `server` subcommand. As a result, `docker compose --profile demo up -d` never brings Grafana up.

## What

Switch the entrypoint in `docker-compose.yaml` to invoke `${GRAFANA_HOME_PATH}/bin/grafana server` instead of the (now non-existent) `${GRAFANA_HOME_PATH}/bin/grafana-server`. The CLI flags (`--homepath`, `--config`) are unchanged.

Verified locally:
- `docker compose --profile demo up -d` brings up all 7 containers cleanly.
- `curl -s http://localhost:3000/api/health` returns `{"database":"ok","version":"13.0.1",...}`.
- The demo app loads at http://localhost:5173.
- Posting a beacon to `http://localhost:8027/collect` returns HTTP 202 and the log lands in Loki under `{app="@grafana/faro-demo-client"}`.

## Links

Closes #2034

## Checklist

- [ ] Tests added — N/A (docker-compose entrypoint fix; no test harness applicable)
- [x] Changelog updated — handled by `release-please` via the conventional commit message
- [ ] Documentation updated — N/A