### PR TITLE
fix(deps): bump axios to 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "systeminformation": "^5.31.0",
     "@isaacs/brace-expansion": "^5.0.1",
     "protobufjs": "^8.0.1",
-    "tar": "^7.5.8"
+    "tar": "^7.5.8",
+    "axios": "1.15.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5435,14 +5435,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0, axios@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pin `axios` to `1.15.2` via `resolutions` to remediate 13 CVEs (2 CRITICAL, 5 HIGH, 5 MEDIUM, 1 LOW): CVE-2026-42033 through CVE-2026-42044, plus CVE-2026-42264.
- `axios` is transitive (pulled in by `nx` and `wait-on`, both dev-only) — no source in this repo imports it, so the bump cannot affect published SDK behavior.
- `yarn build` passes; only pre-existing `@reduxjs/toolkit` `IMPORT_IS_UNDEFINED` warnings remain.

_PR description authored by Claude on Domas's behalf._