### PR TITLE
chore(ci): bind publish job to publish environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,11 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [test, e2e]
+    # Binds the job to the `publish` GitHub Environment. The environment's
+    # protection rules (required reviewers, deployment tag pattern) gate when
+    # this job actually runs, and its name is included in the OIDC token's
+    # `environment` claim so npm Trusted Publishing can pin against it.
+    environment: publish
 
     env:
       NPM_CONFIG_ACCESS: public


### PR DESCRIPTION
## Summary

- Adds `environment: publish` to the publish job in [`.github/workflows/release.yml`](.github/workflows/release.yml) so the GitHub Environment's protection rules (required reviewers, deployment tag pattern) gate execution.
- Surfaces the environment name in the OIDC token's `environment` claim so the npm Trusted Publisher config on each `@grafana/faro-*` package can pin against it.

_PR description authored by Claude on Domas's behalf._