### PR TITLE
fix(ci): exclude CHANGELOG.md from markdownlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "quality:lint": "run-s quality:lint:packages quality:lint:root",
     "quality:lint:packages": "lerna run --parallel quality:lint",
     "quality:lint:root": "run-p 'quality:lint:root:*'",
-    "quality:lint:root:markdown": "markdownlint README.md CHANGELOG.md docs/**/*.md",
+    "quality:lint:root:markdown": "markdownlint README.md docs/**/*.md",
     "quality:lint:root:prettier": "prettier --cache --cache-location=.cache/prettier/root -c \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\" \"!./{demo,packages}/**\"",
     "quality:lint:fix": "run-p quality:lint:fix:root quality:lint:fix:packages",
     "quality:lint:fix:root": "prettier --cache --cache-location=.cache/prettier/root -w \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\" \"!./{demo,packages,experimental}/**\"",


### PR DESCRIPTION
## Summary

- `CHANGELOG.md` is now machine-owned by release-please. Auto-generated entries embed long GitHub commit/PR links that routinely exceed 200 chars, breaking `MD013/line-length` (limit 120) and blocking the release PR (#2052).
- Drop `CHANGELOG.md` from the `markdownlint` glob in `quality:lint:root:markdown`.
- Prettier still runs on the file via `quality:lint:root:prettier`, so basic formatting is preserved.

## Follow-up

After #2061 anchored release-please correctly, the workflow regenerates #2052 with proper post-v2.5.0 entries — but the auto-generated link-heavy lines tripped `MD013`. This PR unblocks that.