### PR TITLE
chore(deps): pin axios to ^1.15.2 to remediate 13 CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "systeminformation": "^5.31.0",
     "@isaacs/brace-expansion": "^5.0.1",
     "protobufjs": "^8.0.1",
-    "tar": "^7.5.8"
+    "tar": "^7.5.8",
+    "axios": "^1.15.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5445,18 +5445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.16.0":
+"axios@npm:^1.15.2":
   version: 1.16.1
   resolution: "axios@npm:1.16.1"
   dependencies:
@@ -8427,7 +8416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:


### PR DESCRIPTION
## Summary

Remediates 13 CVEs (3× CRITICAL, 4× HIGH, 5× MEDIUM, 1× LOW) on `axios` reported by VulnO11y, all from the same transitive copy.

| Package | From | To | Strategy | Severities | CVEs |
|---|---|---|---|---|---|
| axios | 1.15.0 | 1.16.1 (via `resolutions: "axios": "^1.15.2"`) | resolutions | CRITICAL, HIGH, MEDIUM, LOW | CVE-2026-42033, -42034, -42035, -42036, -42037, -42038, -42039, -42040, -42041, -42042, -42043, -42044, -42264 |

`axios@1.15.0` is exact-pinned by `nx@22.6.5` (`axios@npm:1.15.0`, no caret), so natural re-resolution can't move it. The `^1.15.2` resolution unifies it with the existing `wait-on → axios@npm:^1.16.0` stanza into a single `axios@npm:^1.15.2 → 1.16.1` entry — no downgrades, just nx going 1.15.0 → 1.16.1.

## Test plan

- [x] `yarn install --frozen-lockfile`
- [x] `yarn build`
- [x] `yarn quality:lint:fix` (no diff produced)
- [x] `yarn quality:lint`
- [x] `yarn quality:circular-deps`
- [x] `yarn quality:test` (all 7 projects passed)
- [ ] E2E in CI (cypress + postgres, not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_PR description authored by Claude on Domas's behalf._