### PR TITLE
fix(web-sdk): cap stack-frame line length to bound regex backtracking

### DIFF
--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
@@ -195,9 +195,7 @@ describe('getStackFramesFromError', () => {
 
     const result = getStackFramesFromError(error);
 
-    expect(result).toEqual([
-      buildStackFrame('http://localhost:8080/file.js', 'HTMLButtonElement.onclick', 107, 146),
-    ]);
+    expect(result).toEqual([buildStackFrame('http://localhost:8080/file.js', 'HTMLButtonElement.onclick', 107, 146)]);
   });
 
   it('should still parse a stack line at exactly the max line length', () => {

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
@@ -181,6 +181,42 @@ describe('getStackFramesFromError', () => {
       buildStackFrame('http://path/to/file.js', 'bar', 108, 168),
     ]);
   });
+
+  it('should skip stack lines that exceed the max line length', () => {
+    const longFilename = `http://localhost:8080/${'a'.repeat(1100)}.js`;
+    const error: any = {
+      message: 'Default error',
+      name: 'Error',
+      stack:
+        'Error: Default error\n' +
+        `    at longFrame (${longFilename}:41:27)\n` +
+        '    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)',
+    };
+
+    const result = getStackFramesFromError(error);
+
+    expect(result).toEqual([
+      buildStackFrame('http://localhost:8080/file.js', 'HTMLButtonElement.onclick', 107, 146),
+    ]);
+  });
+
+  it('should still parse a stack line at exactly the max line length', () => {
+    const prefix = '    at boundaryFrame (http://localhost:8080/';
+    const suffix = '.js:41:27)';
+    const filler = 'a'.repeat(1024 - prefix.length - suffix.length);
+    const line = `${prefix}${filler}${suffix}`;
+    expect(line.length).toBe(1024);
+
+    const error: any = {
+      message: 'Default error',
+      name: 'Error',
+      stack: `Error: Default error\n${line}`,
+    };
+
+    const result = getStackFramesFromError(error);
+
+    expect(result).toEqual([buildStackFrame(`http://localhost:8080/${filler}.js`, 'boundaryFrame', 41, 27)]);
+  });
 });
 
 /* Taken from: https://github.com/stacktracejs/error-stack-parser/blob/master/spec/fixtures/captured-errors.js */

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.ts
@@ -17,8 +17,8 @@ import {
 } from './const';
 import { getDataFromSafariExtensions } from './getDataFromSafariExtensions';
 
+// Cap individual stack lines to bound runtime of the stack parsing regexes (avoid pathological backtracking on crafted input).
 const MAX_STACK_LINE_LENGTH = 1024;
-
 export function getStackFramesFromError(error: ExtendedError): ExceptionStackFrame[] {
   let lines: string[] = [];
 

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.ts
@@ -17,6 +17,8 @@ import {
 } from './const';
 import { getDataFromSafariExtensions } from './getDataFromSafariExtensions';
 
+const MAX_STACK_LINE_LENGTH = 1024;
+
 export function getStackFramesFromError(error: ExtendedError): ExceptionStackFrame[] {
   let lines: string[] = [];
 
@@ -27,6 +29,10 @@ export function getStackFramesFromError(error: ExtendedError): ExceptionStackFra
   }
 
   const stackFrames = lines.reduce((acc, line, idx) => {
+    if (line.length > MAX_STACK_LINE_LENGTH) {
+      return acc;
+    }
+
     let parts: RegExpExecArray | null;
     let func: string | undefined;
     let filename: string | undefined;


### PR DESCRIPTION
## Summary

Caps each input line to 1024 characters in `getStackFramesFromError` before running the per-line parser regexes. Lines longer than the cap are skipped (no stack frame produced for them).

## Why

Static analysis flags the four stack-trace parser regexes (`webkitLineRegex`, `webkitEvalRegex`, `firefoxLineRegex`, `firefoxEvalRegex`) as having polynomial worst-case behavior. The patterns are correct for parsing real engine-generated stack traces, but they can backtrack quadratically on crafted input.

**Reachability:** Faro instruments `window.onerror`, `unhandledrejection`, and `console.error`, so any error thrown in a host app reaches this parser. The bytes that drive backtracking would have to land inside an `error.message` (which becomes line 1 of `error.stack`) or `error.stacktrace`. The most plausible chain is a host app that interpolates server-provided or cross-user content into an Error message — e.g., `throw new Error(\`Failed to parse: ${response.field}\`)`.

The threat is bounded (worst case is a stalled tab on the user whose app already received the bad content) but Faro can't audit how its consumers build errors, so a defensive cap in the parser protects every consumer.

**Why a length cap rather than rewriting the regexes:** the regexes parse historical stack formats across three browsers; rewriting risks subtle parsing regressions. A length cap is one line, doesn't touch parsing logic, and bounds runtime at any input size. Legitimate stack lines are well under 500 characters even with absurd minified bundle URLs; 1024 leaves headroom.

## Test plan

- [x] `yarn quality` passes in `packages/web-sdk`
- [x] Existing parser tests pass (`packages/web-sdk/src/instrumentations/errors` — 37 tests)
- [ ] Manually verify a synthetic long-line stack input doesn't stall, and normal stack inputs still produce frames

## Notes

Draft because:
- The 1024 cap is a judgment call — worth a second opinion on whether legitimate stack frame lines ever exceed this in real bundlers.
- May want to add a dedicated test with a crafted long line.