### PR TITLE
fix(ci): pre-format release-please PR to satisfy prettier check

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,21 +70,33 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - name: Refresh yarn.lock on release PR
+      # Two cleanups happen here:
+      #   1. Refresh yarn.lock — release-please rewrites cross-package dep
+      #      ranges in package.json but does not touch yarn.lock. The Pull
+      #      Request workflow runs `yarn install --frozen-lockfile`, which
+      #      fails on the release PR if the resolution would change.
+      #   2. Run `yarn quality:lint:fix` — the project's prettier config
+      #      normalizes markdown bullets to `-`, while release-please writes
+      #      `*`. The Pull Request workflow runs `yarn quality:lint:fix` and
+      #      then `git diff --exit-code`, which fails if CHANGELOG.md needs
+      #      reformatting. Pre-format here so CI is clean.
+      - name: Refresh yarn.lock and format release PR
         if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
         run: |
           set -euo pipefail
           corepack enable
-          # --mode update-lockfile rewrites yarn.lock without installing.
-          yarn install --mode update-lockfile
-          if git diff --quiet -- yarn.lock; then
-            echo "yarn.lock already in sync."
+          # Plain `yarn install` updates yarn.lock and installs deps so
+          # prettier/lerna are available for the lint:fix step below.
+          yarn install
+          yarn quality:lint:fix
+          if git diff --quiet; then
+            echo "No lockfile or formatting changes."
             exit 0
           fi
           # Match the identity the release-please-action uses for its commits
-          # on the same branch, so the lockfile commit appears as the same bot.
+          # on the same branch, so this commit appears as the same bot.
           git config user.name 'app-o11y-kwl-ci[bot]'
           git config user.email 'app-o11y-kwl-ci[bot]@users.noreply.github.com'
-          git add yarn.lock
-          git commit -m 'chore: update yarn.lock for release'
+          git add -A
+          git commit -m 'chore: refresh yarn.lock and format release files'
           git push


### PR DESCRIPTION
## Why

The release-please PR (#2050) opens cleanly but every Pull Request CI run fails on the lint check:

> [Failing run](https://github.com/grafana/faro-web-sdk/actions/runs/25563921039/job/75042473434):
> ```
> ##[error]The files above have auto-fixable lint issues that were not committed.
> ##[error]Run 'yarn quality:lint:fix' locally and commit the changes.
> ```

The diff in the log is exclusively `prettier`'s normalization of `CHANGELOG.md`:

```diff
- * **errors:** preserve error type ...
+ - **errors:** preserve error type ...
```

The Pull Request workflow ([pull-request.yml:34-44](https://github.com/grafana/faro-web-sdk/blob/main/.github/workflows/pull-request.yml#L34-L44)):

1. Runs `yarn quality:lint:fix`
2. Runs `git diff --exit-code` — fails if anything changed

Release-please writes `CHANGELOG.md` with `*` bullets; this repo's prettier config normalizes to `-` bullets; so every release PR fails this check on the first run.

Pre-#2048, per-package CHANGELOGs lived under `packages/*/` and `experimental/*/`, both excluded from the root prettier glob (`"!./{demo,packages}/**"` in `package.json`). The new consolidated root `CHANGELOG.md` is not excluded.

## What

Extend the existing post-release-please cleanup step in `release-please.yml` (which currently only refreshes `yarn.lock`) to also run `yarn quality:lint:fix` and commit the result. One commit, one push, mirrors the lockfile-refresh pattern that already exists.

Concrete change: in `release-please.yml`, switch `yarn install --mode update-lockfile` → plain `yarn install` (we need `prettier` and `lerna` populated in `node_modules`), add a `yarn quality:lint:fix` line, and broaden the diff/commit from `yarn.lock` only to `git add -A`. Combined commit message: `chore: refresh yarn.lock and format release files`.

## Verification approach

Once this lands, the next push to `main` re-triggers `release-please.yml`, which updates the existing release PR (#2050) with formatted CHANGELOG.md and refreshed yarn.lock. The Pull Request workflow on that PR should then pass.

## Caveats

- Adds time to the release-please workflow (~30 seconds for full `yarn install` vs. `--mode update-lockfile`). Acceptable — it runs only when a release PR is opened/updated.
- If `yarn quality:lint:fix` itself ever fails (e.g. lerna sub-runs error), the release PR is stuck. Same fragility class as the existing lockfile step.
- The `markdownlint` script (`quality:lint:root:markdown`) also runs on `CHANGELOG.md`. Looking at the failing run, only prettier triggered the diff failure — markdownlint passed. If markdownlint ever flags release-please output in the future, we can add a `.markdownlintignore` entry.