### PR TITLE
fix(ci): make release-please auto-tag on merge

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,13 +9,11 @@
   "draft": false,
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore: release ${version}",
   "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",
   "packages": {
     ".": {
-      "package-name": "faro-web-sdk",
-      "component": "faro-web-sdk",
+      "package-name": "",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },


### PR DESCRIPTION
## Summary

Three previous release PRs (#2052, #2064, #2068 for v2.6.0, v2.6.1, v2.6.2) merged but **were not auto-tagged**. Each required manual `git tag`, `gh release create`, and PR label flip. This PR fixes the underlying config bug so release-please tags releases automatically going forward.

## Root cause

Release-please's post-merge matcher in `buildRelease()` (release-please v17.6.0, [`src/strategies/base.ts`](https://github.com/googleapis/release-please/blob/v17.6.0/src/strategies/base.ts)) compares two values:

- `branchName.component` — parsed from the release PR's branch name. For our branch `release-please--branches--main` (no component segment), this is `undefined`.
- `branchComponent = getBranchComponent()` — derived from config. With our current `"component": "faro-web-sdk"`, returns `"faro-web-sdk"`.

The matcher does `normalizeComponent(undefined) !== normalizeComponent("faro-web-sdk")` → `"" !== "faro-web-sdk"` → **mismatch** → aborts with:

```
⚠ PR component: undefined does not match configured component: faro-web-sdk
⚠ There are untagged, merged release PRs outstanding - aborting
```

Previous attempted fixes (#2063 title pattern, #2066 added `${component}`) didn't address the configured component. The mismatch persisted.

## Changes

```diff
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
-  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "group-pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
-      "package-name": "faro-web-sdk",
-      "component": "faro-web-sdk",
+      "package-name": "",
```

1. **Drop `component: faro-web-sdk`** and set **`package-name: ""`** in the package config. Forces `getBranchComponent()` to return `""` (empty string) instead of falling back to deriving `"faro-web-sdk"` from root `package.json` "name". Both sides of the matcher then resolve to `""` → match → tag.
2. **Replace title patterns with a single `group-pull-request-title-pattern: "chore: release ${version}"`.** Generates titles like `chore: release 2.7.0` that the post-merge parser can extract a version from. The per-package `pull-request-title-pattern` is unused here (we use `separate-pull-requests: false`).

## Verification

Tested against a `test/release-please-dryrun` branch with release-please CLI 17.6.0:

**Generated PR title** (with a `feat:` commit on top of v2.6.2):
```
title: chore: release 2.7.0
branch: release-please--branches--test/release-please-dryrun
```

**File updates** (15 total, lockstep preserved across all 6 publishable packages):
```
package-lock.json, samples/package.json, CHANGELOG.md, package.json,
packages/core/package.json, packages/web-sdk/package.json,
packages/web-tracing/package.json, packages/react/package.json,
experimental/instrumentation-replay/package.json,
experimental/transport-otlp-http/package.json,
lerna.json, demo/package.json, .release-please-manifest.json,
changelog.json, npm-shrinkwrap.json
```

**Parser behavior** (verified directly against `release-please@17.6.0` exports):

| Title | `version` | `component` |
|---|---|---|
| `chore: release 2.7.0` | `"2.7.0"` ✅ | `undefined` ✅ |
| `chore(main): release 2.7.0` | `"2.7.0"` ✅ | `undefined` ✅ |

| Branch | `component` |
|---|---|
| `release-please--branches--main` | `undefined` ✅ |

With `package-name: ""`, `getBranchComponent()` returns `""`. Matcher: `normalizeComponent(undefined) === normalizeComponent("")` → both `""` → **no mismatch**.

## Invariants preserved

- **Lockstep versioning**: all 6 published packages bump to the same version via `extra-files` (unchanged).
- **Single PR per release**: `separate-pull-requests: false` (unchanged).
- **Single tag per release**: `include-component-in-tag: false`, `include-v-in-tag: true` → tags remain `vX.Y.Z` (unchanged).
- **Existing `release.yml` workflow** unchanged; still triggers on `v*` tag push.

## Follow-up (separate PR after first successful auto-release)

Remove `last-release-sha` from the config. It's a safety net from the v2.5.0 dangling-tag incident; release-please will anchor on the v2.6.2 tag once it tags v2.7.0 automatically.