### PR TITLE
fix(ci): include ${component} in release-please PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,8 @@
   "draft": false,
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
-  "pull-request-title-pattern": "chore: release ${version}",
-  "group-pull-request-title-pattern": "chore: release ${version}",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- PR #2064 (`chore: release 2.6.1`) merged but release-please did not tag/release it. Post-merge workflow log:
  ```
  ⚠ pullRequestTitlePattern miss the part of '${component}'
  ⚠ PR component: undefined does not match configured component: faro-web-sdk
  ⚠ There are untagged, merged release PRs outstanding - aborting
  ```
- Release-please's title parser extracts `${component}` from the PR title to match it back to a configured package. With `"component": "faro-web-sdk"` set in the package config, the parser requires `${component}` to be present in the title pattern.
- The previous patterns (`chore: release ${version}`, set in #2063) omitted `${component}`. The parser produced `component=undefined`, mismatched the configured value, and aborted the release step.

## Change

Switch both `pull-request-title-pattern` and `group-pull-request-title-pattern` to the [documented default form](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#pull-request-title):

```
chore${scope}: release${component} ${version}
```

Future release PR titles will be `chore(main): release faro-web-sdk 2.6.2`. The title parser will match `component=faro-web-sdk`, allowing release-please to tag and release on merge.

## Why we didn't catch this in #2063

#2063 fixed the `chore: release main` title that lacked `${version}`. We chose `chore: release ${version}` as the minimal correction without re-introducing `${component}`. That works for *creating* the release PR (PR #2064 was generated and merged fine), but **fails on the post-merge release step** because the parser needs `${component}` to match the merged PR back to its package config.

## Recovery

v2.6.1 still needs to be tagged manually (same as we did for v2.6.0). That will happen as a separate operation once this fix is merged.