### PR TITLE
fix(ci): consolidate release-please into single changelog and unblock release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,3 +40,51 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      # release-please rewrites cross-package dep ranges in package.json (e.g.
+      # `@grafana/faro-core` from `^2.5.0` to `^2.6.0`) but does not touch
+      # yarn.lock. CI runs `yarn install --frozen-lockfile`, which fails on the
+      # release PR because the resolution would change. Refresh yarn.lock on
+      # the release branch so CI passes.
+      - name: Resolve release PR branch
+        id: release-branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          BRANCH="$(echo "$PR_JSON" | jq -r '.headBranchName')"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.release-branch.outputs.branch }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Refresh yarn.lock on release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        run: |
+          set -euo pipefail
+          corepack enable
+          # --mode update-lockfile rewrites yarn.lock without installing.
+          yarn install --mode update-lockfile
+          if git diff --quiet -- yarn.lock; then
+            echo "yarn.lock already in sync."
+            exit 0
+          fi
+          # Match the identity the release-please-action uses for its commits
+          # on the same branch, so the lockfile commit appears as the same bot.
+          git config user.name 'app-o11y-kwl-ci[bot]'
+          git config user.email 'app-o11y-kwl-ci[bot]@users.noreply.github.com'
+          git add yarn.lock
+          git commit -m 'chore: update yarn.lock for release'
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,10 @@ jobs:
       - name: Install npm latest version #needed for Trusted Publishing
         run: npm install -g npm@latest
 
+      # `from-package` reads versions from each `package.json` and publishes
+      # any version not already present on npm. release-please tags the repo
+      # with a single `v<version>` tag, so the previous `from-git` flow (which
+      # expects per-package `<name>@<version>` tags from `lerna version`)
+      # would publish nothing.
       - name: Publish package to NPM
-        run: npm run publish -- from-git --yes
+        run: npm run publish -- from-package --yes

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,3 @@
 {
-  "packages/core": "2.5.0",
-  "packages/web-sdk": "2.5.0",
-  "packages/web-tracing": "2.5.0",
-  "packages/react": "2.5.0",
-  "experimental/instrumentation-replay": "2.5.0",
-  "experimental/transport-otlp-http": "2.5.0"
+  ".": "2.5.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "changelog-path": "CHANGELOG.md",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "separate-pull-requests": false,
@@ -10,37 +9,49 @@
   "draft": false,
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "faro"
-    },
-    "node-workspace"
-  ],
   "packages": {
-    "packages/core": {
-      "package-name": "@grafana/faro-core",
-      "component": "@grafana/faro-core"
-    },
-    "packages/web-sdk": {
-      "package-name": "@grafana/faro-web-sdk",
-      "component": "@grafana/faro-web-sdk"
-    },
-    "packages/web-tracing": {
-      "package-name": "@grafana/faro-web-tracing",
-      "component": "@grafana/faro-web-tracing"
-    },
-    "packages/react": {
-      "package-name": "@grafana/faro-react",
-      "component": "@grafana/faro-react"
-    },
-    "experimental/instrumentation-replay": {
-      "package-name": "@grafana/faro-instrumentation-replay",
-      "component": "@grafana/faro-instrumentation-replay"
-    },
-    "experimental/transport-otlp-http": {
-      "package-name": "@grafana/faro-transport-otlp-http",
-      "component": "@grafana/faro-transport-otlp-http"
+    ".": {
+      "package-name": "faro-web-sdk",
+      "component": "faro-web-sdk",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/web-sdk/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "packages/web-sdk/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+        },
+        { "type": "json", "path": "packages/web-tracing/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "packages/web-tracing/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+        },
+        { "type": "json", "path": "packages/react/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "packages/react/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "packages/react/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-web-tracing']"
+        },
+        { "type": "json", "path": "experimental/instrumentation-replay/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "experimental/instrumentation-replay/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+        },
+        { "type": "json", "path": "experimental/transport-otlp-http/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "experimental/transport-otlp-http/package.json",
+          "jsonpath": "$.devDependencies.['@grafana/faro-core']"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,6 +50,28 @@
           "type": "json",
           "path": "experimental/transport-otlp-http/package.json",
           "jsonpath": "$.devDependencies.['@grafana/faro-core']"
+        },
+        { "type": "json", "path": "lerna.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "demo/package.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "demo/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+        },
+        {
+          "type": "json",
+          "path": "demo/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-react']"
+        },
+        {
+          "type": "json",
+          "path": "demo/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "demo/package.json",
+          "jsonpath": "$.dependencies.['@grafana/faro-web-tracing']"
         }
       ]
     }


### PR DESCRIPTION
## Why

The release-please flow set up in #2023 and patched in #2045 still doesn't match how this repo releases. Two concrete failures on the open release PR (#2046):

1. **Per-package changelogs.** Six separate `CHANGELOG.md` files instead of one. We always release every package together at the same version, so a single root changelog is the source of truth.
2. **CI on the release PR fails at `yarn install --frozen-lockfile`** ([failing job](https://github.com/grafana/faro-web-sdk/actions/runs/25556905496/job/75018111580?pr=2046)). release-please bumps cross-package dep ranges in `package.json` from `^2.5.0` → `^2.6.0` but doesn't touch `yarn.lock`. Yarn computes a new resolution; `--frozen-lockfile` rejects writing it.
3. **Publish would no-op.** `release.yml` calls `lerna publish from-git`, which expects `<name>@<version>` tags from `lerna version`. release-please now writes a single `v<version>` tag, so `from-git` finds no matching tags and publishes nothing.

## What

Four changes, single PR:

- **`release-please-config.json`** — collapse to a single `"."` package owning the root `CHANGELOG.md` and a single `v<version>` tag. Use `extra-files` to bump every subpackage `version` field plus all internal `@grafana/faro-*` dep ranges in lockstep. Removes `linked-versions` and `node-workspace` plugins (both designed for independent versioning).
- **`.release-please-manifest.json`** — single root entry. All packages release as one unit at the same version.
- **`.github/workflows/release-please.yml`** — after release-please opens or updates its PR, check out that branch with the GitHub App token, run `yarn install --mode update-lockfile`, then commit and push the refreshed `yarn.lock`. CI on the release PR now sees a consistent lockfile.
- **`.github/workflows/release.yml`** — switch `lerna publish from-git` → `lerna publish from-package`. Reads versions from `package.json` instead of expecting per-package tags. Idempotent: republishing a version already on npm is a no-op.

Lerna stays in the publish path. Cross-package deps stay as `^x.y.z`. Project layout unchanged.

## Caveats

- **Tag scheme changes** from `<name>@<version>` (lerna style) to `v<version>` (release-please style). Nothing in this repo reads the old tags, but external tooling that does will need updating.
- **First release after merge:** release-please reads `2.5.0` from the manifest; the existing `v2.5.0` tag from #2023 should serve as the previous-release marker. If it can't find it, set `last-release-sha` once.
- **GitHub App token push permission:** the lockfile-refresh step relies on `app-o11y-kwl-ci` being able to push to release-please branches. #2046 confirms it can — release-please-action used the same token for those commits.
- **Old release PR (#2046)** should be closed after this lands; the next push to `main` will open a fresh release PR with the new config.

## Links

- Original release-please introduction: #2023
- First fix (changelog-path): #2045
- Currently open release PR with failing CI: #2046

## Checklist

- [ ] Tests added — N/A, CI config only
- [x] Changelog updated — fix is itself the changelog mechanism
- [ ] Documentation updated — `docs/sources/developer/releasing.md` may need updating after this lands; will follow up if needed