### PR TITLE
fix(instrumentation): incomplete regular expression for hostnames

### DIFF
--- a/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
@@ -129,7 +129,7 @@ describe('Performance Instrumentation', () => {
     const config = mockConfig({
       transports: [fetchTransport],
       instrumentations: [new PerformanceInstrumentation()],
-      ignoreUrls: [/.*foo-analytics/, /.*.analytics.com/, 'http://example.com/awesome-image'],
+      ignoreUrls: [/.*foo-analytics/, /.*\.analytics\.com/, 'http://example.com/awesome-image'],
       trackResources: true,
     });
 

--- a/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/instrumentation.test.ts
@@ -129,7 +129,7 @@ describe('Performance Instrumentation', () => {
     const config = mockConfig({
       transports: [fetchTransport],
       instrumentations: [new PerformanceInstrumentation()],
-      ignoreUrls: [/.*foo-analytics/, /.*\.analytics\.com/, 'http://example.com/awesome-image'],
+      ignoreUrls: [/.*foo-analytics/, /analytics\.com/, 'http://example.com/awesome-image'],
       trackResources: true,
     });
 


### PR DESCRIPTION
This was flagged by CodeQL
[https://github.com/grafana/faro-web-sdk/security/code-scanning/29](https://github.com/grafana/faro-web-sdk/security/code-scanning/29)

The regex is wrong, but it's just in a test, so not really urgent. In any case, here is a fix since it was brought up.
