### PR TITLE
fix(ci): anchor release-please at v2.5.0 commit on main

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   "draft": false,
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
+  "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",
   "packages": {
     ".": {
       "package-name": "faro-web-sdk",


### PR DESCRIPTION
## Summary

- The `v2.5.0` git tag points at orphan commit `be7742480`, which is **not reachable from `main`**. Without an anchor on `main`, release-please falls back to scanning the entire repo history and the 2.6.0 release PR (#2052) lists every conventional commit ever made.
- Add `last-release-sha` pointing at `0c6603ea` (`chore(release): bump packages to v2.5.0`, #2021) — the commit on `main` that contains the same file changes as the orphan tag.
- Release-please will now anchor at `0c6603ea` and the regenerated #2052 will only include the 16 commits landed after v2.5.0.

## Why `last-release-sha` and not `bootstrap-sha`?

Per the [release-please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md):

- `bootstrap-sha` is ignored once a release PR has been merged.
- `last-release-sha` is "never ignored" and is intended for cases where "you've accidentally merged a bad release PR" — exactly our situation.

## Follow-up after v2.6.0 ships

`last-release-sha` is permanent until removed. Once PR #2052 merges and v2.6.0 is tagged at a commit on `main`, the v2.6.0 tag itself becomes the natural anchor, so this entry should be **removed** from the config. I'll open the cleanup PR right after v2.6.0 ships.

## Will future releases be ok?

Yes. Once v2.6.0 is tagged at a commit on `main` (which it will be — release-please tags the merge commit of the release PR), subsequent walks anchor cleanly. The dangling `v2.5.0` tag becomes irrelevant.