### PR TITLE
fix(ci): correct release-please changelog-path to unblock release flow

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "changelog-path": "CHANGELOG.md",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "separate-pull-requests": false,
@@ -12,48 +13,34 @@
   "plugins": [
     {
       "type": "linked-versions",
-      "groupName": "faro",
-      "components": [
-        "@grafana/faro-core",
-        "@grafana/faro-web-sdk",
-        "@grafana/faro-web-tracing",
-        "@grafana/faro-react",
-        "@grafana/faro-instrumentation-replay",
-        "@grafana/faro-transport-otlp-http"
-      ]
+      "groupName": "faro"
     },
     "node-workspace"
   ],
   "packages": {
     "packages/core": {
       "package-name": "@grafana/faro-core",
-      "component": "@grafana/faro-core",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-core"
     },
     "packages/web-sdk": {
       "package-name": "@grafana/faro-web-sdk",
-      "component": "@grafana/faro-web-sdk",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-web-sdk"
     },
     "packages/web-tracing": {
       "package-name": "@grafana/faro-web-tracing",
-      "component": "@grafana/faro-web-tracing",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-web-tracing"
     },
     "packages/react": {
       "package-name": "@grafana/faro-react",
-      "component": "@grafana/faro-react",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-react"
     },
     "experimental/instrumentation-replay": {
       "package-name": "@grafana/faro-instrumentation-replay",
-      "component": "@grafana/faro-instrumentation-replay",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-instrumentation-replay"
     },
     "experimental/transport-otlp-http": {
       "package-name": "@grafana/faro-transport-otlp-http",
-      "component": "@grafana/faro-transport-otlp-http",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "@grafana/faro-transport-otlp-http"
     }
   }
 }


### PR DESCRIPTION
## Why

The `Release please` workflow has been failing on every push to `main` since PR #2023 introduced release-please.

Failing run: https://github.com/grafana/faro-web-sdk/actions/runs/25482676993/job/75002074144

```
release-please failed: illegal pathing characters in path: packages/core/../../CHANGELOG.md
```

release-please v17 rejects `..` segments in per-package `changelog-path`. The current config sets `"changelog-path": "../../CHANGELOG.md"` on each of the 6 packages to point at a single root changelog, which trips the path validator and aborts the run before the release PR is built.

## What

Single-file change in `release-please-config.json`:

- Add a top-level `"changelog-path": "CHANGELOG.md"` (resolved from the repo root, no `..`). All packages now write into the single root `CHANGELOG.md`, preserving the original intent.
- Remove the six per-package `"changelog-path": "../../CHANGELOG.md"` overrides.
- Tighten the `linked-versions` plugin to `{ "type": "linked-versions", "groupName": "faro" }`. The previous explicit `components` array produced harmless but noisy `⚠ Multiple paths for ___` warnings; the plugin already links every package in the `packages` map by default.

No changes to the workflow, manifest, or `deployment_tools` Vault/GitHub App config — the failing run shows token mint, Vault auth, and API access all working end-to-end. The failure is config-only.

After this lands, the next push to `main` will trigger the workflow with the corrected config; release-please walks from `v2.5.0` to `HEAD` and should open its first release PR (likely `chore(main): release ...`).

## Links

Closes #2044

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated