### PR TITLE
fix(ci): set release-please PR title pattern with version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,8 @@
   "draft": false,
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
+  "pull-request-title-pattern": "chore: release ${version}",
+  "group-pull-request-title-pattern": "chore: release ${version}",
   "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- PR #2052 (the v2.6.0 release PR) was generated with title `chore: release main` because release-please's default `group-pull-request-title-pattern` is `chore: release ${branch}` — it substitutes the target branch, not the version.
- Without `${version}` in the title, release-please cannot match the merged PR back to a release. On the post-merge run it logged:
  ```
  ⚠ PR component: undefined does not match configured component: faro-web-sdk
  ⚠ There are untagged, merged release PRs outstanding - aborting
  ```
  Result: no `v2.6.0` tag, no GitHub release, no npm publish.
- Set both `pull-request-title-pattern` and `group-pull-request-title-pattern` to `chore: release ${version}`. Future release PR titles will look like `chore: release 2.7.0`, and release-please will correctly tag + release them on merge.

## Scope

This affects only **future** release PRs. The current v2.6.0 release needs to be tagged manually as a one-off recovery (separate task).

## Reference

- [Release-please customizing — Pull Request Title](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#pull-request-title)
- [Manifest-releaser — `group-pull-request-title-pattern`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)