### PR TITLE
chore(ci): remove floating npm@latest from publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -185,9 +185,6 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Install npm latest version #needed for Trusted Publishing
-        run: npm install -g npm@latest
-
       # `from-package` reads versions from each `package.json` and publishes
       # any version not already present on npm. release-please tags the repo
       # with a single `v<version>` tag, so the previous `from-git` flow (which


### PR DESCRIPTION
## What

Removes `npm install -g npm@latest` from the `publish` job in `release-please.yml`.

## Why

The publish job runs with `id-token: write` for npm Trusted Publishing. Installing a floating `npm@latest` inside this privileged context is a supply-chain risk: if the npm CLI package is ever compromised, the attacker-controlled binary publishes tarballs for every `@grafana/faro-*` package **with valid Sigstore provenance attestations**.

Node 24 (pinned in `.nvmrc`) ships npm 11.x, which supports Trusted Publishing natively. The "needed for Trusted Publishing" comment was stale.

## Verification

The publish job still uses npm (from `actions/setup-node@v6` + Node 24) to run `npm run publish -- from-package --yes`. No behavior change — just removes the floating install.

Closes grafana/app-o11y-kwl#3439

Epic: grafana/app-o11y-kwl#3420