### PR TITLE
chore(cleanup week): dedupe markdownlint (keep only markdownlint-cli)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "lerna": "9.0.7",
     "lint-staged": "17.0.4",
     "madge": "8.0.0",
-    "markdownlint": "0.40.0",
     "markdownlint-cli": "0.48.0",
     "npm-run-all2": "8.0.4",
     "os-browserify": "0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8202,7 +8202,6 @@ __metadata:
     lerna: "npm:9.0.7"
     lint-staged: "npm:17.0.4"
     madge: "npm:8.0.0"
-    markdownlint: "npm:0.40.0"
     markdownlint-cli: "npm:0.48.0"
     npm-run-all2: "npm:8.0.4"
     os-browserify: "npm:0.3.0"
@@ -11608,7 +11607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdownlint@npm:0.40.0, markdownlint@npm:~0.40.0":
+"markdownlint@npm:~0.40.0":
   version: 0.40.0
   resolution: "markdownlint@npm:0.40.0"
   dependencies:


### PR DESCRIPTION
## Summary

- Removes `markdownlint@0.40.0` from root `devDependencies`.
- Nothing in the repo imports `markdownlint` programmatically — every usage goes through the `markdownlint` CLI binary, which is owned by `markdownlint-cli`.
- `markdownlint-cli@0.48.0` already depends on the same `~0.40.0` range, so the lockfile keeps the package transitively at the same resolved version (0.40.0). Only the direct-dep selector is dropped.

Part of a broader supply-chain cleanup — removes a redundant top-level dep from the install/audit surface.

## Test plan

- [x] Repo-wide grep for `import.*markdownlint` / `require('markdownlint')` → zero hits outside `node_modules`
- [x] `node_modules/.bin/markdownlint` confirmed to resolve to `markdownlint-cli/markdownlint.js`
- [x] `yarn install --immutable` — lockfile accepted (no `YN0028` mutation error)
- [x] `yarn quality:lint:fix` — no new changes beyond intended diff (the CI failure trigger in `pull-request.yml:35-42`)
- [x] `yarn build` — 7 projects green
- [x] `yarn quality:lint` — 7 projects green (exercises root markdownlint + per-package md lints)
- [x] `yarn quality:circular-deps` — no cycles, 449 files
- [x] `yarn quality:test` — 537 tests pass, 1 pre-existing skip