### PR TITLE
fix(core): fall back to window when resolving Metro bundle id

### DIFF
--- a/packages/core/src/utils/sourceMaps.test.ts
+++ b/packages/core/src/utils/sourceMaps.test.ts
@@ -1,13 +1,21 @@
 import { getBundleId, getGitHash } from './sourceMaps';
 
 describe('sourceMapUpload utils', () => {
+  const bundleKey = (appName: string) => `__faroBundleId_${appName}`;
+
+  const deleteBundleId = (appName: string): void => {
+    const key = bundleKey(appName);
+    delete (globalThis as any)[key];
+    delete (window as any)[key];
+  };
+
   beforeAll(() => {
-    delete (global as any).__faroBundleId_foo;
+    deleteBundleId('foo');
     delete (global as any).__faroGitHash_foo;
   });
 
   afterAll(() => {
-    delete (global as any).__faroBundleId_foo;
+    deleteBundleId('foo');
     delete (global as any).__faroGitHash_foo;
   });
 
@@ -25,5 +33,107 @@ describe('sourceMapUpload utils', () => {
   it('can get the git hash from the global object', () => {
     (global as any).__faroGitHash_foo = 'abc123def456abc123def456abc123def456abc1';
     expect(getGitHash('foo')).toEqual('abc123def456abc123def456abc123def456abc1');
+  });
+
+  it('returns undefined when neither globalObject nor window defines a usable bundle id', () => {
+    const app = 'missingBoth';
+    deleteBundleId(app);
+    expect(getBundleId(app)).toBeUndefined();
+  });
+
+  it('prefers globalObject over window when both define the bundle id', async () => {
+    const app = 'bothDefined';
+    const key = bundleKey(app);
+    deleteBundleId(app);
+
+    jest.resetModules();
+    const detachedGlobalObject: Record<string, unknown> = { [key]: 'from-global' };
+    jest.doMock('../globalObject', () => ({
+      globalObject: detachedGlobalObject,
+    }));
+
+    const { getBundleId: getBundleIdFresh } = await import('./sourceMaps');
+
+    try {
+      (window as any)[key] = 'from-window';
+      expect(getBundleIdFresh(app)).toBe('from-global');
+    } finally {
+      deleteBundleId(app);
+      jest.dontMock('../globalObject');
+      jest.resetModules();
+    }
+  });
+
+  it('ignores an empty string on globalObject and reads from window', async () => {
+    const app = 'emptyGlobalStr';
+    const key = bundleKey(app);
+    deleteBundleId(app);
+
+    jest.resetModules();
+    const detachedGlobalObject: Record<string, unknown> = { [key]: '' };
+    jest.doMock('../globalObject', () => ({
+      globalObject: detachedGlobalObject,
+    }));
+
+    const { getBundleId: getBundleIdFresh } = await import('./sourceMaps');
+
+    try {
+      (window as any)[key] = 'from-window';
+      expect(getBundleIdFresh(app)).toBe('from-window');
+    } finally {
+      deleteBundleId(app);
+      jest.dontMock('../globalObject');
+      jest.resetModules();
+    }
+  });
+
+  it('returns undefined when globalObject holds only an empty string', () => {
+    const app = 'onlyEmptyGlobal';
+    const key = bundleKey(app);
+    try {
+      deleteBundleId(app);
+      (globalThis as any)[key] = '';
+      expect(getBundleId(app)).toBeUndefined();
+    } finally {
+      deleteBundleId(app);
+    }
+  });
+
+  it('returns undefined when globalObject misses and window has an empty string', () => {
+    const app = 'emptyWindowStr';
+    const key = bundleKey(app);
+    try {
+      delete (globalThis as any)[key];
+      (window as any)[key] = '';
+      expect(getBundleId(app)).toBeUndefined();
+    } finally {
+      deleteBundleId(app);
+    }
+  });
+
+  it('reads the bundle ID from window when globalObject does not carry it', async () => {
+    const fooKey = bundleKey('foo');
+    delete (globalThis as any)[fooKey];
+    delete (window as any)[fooKey];
+
+    jest.resetModules();
+    const detachedGlobalObject: Record<string, unknown> = {};
+    jest.doMock('../globalObject', () => ({
+      globalObject: detachedGlobalObject,
+    }));
+
+    const { getBundleId: getBundleIdWithDetachedGlobal } = await import('./sourceMaps');
+
+    expect(getBundleIdWithDetachedGlobal('foo')).toBeUndefined();
+    expect(detachedGlobalObject[fooKey]).toBeUndefined();
+    expect((globalThis as any)[fooKey]).toBeUndefined();
+
+    (window as any)[fooKey] = 'from-window';
+
+    expect(getBundleIdWithDetachedGlobal('foo')).toEqual('from-window');
+
+    jest.dontMock('../globalObject');
+    jest.resetModules();
+    delete (window as any)[fooKey];
   });
 });

--- a/packages/core/src/utils/sourceMaps.test.ts
+++ b/packages/core/src/utils/sourceMaps.test.ts
@@ -99,15 +99,22 @@ describe('sourceMapUpload utils', () => {
     }
   });
 
-  it('returns undefined when globalObject misses and window has an empty string', () => {
+  it('returns undefined when globalObject misses and window has an empty string', async () => {
     const app = 'emptyWindowStr';
     const key = bundleKey(app);
+    deleteBundleId(app);
+
+    jest.resetModules();
+    jest.doMock('../globalObject', () => ({ globalObject: {} }));
+    const { getBundleId: getBundleIdFresh } = await import('./sourceMaps');
+
     try {
-      delete (globalThis as any)[key];
       (window as any)[key] = '';
-      expect(getBundleId(app)).toBeUndefined();
+      expect(getBundleIdFresh(app)).toBeUndefined();
     } finally {
       deleteBundleId(app);
+      jest.dontMock('../globalObject');
+      jest.resetModules();
     }
   });
 
@@ -152,15 +159,22 @@ describe('sourceMapUpload utils', () => {
     }
   });
 
-  it('returns undefined when window holds a non-string bundle id', () => {
+  it('returns undefined when window holds a non-string bundle id', async () => {
     const app = 'nonStringWindow';
     const key = bundleKey(app);
+    deleteBundleId(app);
+
+    jest.resetModules();
+    jest.doMock('../globalObject', () => ({ globalObject: {} }));
+    const { getBundleId: getBundleIdFresh } = await import('./sourceMaps');
+
     try {
-      delete (globalThis as any)[key];
       (window as any)[key] = true as any;
-      expect(getBundleId(app)).toBeUndefined();
+      expect(getBundleIdFresh(app)).toBeUndefined();
     } finally {
       deleteBundleId(app);
+      jest.dontMock('../globalObject');
+      jest.resetModules();
     }
   });
 });

--- a/packages/core/src/utils/sourceMaps.test.ts
+++ b/packages/core/src/utils/sourceMaps.test.ts
@@ -112,9 +112,10 @@ describe('sourceMapUpload utils', () => {
   });
 
   it('reads the bundle ID from window when globalObject does not carry it', async () => {
-    const fooKey = bundleKey('foo');
-    delete (globalThis as any)[fooKey];
-    delete (window as any)[fooKey];
+    const app = 'windowOnlyDetached';
+    const key = bundleKey(app);
+    delete (globalThis as any)[key];
+    delete (window as any)[key];
 
     jest.resetModules();
     const detachedGlobalObject: Record<string, unknown> = {};
@@ -124,16 +125,42 @@ describe('sourceMapUpload utils', () => {
 
     const { getBundleId: getBundleIdWithDetachedGlobal } = await import('./sourceMaps');
 
-    expect(getBundleIdWithDetachedGlobal('foo')).toBeUndefined();
-    expect(detachedGlobalObject[fooKey]).toBeUndefined();
-    expect((globalThis as any)[fooKey]).toBeUndefined();
+    try {
+      expect(getBundleIdWithDetachedGlobal(app)).toBeUndefined();
+      expect(detachedGlobalObject[key]).toBeUndefined();
+      expect((globalThis as any)[key]).toBeUndefined();
 
-    (window as any)[fooKey] = 'from-window';
+      (window as any)[key] = 'from-window';
 
-    expect(getBundleIdWithDetachedGlobal('foo')).toEqual('from-window');
+      expect(getBundleIdWithDetachedGlobal(app)).toEqual('from-window');
+    } finally {
+      deleteBundleId(app);
+      jest.dontMock('../globalObject');
+      jest.resetModules();
+    }
+  });
 
-    jest.dontMock('../globalObject');
-    jest.resetModules();
-    delete (window as any)[fooKey];
+  it('returns undefined when globalObject holds a non-string bundle id', () => {
+    const app = 'nonStringGlobal';
+    const key = bundleKey(app);
+    try {
+      deleteBundleId(app);
+      (globalThis as any)[key] = 123 as any;
+      expect(getBundleId(app)).toBeUndefined();
+    } finally {
+      deleteBundleId(app);
+    }
+  });
+
+  it('returns undefined when window holds a non-string bundle id', () => {
+    const app = 'nonStringWindow';
+    const key = bundleKey(app);
+    try {
+      delete (globalThis as any)[key];
+      (window as any)[key] = true as any;
+      expect(getBundleId(app)).toBeUndefined();
+    } finally {
+      deleteBundleId(app);
+    }
   });
 });

--- a/packages/core/src/utils/sourceMaps.ts
+++ b/packages/core/src/utils/sourceMaps.ts
@@ -8,11 +8,12 @@ import { globalObject } from '../globalObject';
 export function getBundleId(appName: string): string | undefined {
   const key = `__faroBundleId_${appName}`;
   const fromGlobal = (globalObject as any)?.[key];
-  if (fromGlobal != null && fromGlobal !== '') {
-    return fromGlobal as string;
+  if (typeof fromGlobal === 'string' && fromGlobal !== '') {
+    return fromGlobal;
   }
-  if (typeof window !== 'undefined' && (window as any)[key] != null && (window as any)[key] !== '') {
-    return (window as any)[key] as string;
+  const fromWindow = typeof window !== 'undefined' ? (window as any)[key] : undefined;
+  if (typeof fromWindow === 'string' && fromWindow !== '') {
+    return fromWindow;
   }
   return undefined;
 }

--- a/packages/core/src/utils/sourceMaps.ts
+++ b/packages/core/src/utils/sourceMaps.ts
@@ -1,7 +1,20 @@
 import { globalObject } from '../globalObject';
 
+/**
+ * Reads the bundle id injected by `@grafana/faro-metro-plugin` / webpack plugin preamble.
+ * Prefer `globalObject` (globalThis-first). Also check `window` for older bundles that set the
+ * property only on `window` when it differed from `globalThis` (e.g. legacy preamble order).
+ */
 export function getBundleId(appName: string): string | undefined {
-  return (globalObject as any)?.[`__faroBundleId_${appName}`];
+  const key = `__faroBundleId_${appName}`;
+  const fromGlobal = (globalObject as any)?.[key];
+  if (fromGlobal != null && fromGlobal !== '') {
+    return fromGlobal as string;
+  }
+  if (typeof window !== 'undefined' && (window as any)[key] != null && (window as any)[key] !== '') {
+    return (window as any)[key] as string;
+  }
+  return undefined;
 }
 
 export function getGitHash(appName: string): string | undefined {


### PR DESCRIPTION
## Why

<!-- Add a clear and concise description of why that changes are needed. -->

## What

<!-- Add a clear and concise description of what you changed. -->
fall back to window when resolving Metro bundle id.
Reads the bundle id injected by `@grafana/faro-metro-plugin` / webpack plugin preamble.
Prefer `globalObject` (globalThis-first). Also check `window` for older bundles that set the property only on `window` when it differed from `globalThis` (e.g. legacy preamble order).

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
