### PR TITLE
feat(core): include git commit hash in app meta

### DIFF
--- a/packages/core/src/metas/initialize.test.ts
+++ b/packages/core/src/metas/initialize.test.ts
@@ -21,7 +21,9 @@ describe('metas', () => {
   it('preserves config.app.gitHash when global __faroGitHash is absent', () => {
     delete (global as any).__faroGitHash_test;
 
-    const { metas } = initializeFaro(mockConfig({ app: { name: 'test', version: '1.0.0', gitHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' } }));
+    const { metas } = initializeFaro(
+      mockConfig({ app: { name: 'test', version: '1.0.0', gitHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' } })
+    );
     expect(metas.value.app?.gitHash).toEqual('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
   });
 

--- a/packages/core/src/metas/initialize.test.ts
+++ b/packages/core/src/metas/initialize.test.ts
@@ -2,6 +2,22 @@ import { initializeFaro } from '../initialize';
 import { mockConfig } from '../testUtils';
 
 describe('metas', () => {
+  it('sets app.gitHash from global object on initialization', () => {
+    (global as any).__faroGitHash_test = 'abc123def456abc123def456abc123def456abc1';
+
+    const { metas } = initializeFaro(mockConfig());
+    expect(metas.value.app?.gitHash).toEqual('abc123def456abc123def456abc123def456abc1');
+
+    delete (global as any).__faroGitHash_test;
+  });
+
+  it('leaves app.gitHash undefined when global is not set', () => {
+    delete (global as any).__faroGitHash_test;
+
+    const { metas } = initializeFaro(mockConfig());
+    expect(metas.value.app?.gitHash).toBeUndefined();
+  });
+
   it('can set listeners and they will be notified on meta changes', () => {
     const { metas } = initializeFaro(mockConfig());
 

--- a/packages/core/src/metas/initialize.test.ts
+++ b/packages/core/src/metas/initialize.test.ts
@@ -18,6 +18,13 @@ describe('metas', () => {
     expect(metas.value.app?.gitHash).toBeUndefined();
   });
 
+  it('preserves config.app.gitHash when global __faroGitHash is absent', () => {
+    delete (global as any).__faroGitHash_test;
+
+    const { metas } = initializeFaro(mockConfig({ app: { name: 'test', version: '1.0.0', gitHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' } }));
+    expect(metas.value.app?.gitHash).toEqual('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
+  });
+
   it('can set listeners and they will be notified on meta changes', () => {
     const { metas } = initializeFaro(mockConfig());
 

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -5,14 +5,17 @@ import { VERSION } from '../version';
 import type { Meta } from './types';
 
 export function registerInitialMetas(faro: Faro): void {
+  const appName = faro.config.app.name;
+  const gitHash = appName ? getGitHash(appName) : undefined;
+
   const initial: Meta = {
     sdk: {
       version: VERSION,
       name: 'faro',
     },
     app: {
-      bundleId: faro.config.app.name && getBundleId(faro.config.app.name),
-      gitHash: faro.config.app.name && getGitHash(faro.config.app.name),
+      bundleId: appName && getBundleId(appName),
+      ...(gitHash !== undefined ? { gitHash } : {}),
     },
   };
 

--- a/packages/core/src/metas/registerInitial.ts
+++ b/packages/core/src/metas/registerInitial.ts
@@ -1,5 +1,5 @@
 import type { Faro } from '../sdk';
-import { getBundleId } from '../utils/sourceMaps';
+import { getBundleId, getGitHash } from '../utils/sourceMaps';
 import { VERSION } from '../version';
 
 import type { Meta } from './types';
@@ -12,6 +12,7 @@ export function registerInitialMetas(faro: Faro): void {
     },
     app: {
       bundleId: faro.config.app.name && getBundleId(faro.config.app.name),
+      gitHash: faro.config.app.name && getGitHash(faro.config.app.name),
     },
   };
 

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -27,6 +27,7 @@ export interface MetaSDK {
 
 export interface MetaApp {
   bundleId?: string;
+  gitHash?: string;
   environment?: string;
   installationId?: string;
   name?: string;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -48,7 +48,7 @@ export type { BufferItem, PromiseBuffer, PromiseBufferOptions, PromiseProducer }
 
 export { genShortID } from './shortId';
 
-export { getBundleId } from './sourceMaps';
+export { getBundleId, getGitHash } from './sourceMaps';
 
 export { dateNow, monoNow } from './date';
 

--- a/packages/core/src/utils/sourceMaps.test.ts
+++ b/packages/core/src/utils/sourceMaps.test.ts
@@ -1,12 +1,14 @@
-import { getBundleId } from './sourceMaps';
+import { getBundleId, getGitHash } from './sourceMaps';
 
 describe('sourceMapUpload utils', () => {
   beforeAll(() => {
     delete (global as any).__faroBundleId_foo;
+    delete (global as any).__faroGitHash_foo;
   });
 
   afterAll(() => {
     delete (global as any).__faroBundleId_foo;
+    delete (global as any).__faroGitHash_foo;
   });
 
   it('can get the bundle ID from the global object', () => {
@@ -14,5 +16,14 @@ describe('sourceMapUpload utils', () => {
 
     (global as any).__faroBundleId_foo = 'bar';
     expect(getBundleId('foo')).toEqual('bar');
+  });
+
+  it('returns undefined for git hash when not set', () => {
+    expect(getGitHash('foo')).toBeUndefined();
+  });
+
+  it('can get the git hash from the global object', () => {
+    (global as any).__faroGitHash_foo = 'abc123def456abc123def456abc123def456abc1';
+    expect(getGitHash('foo')).toEqual('abc123def456abc123def456abc123def456abc1');
   });
 });

--- a/packages/core/src/utils/sourceMaps.ts
+++ b/packages/core/src/utils/sourceMaps.ts
@@ -3,3 +3,7 @@ import { globalObject } from '../globalObject';
 export function getBundleId(appName: string): string | undefined {
   return (globalObject as any)?.[`__faroBundleId_${appName}`];
 }
+
+export function getGitHash(appName: string): string | undefined {
+  return (globalObject as any)?.[`__faroGitHash_${appName}`];
+}


### PR DESCRIPTION
## Summary

- Adds `getGitHash(appName)` to `core/src/utils/sourceMaps.ts` — reads `window.__faroGitHash_<appName>` from the global object, mirrors the existing `getBundleId` pattern exactly
- Adds `gitHash?: string` to `MetaApp` in `core/src/metas/types.ts`
- `registerInitialMetas` now calls `getGitHash` and sets `app.gitHash`, so every telemetry payload carries the commit hash

The git hash itself is injected at build time by the bundler plugins. Companion PR: https://github.com/grafana/faro-javascript-bundler-plugins/pull/533

## Test plan

- [ ] Initialize Faro in an app built with the companion bundler plugin PR — confirm `app.gitHash` is present in the meta and appears in telemetry payloads
- [ ] Initialize Faro in an app without the bundler plugin (no `window.__faroGitHash_*`) — confirm `app.gitHash` is `undefined` and no error is thrown