### PR TITLE
chore(security): add npm minimum age gate and trufflehog secrets scanning

### DIFF
--- a/.github/actions/secret-scan/action.yml
+++ b/.github/actions/secret-scan/action.yml
@@ -1,0 +1,64 @@
+name: Secret scan
+description: |
+  Scan first-party source folders for secrets with TruffleHog.
+  Avoids scanning node_modules, .yarn/cache, and other third-party trees that
+  produce noisy false positives from package test fixtures and READMEs.
+
+inputs:
+  trufflehog-version:
+    description: TruffleHog version to install.
+    required: false
+    default: '3.94.3'
+  exclude-detectors:
+    description: |
+      Comma-separated list of detector types to exclude (passed to TruffleHog
+      via --exclude-detectors).
+    required: false
+    default: 'SentryToken'
+
+runs:
+  using: composite
+  steps:
+    - name: install trufflehog
+      uses: grafana/plugin-ci-workflows/actions/internal/plugins/trufflehog@9bf555fa8e51759074babd212133911d63ad327d
+      with:
+        trufflehog-version: ${{ inputs.trufflehog-version }}
+        setup-only: 'true'
+
+    - name: scan first-party source folders
+      shell: bash
+      env:
+        EXCLUDE_DETECTORS: ${{ inputs.exclude-detectors }}
+      run: |
+        set -euo pipefail
+
+        FOLDERS=(
+          packages
+          demo
+          experimental
+          cypress
+          docs
+          infra
+          ai
+          dashboards
+        )
+
+        fail=0
+        for folder in "${FOLDERS[@]}"; do
+          if [[ ! -d "${folder}" ]]; then
+            echo "::notice title=Secret scan::Skipping ${folder} — directory does not exist."
+            continue
+          fi
+
+          echo "::group::trufflehog ${folder}"
+          if ! /usr/local/bin/trufflehog filesystem "${folder}" \
+              --no-update --fail --github-actions \
+              --results=verified,unknown \
+              --exclude-detectors="${EXCLUDE_DETECTORS}"; then
+            echo "::error title=Secret scan::Secrets found in ${folder}."
+            fail=1
+          fi
+          echo "::endgroup::"
+        done
+
+        exit "${fail}"

--- a/.github/actions/secret-scan/action.yml
+++ b/.github/actions/secret-scan/action.yml
@@ -51,7 +51,7 @@ runs:
           fi
 
           echo "::group::trufflehog ${folder}"
-          if ! /usr/local/bin/trufflehog filesystem "${folder}" \
+          if ! trufflehog filesystem "${folder}" \
               --no-update --fail --github-actions \
               --results=verified,unknown \
               --exclude-detectors="${EXCLUDE_DETECTORS}"; then

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,10 @@
   "separateMultipleMajor": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0"
+  },
   "packageRules": [
     {
       "description": "Group npm dependencies",

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Secret scan
+        # Scans first-party source folders (packages, demo, experimental,
+        # cypress, docs, infra, ai, dashboards) to avoid noisy false positives
+        # from node_modules and .yarn/cache. TruffleHog flags minified webpack
+        # chunks as unverified Sentry DSN-style tokens; we do not ship Sentry
+        # auth tokens, so SentryToken is excluded. Runs before install/build
+        # to fail fast.
+        uses: ./.github/actions/secret-scan
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  secret-scan:
+    permissions:
+      contents: read
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Scans first-party source folders (packages, demo, experimental,
+      # cypress, docs, infra, ai, dashboards) to avoid noisy false positives
+      # from node_modules and .yarn/cache. TruffleHog flags minified webpack
+      # chunks as unverified Sentry DSN-style tokens; we do not ship Sentry
+      # auth tokens, so SentryToken is excluded. Runs as its own job (rather
+      # than once per Node matrix entry) and gates downstream jobs so they
+      # fail fast on a finding without triplicating the scan.
+      - name: Run secret scan
+        uses: ./.github/actions/secret-scan
+
   test:
+    needs: secret-scan
     permissions:
       contents: read
     name: Testing with Node version (${{ matrix.node }})
@@ -21,15 +42,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
-      - name: Secret scan
-        # Scans first-party source folders (packages, demo, experimental,
-        # cypress, docs, infra, ai, dashboards) to avoid noisy false positives
-        # from node_modules and .yarn/cache. TruffleHog flags minified webpack
-        # chunks as unverified Sentry DSN-style tokens; we do not ship Sentry
-        # auth tokens, so SentryToken is excluded. Runs before install/build
-        # to fail fast.
-        uses: ./.github/actions/secret-scan
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
@@ -65,6 +77,7 @@ jobs:
         run: yarn quality:test
 
   e2e:
+    needs: secret-scan
     permissions:
       contents: read
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,8 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.14.1.cjs
 
 enableScripts: false
+
+# Refuse to install npm package versions younger than 7 days as a defense
+# against newly-published malicious packages (supply-chain attacks).
+# Value is a duration string; the underlying unit is minutes.
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
## Summary

Three defensive measures in response to recent npm supply-chain incidents. Mirrors what was added to [grafana/app-o11y-kwl#3382](https://github.com/grafana/app-o11y-kwl/pull/3382), with the Renovate change folded in here.

### 1. Yarn npm minimum age gate (7 days)

Adds `npmMinimalAgeGate: 7d` to `.yarnrc.yml`. Yarn (4.10+) will refuse to install npm package versions younger than 7 days, giving the ecosystem time to detect and yank malicious freshly-published versions before we pull them.

**Note on units:** the setting accepts a duration string; the underlying unit is *minutes* (per Yarn's `DurationUnit.MINUTES`), not milliseconds. Using `7d` rather than the raw number to avoid the confusion that bit us in the kowalski PR.

### 2. TruffleHog secrets scanning in CI

Adds a reusable composite action at `.github/actions/secret-scan` and wires it into `pull-request.yml` immediately after checkout, before install/build, so the job fails fast on a finding.

Scans first-party source folders only, avoiding the false-positive noise from `node_modules/` and `.yarn/cache/`:

- `packages`
- `demo`
- `experimental`
- `cypress`
- `docs`
- `infra`
- `ai`
- `dashboards`

Uses the same upstream TruffleHog action that `grafana-assistant-app` gets through `grafana/plugin-ci-workflows` (composite at `actions/internal/plugins/trufflehog`), pinned to a SHA, with the same `SentryToken` detector exclusion (TruffleHog flags minified webpack chunks as unverified Sentry DSN-style tokens).

### 3. Renovate `minimumReleaseAge` to match the gate

Adds `"minimumReleaseAge": "7 days"` to `.github/renovate.json` so Renovate only opens dep PRs for versions that have already cleared the Yarn gate. Without this, every fresh release would produce a PR whose `yarn install` fails until the package ages — pointless churn.

Carves out an exception via `"vulnerabilityAlerts": { "minimumReleaseAge": "0" }` so Renovate-detected CVE fixes still apply immediately rather than waiting through the gate window.

## Test plan

- [ ] CI green on this PR — confirms scan finds nothing real, gate doesn't break install on the existing lockfile.
- [ ] Spot-check the trufflehog step log to verify each scanned folder appears under its own `::group::` header.
- [ ] After merge: watch the next Renovate run to confirm fresh-release PRs are deferred and the existing batched cadence still works.