### PR TITLE
fix(ci): two-stage yarn install in release-please cleanup step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,9 +85,16 @@ jobs:
         run: |
           set -euo pipefail
           corepack enable
-          # Plain `yarn install` updates yarn.lock and installs deps so
-          # prettier/lerna are available for the lint:fix step below.
-          yarn install
+          # Yarn berry auto-enables hardened mode on public PR workflows,
+          # which forbids modifying yarn.lock with a plain `yarn install`.
+          # `--mode update-lockfile` writes the lockfile without installing
+          # node_modules, bypassing the hardened-mode check.
+          yarn install --mode update-lockfile
+          # Now that the lockfile matches package.json, do a real install
+          # so prettier/lerna are available for the lint:fix step.
+          # `--immutable` is allowed in hardened mode because the lockfile
+          # is already in sync.
+          yarn install --immutable
           yarn quality:lint:fix
           if git diff --quiet; then
             echo "No lockfile or formatting changes."


### PR DESCRIPTION
## Why

PR #2051 switched the release-please cleanup step from `yarn install --mode update-lockfile` to plain `yarn install` so prettier and lerna would be available for `yarn quality:lint:fix`. That broke the workflow:

> [Failing run](https://github.com/grafana/faro-web-sdk/actions/runs/25564644531/job/75044840504):
> ```
> ➤ YN0028: The lockfile would have been modified by this install,
>           which is explicitly forbidden.
> ```

Yarn berry auto-enables hardened mode when CI is triggered from a public-PR-like context (release-please's branch counts):

> Yarn detected that the current workflow is executed from a public pull request. For safety the hardened mode has been enabled.

In hardened mode, plain `yarn install` is treated as immutable — it refuses to write `yarn.lock` and aborts when the resolution would change. The original `--mode update-lockfile` worked around this by being an explicit lockfile-only operation, which hardened mode permits.

## What

Two-stage install:

1. `yarn install --mode update-lockfile` — writes `yarn.lock` to match `package.json`. Allowed in hardened mode (explicit lockfile-update operation).
2. `yarn install --immutable` — installs `node_modules` from the now-correct lockfile. Allowed in hardened mode because the lockfile already matches; no modification needed.
3. `yarn quality:lint:fix` — formats `CHANGELOG.md` etc.

## Caveats

- Two `yarn install` calls roughly double the install time of this step. The first is fast (lockfile-only, ~5s), the second is the full install (~30s). Total cost: ~35s for the cleanup step. Acceptable.
- If yarn's hardened mode behavior changes in a future release, this two-stage dance may stop being necessary. Worth revisiting if yarn 5 ships.

## Verification approach

Once this lands, the next push to `main` re-triggers `release-please.yml`. The release PR (#2050) should be updated with both refreshed `yarn.lock` and formatted `CHANGELOG.md` in a single bot commit, and CI on the release PR should then pass.