### PR TITLE
fix(ci): correct jsonpath syntax in release-please extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,58 +20,58 @@
         {
           "type": "json",
           "path": "packages/web-sdk/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+          "jsonpath": "$['dependencies']['@grafana/faro-core']"
         },
         { "type": "json", "path": "packages/web-tracing/package.json", "jsonpath": "$.version" },
         {
           "type": "json",
           "path": "packages/web-tracing/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+          "jsonpath": "$['dependencies']['@grafana/faro-web-sdk']"
         },
         { "type": "json", "path": "packages/react/package.json", "jsonpath": "$.version" },
         {
           "type": "json",
           "path": "packages/react/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+          "jsonpath": "$['dependencies']['@grafana/faro-web-sdk']"
         },
         {
           "type": "json",
           "path": "packages/react/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-web-tracing']"
+          "jsonpath": "$['dependencies']['@grafana/faro-web-tracing']"
         },
         { "type": "json", "path": "experimental/instrumentation-replay/package.json", "jsonpath": "$.version" },
         {
           "type": "json",
           "path": "experimental/instrumentation-replay/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+          "jsonpath": "$['dependencies']['@grafana/faro-core']"
         },
         { "type": "json", "path": "experimental/transport-otlp-http/package.json", "jsonpath": "$.version" },
         {
           "type": "json",
           "path": "experimental/transport-otlp-http/package.json",
-          "jsonpath": "$.devDependencies.['@grafana/faro-core']"
+          "jsonpath": "$['devDependencies']['@grafana/faro-core']"
         },
         { "type": "json", "path": "lerna.json", "jsonpath": "$.version" },
         { "type": "json", "path": "demo/package.json", "jsonpath": "$.version" },
         {
           "type": "json",
           "path": "demo/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-core']"
+          "jsonpath": "$['dependencies']['@grafana/faro-core']"
         },
         {
           "type": "json",
           "path": "demo/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-react']"
+          "jsonpath": "$['dependencies']['@grafana/faro-react']"
         },
         {
           "type": "json",
           "path": "demo/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-web-sdk']"
+          "jsonpath": "$['dependencies']['@grafana/faro-web-sdk']"
         },
         {
           "type": "json",
           "path": "demo/package.json",
-          "jsonpath": "$.dependencies.['@grafana/faro-web-tracing']"
+          "jsonpath": "$['dependencies']['@grafana/faro-web-tracing']"
         }
       ]
     }


### PR DESCRIPTION
## Why

The release-please workflow on `main` has been failing on every push since #2048 was merged:

> [Run 25563027147](https://github.com/grafana/faro-web-sdk/actions/runs/25563027147/job/75039268839):
> ```
> ##[error]release-please failed: Unknown value type grafana/faro-co
> ```

This blocks release-please from opening any release PR.

## Root cause

The `extra-files` entries I added for cross-package dep range bumps used a non-standard JSONPath form with a stray `.` between the property and the bracket:

```json
"jsonpath": "$.dependencies.['@grafana/faro-core']"
```

`jsonpath-plus` (used internally by release-please's `GenericJson` updater) does not accept `.[` — bracket notation comes immediately after the parent property, no leading dot. When the parser hits that dot it falls into a fallback path that interprets the bracket contents as a "value type", which surfaces as `Unknown value type grafana/faro-co` (truncated form of `@grafana/faro-core`).

Reproduced locally against `jsonpath-plus@10`:

```js
JSONPath({path: "$.dependencies.['@grafana/faro-core']", json: {...}})
// → Error: Unknown value type grafana/faro-co

JSONPath({path: "$['dependencies']['@grafana/faro-core']", json: {...}})
// → ['^2.5.0']
```

Logs match: release-please successfully processes the first 4 `$.version`-only entries, then errors immediately after fetching `packages/web-sdk/package.json` — the first entry with the broken bracket syntax.

The reference for the correct syntax is in the [jsonpath-plus README](https://github.com/JSONPath-Plus/JSONPath#syntax-through-examples), which uses `$['aProperty']['anotherProperty']` for properties with special characters.

## What

Switch all 12 cross-package dep entries in `release-please-config.json` to full-bracket form:

```diff
- "jsonpath": "$.dependencies.['@grafana/faro-core']"
+ "jsonpath": "$['dependencies']['@grafana/faro-core']"
```

`$.version` entries are unchanged — they were always valid.

## Verification

1. Local jsonpath-plus test against every actual package.json file in the repo: **18/18 paths resolve cleanly** to a string value.
2. End-to-end `npx release-please@17 release-pr --target-branch=fix-release-please-jsonpath-syntax --dry-run` against this branch completes without errors and queues 15 updates across 7 files (`CompositeUpdater` for the multi-update files, `GenericJson` for the single-update files).

## Caveats

- The release-please action on `main` is currently broken; once this lands, the next push to `main` should produce a clean release PR run.
- I should have validated the jsonpath syntax with `jsonpath-plus` directly when adding the `extra-files` entries in #2048. The action's docs link to JSONPath generically without showing bracket notation examples, and I extrapolated the wrong form.