### PR TITLE
fix(demo): bind Tempo OTLP receiver to 0.0.0.0 so Alloy can reach it

### DIFF
--- a/infra/tempo/config/tempo.yaml
+++ b/infra/tempo/config/tempo.yaml
@@ -15,7 +15,9 @@ distributor:
     otlp:
       protocols:
         http:
+          endpoint: '0.0.0.0:4318'
         grpc:
+          endpoint: '0.0.0.0:4317'
     opencensus:
 
 ingester:


### PR DESCRIPTION
## Why

Tempo 2.x embeds the OpenTelemetry Collector OTLP receiver. The default bind address for that receiver shifted from `0.0.0.0` to `localhost` after upstream OTel Collector marked the `UseLocalHostAsDefaultHost` feature gate stable in [v0.110.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.110.0). Tempo's own [v2.7.0 CHANGELOG](https://github.com/grafana/tempo/blob/main/CHANGELOG.md) calls this out explicitly:

> After this update the Open-Telemetry Collector receiver will connect to `localhost` instead of all interfaces `0.0.0.0`. Due to this, Tempo installations running inside Docker have to update the address they listen.

`infra/tempo/config/tempo.yaml` has no `endpoint:` set under the OTLP receiver, so Tempo 2.10.5 inherits the new default and listens only on the container's loopback interface:

```
Starting GRPC server   component=tempo endpoint=127.0.0.1:4317
Starting HTTP server   component=tempo endpoint=127.0.0.1:4318
```

The Alloy container on the same Docker network therefore cannot reach Tempo, and every trace forwarded by `otelcol.exporter.otlp.trace_write` fails with `dial tcp <tempo-ip>:4317: connect: connection refused`. All FaRo-collected traces are dropped before reaching Tempo.

## What

Set the OTLP receiver endpoints explicitly to `0.0.0.0:4317` (gRPC) and `0.0.0.0:4318` (HTTP) in `infra/tempo/config/tempo.yaml`, restoring sibling-container reachability.

Tempo log after the fix:

```
Starting GRPC server   component=tempo endpoint=[::]:4317
Starting HTTP server   component=tempo endpoint=[::]:4318
```

Verified locally on `main` + this branch:

- TCP probe from a sibling container on the demo's Docker network succeeds for both ports:
  ```
  $ docker run --rm --network faro-sample_default alpine \
      sh -c 'nc -zv tempo 4317 && nc -zv tempo 4318'
  tempo (172.19.0.4:4317) open
  tempo (172.19.0.4:4318) open
  ```
- Alloy log: zero `connection refused` errors over 9 minutes of uptime.
- `docker compose --profile demo up -d` brings up all 7 containers cleanly when this fix is combined with #2035 and the fix for #1953.

The pre-existing Tempo startup warnings (`v2_index_downsample_bytes is set` and `Inline, unscoped overrides are deprecated`) noted in the issue are intentionally left out of this PR to keep the diff focused on the bind issue. Happy to address them in a separate PR.

## Links

Closes #2036

## Checklist

- [ ] Tests added — N/A (Tempo config fix; no test harness applicable)
- [x] Changelog updated — handled by `release-please` via the conventional commit message
- [ ] Documentation updated — N/A