### PR TITLE
fix(ci): drop unsupported ${version} placeholder from release-please header

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "prerelease": false,
-  "pull-request-header": "Faro Web SDK Release - ${version}",
+  "pull-request-header": "Faro Web SDK Release",
   "pull-request-title-pattern": "chore: release ${version}",
   "group-pull-request-title-pattern": "chore: release ${version}",
   "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",


### PR DESCRIPTION
## Summary

- The `pull-request-header` field in `release-please-config.json` contained the placeholder `${version}`, but **release-please does not substitute `${version}` into `pull-request-header`** — only into title patterns (`pull-request-title-pattern`, `group-pull-request-title-pattern`).
- As a result, both [#2052 (v2.6.0)](https://github.com/grafana/faro-web-sdk/pull/2052) and [#2064 (v2.6.1)](https://github.com/grafana/faro-web-sdk/pull/2064) ended up with `Faro Web SDK Release - ${version}` rendered literally in the PR body.
- Drop the placeholder. The version is already visible in the PR title and the changelog `<summary>` inside the body, so no information is lost.

## Reference

- [release-please customizing docs — Pull Request Title](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#pull-request-title) lists `${version}` only under title-related options.
- Follow-up to #2063 which fixed the title pattern but did not catch the header.

## Verification

Applies to **future** release PRs only. The next release PR generated after this merges should have a clean `Faro Web SDK Release` header with no literal `${version}`.