### PR TITLE
chore(ci): remove release-please last-release-sha safety net

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
   "prerelease": false,
   "pull-request-header": "Faro Web SDK Release - ${version}",
   "group-pull-request-title-pattern": "chore: release ${version}",
-  "last-release-sha": "0c6603eacb286719e363ac0ad44d0712bbf81cb3",
   "packages": {
     ".": {
       "package-name": "",


### PR DESCRIPTION
## Summary

Remove `last-release-sha` from `release-please-config.json`. It was added in #2061 as a safety net after the v2.5.0 git tag turned out to point at an orphan commit not reachable from `main`.

## Why it's safe to remove now

- v2.6.3 (released today via #2070) **tagged automatically** for the first time after #2069 fixed the config.
- The post-merge release-please run logged `❯ Found release for path ., v2.6.3` — proving tag-based anchoring works correctly.
- `last-release-sha` was pointing at `0c6603ea` (the old v2.5.0 anchor on main), which is now stale.

## Why leaving it in is mildly harmful

Per the [release-please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#last-release-sha):

> never ignored: remove/change it once a good release PR is merged

It silently overrides tag-based anchoring. If the v2.6.3 GitHub release were ever deleted, release-please would walk back from `0c6603ea` instead of falling back to the next valid tag — producing a bloated changelog like the one we hit on PR #2052 originally.