### PR TITLE
fix(demo): drop unused Mimir ruler config to prevent startup failure

### DIFF
--- a/infra/mimir/config/config.yaml
+++ b/infra/mimir/config/config.yaml
@@ -37,15 +37,6 @@ limits:
   ingestion_burst_size: 500000
   ingestion_rate: 250000
 multitenancy_enabled: false
-ruler:
-  enable_api: true
-  rule_path: /rules
-ruler_storage:
-  backend: local
-  filesystem:
-    dir: ''
-  local:
-    directory: /tmp/mimir/rules
 server:
   grpc_server_max_concurrent_streams: 1000
   grpc_server_max_recv_msg_size: 104857600


### PR DESCRIPTION
## Why

The demo's Mimir container exits 1 about 30 seconds after start because the `ruler` module fails its initial sync. `ruler_storage` is configured with `backend: local` and `directory: /tmp/mimir/rules`, but that directory does not exist on container start, and the ruler does not create it.

#1953 originally reported the symptom-level `failed services / (*Mimir).Run` log; the underlying cause is one line earlier:

```
caller=mimir.go:1062 level=error msg="module failed" module=ruler
err="… unable to read dir /tmp/mimir/rules: open /tmp/mimir/rules: no such file or directory"
```

Because Mimir then exits, Alloy's `prometheus.remote_write.metrics_write` fails for the rest of the demo's lifetime with `dial tcp: lookup mimir on 127.0.0.11:53: no such host`, so no metrics are collected.

## What

Drop the `ruler` and `ruler_storage` blocks from `infra/mimir/config/config.yaml`. The demo doesn't exercise alert rules, so the cleanest fix is to not start the ruler at all. Mimir then logs `The ruler storage has not been configured. Not starting the ruler.` on boot and the rest of monolithic mode comes up normally.

Verified locally on `main` + this branch:

- `docker compose --profile demo up -d` brings Mimir up, and `faro-sample-mimir-1` stays `Up` indefinitely (previously `Exited (1)` at ~30s).
- Mimir log: `caller=mimir.go:1045 level=info msg="Application started"`; no `module failed` / `failed services`.
- `curl -s http://localhost:9009/api/v1/status/buildinfo` returns 200 with `{"application":"Grafana Mimir","version":"3.0.6",...}`.
- Alloy log: zero `lookup mimir on 127.0.0.11:53: no such host` errors over 9 minutes of uptime.

## Links

Closes #1953

## Checklist

- [ ] Tests added — N/A (Mimir config fix; no test harness applicable)
- [x] Changelog updated — handled by `release-please` via the conventional commit message
- [ ] Documentation updated — N/A