### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @grafana/frontend-o11y


### PR DESCRIPTION
## Summary

- **CODEOWNERS** — `@grafana/frontend-o11y` as default reviewer. Guards changes to `.github/workflows/release-please.yml` against landing without an owner's eyes, given that workflow now runs the npm Trusted Publishing OIDC step end-to-end (#2087). Needs `require_code_owner_review: true` on the `main` ruleset to actually block merges — followup in repo settings / Terraform.

_PR description authored by Claude on Domas's behalf._