### PR TITLE
fix(react): import unknownString from declared @grafana/faro-web-sdk

### DIFF
--- a/packages/react/src/errorBoundary/withFaroErrorBoundary.tsx
+++ b/packages/react/src/errorBoundary/withFaroErrorBoundary.tsx
@@ -2,7 +2,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import React from 'react';
 import type { ComponentType, FC } from 'react';
 
-import { unknownString } from '@grafana/faro-core';
+import { unknownString } from '@grafana/faro-web-sdk';
 
 import { FaroErrorBoundary } from './FaroErrorBoundary';
 import type { FaroErrorBoundaryProps, ReactProps } from './types';

--- a/packages/react/src/profiler/withFaroProfiler.tsx
+++ b/packages/react/src/profiler/withFaroProfiler.tsx
@@ -2,7 +2,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import React from 'react';
 import type { ComponentType, FC } from 'react';
 
-import { unknownString } from '@grafana/faro-core';
+import { unknownString } from '@grafana/faro-web-sdk';
 
 import { FaroProfiler } from './FaroProfiler';
 import type { FaroProfilerProps } from './FaroProfiler';


### PR DESCRIPTION
## Problem

`@grafana/faro-react` imports `unknownString` from `@grafana/faro-core`:

- `packages/react/src/errorBoundary/withFaroErrorBoundary.tsx`
- `packages/react/src/profiler/withFaroProfiler.tsx`

…but **`@grafana/faro-core` is not declared in `packages/react/package.json`**. faro-react only declares `@grafana/faro-web-sdk` and `@grafana/faro-web-tracing`.

faro-core is present only *transitively* (via faro-web-sdk), so the import resolves under a **hoisted** `node_modules` layout (npm / Yarn classic) and silently **breaks under strict layouts** — pnpm `node-linker=isolated` and Yarn PnP — where a package can only import what it declares.

This is the classic "passes because of hoisting" bug: green in this repo's install, broken for some downstream consumers.

## Fix

Switch both imports to `@grafana/faro-web-sdk`:

```diff
-import { unknownString } from '@grafana/faro-core';
+import { unknownString } from '@grafana/faro-web-sdk';
```

`@grafana/faro-web-sdk` is **already a declared dependency** of faro-react and **re-exports the full faro-core surface**, including `unknownString` (see `packages/web-sdk/src/index.ts`). This is the smallest-diff fix:

- no new dependencies
- no risk of faro-core version skew (single resolved copy via faro-web-sdk)
- declares-what-it-imports rule satisfied

## Scope

This PR intentionally fixes only the undeclared-import bug. Worthwhile follow-ups (not included here):

- Treat `@grafana/faro-core` as a singleton via `peerDependencies` across the suite (it owns global SDK state — two copies = split-brain instrumentation).
- Add a packaging lint to CI (publint / `eslint-plugin-import` `no-extraneous-dependencies` / knip) to catch undeclared imports at PR time.
- Run one CI smoke build under a strict node-linker (pnpm isolated or Yarn PnP) to structurally surface transitive-import leaks across all published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)