### PR TITLE
fix(deps): regenerate yarn.lock to drop stale semver descriptor

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12106,7 +12106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.0":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.0":
   version: 7.8.1
   resolution: "semver@npm:7.8.1"
   bin:


### PR DESCRIPTION
## Why

`yarn install --immutable` currently fails on every PR with `YN0028` (the lockfile would be modified). The committed `yarn.lock` carries a stale `semver@npm:^7.7.4` entry in its merged `semver` descriptor key, but no manifest requests `^7.7.4` anymore — it was left behind when #2101 ("update patch updates") regenerated the lockfile. A fresh resolution re-aggregates the key without `^7.7.4`, which the immutable install refuses.

This wasn't caught on `main` because the unit-test and `e2e-smoke` jobs only run on `pull_request`; `main` pushes run only "Release please" and CodeQL, neither of which does an immutable install.

## What

- Regenerated the lockfile with `yarn install --mode=update-lockfile`. The only change is dropping the obsolete `semver@npm:^7.7.4` descriptor from the merged key (resolved version `7.8.1` is unchanged). No dependency versions change.
- Verified `yarn install --immutable` now exits 0.

## Links

- Stale lockfile introduced by #2101

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated