### PR TITLE
chore(ci): align Renovate release-age gating with Yarn age gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,14 @@
   "separateMultipleMajor": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "prPriority": 10
+  },
   "packageRules": [
     {
       "description": "Group npm dependencies",
@@ -21,19 +29,11 @@
       "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"]
     },
     {
-      "description": "Group patch updates together",
+      "description": "Automerged patch updates get no human review, so hold them for an extended cooldown (Renovate recommends 14 days when automerging)",
       "matchUpdateTypes": ["patch"],
       "groupName": "patch updates",
-      "automerge": true
-    },
-    {
-      "description": "Prioritize security updates",
-      "matchDatasources": ["npm"],
-      "vulnerabilityAlerts": {
-        "enabled": true
-      },
-      "labels": ["security"],
-      "prPriority": 10
+      "automerge": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "description": "Restrict ua-parser-js to version below 2.x.x as it changes licensing model with v2 onwards",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,11 +29,9 @@
       "schedule": ["before 5am on Monday", "before 5am on Wednesday", "before 5am on Friday"]
     },
     {
-      "description": "Automerged patch updates get no human review, so hold them for an extended cooldown (Renovate recommends 14 days when automerging)",
+      "description": "Group patch updates together",
       "matchUpdateTypes": ["patch"],
-      "groupName": "patch updates",
-      "automerge": true,
-      "minimumReleaseAge": "14 days"
+      "groupName": "patch updates"
     },
     {
       "description": "Restrict ua-parser-js to version below 2.x.x as it changes licensing model with v2 onwards",


### PR DESCRIPTION
## Why

`.yarnrc.yml` sets `npmMinimalAgeGate: 7d`, which refuses to install any npm version younger than 7 days as a supply-chain defence. Renovate had no matching release-age setting, so it opened PRs for versions Yarn then refused to install — every such PR failed CI at `yarn install` with `YN0016: ... are quarantined` until the version aged past 7 days (e.g. #2102, #2104). This aligns Renovate's behaviour with the Yarn gate so PRs only appear once they're actually installable.

It also makes the dependency-update flow stricter and the `security` label meaningful.

## What

- **Add `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"`** so Renovate doesn't create branches/PRs until a version has passed the same 7-day window Yarn enforces. This removes the spurious CI failures on dependency PRs.
- **Remove automerge — every dependency update now requires human review.** Previously patch updates were automerged; we've decided a human should review all updates. (This also retires the case for a longer cooldown on unreviewed automerges; with a reviewer in the loop, the standard 7-day gate is sufficient, so patch updates simply inherit it.)
- **Replace the "Prioritize security updates" rule.** The old rule matched `matchDatasources: ["npm"]`, so it labelled *every* npm PR `security`. It's replaced with a proper top-level `vulnerabilityAlerts` block (+ `osvVulnerabilityAlerts`) so only PRs backed by a real advisory get the `security` label and priority — making the label meaningful for human triage. The merge gate remains Yarn's, independent of advisory feeds (a missed advisory means a missing label, never a missing gate).

`.yarnrc.yml` is unchanged — the 7-day gate already sits on the value the analysis supports.

## Links

- Related failing PRs: #2102, #2104
- Depends on #2107 (lockfile fix) being merged first; this branch will be rebased onto `main` afterwards.

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated