### PR TITLE
fix(replay): strip query string and fragment from rrweb Meta event href

### DIFF
--- a/experimental/instrumentation-replay/README.md
+++ b/experimental/instrumentation-replay/README.md
@@ -35,14 +35,15 @@ initializeFaro({
 
 ### Privacy & Masking Options
 
-| Key                | Type                                              | Default                 | Description                                                                                                                                |
-| ------------------ | ------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `maskAllInputs`    | `boolean`                                         | `true`                  | Mask all input content                                                                                                                     |
-| `maskInputOptions` | `MaskInputOptions`                                | `{ password: true }`    | Selectively mask specific input types (used only when `maskAllInputs` is `false`)                                                          |
-| `maskInputFn`      | `(value: string, element: HTMLElement) => string` | Fixed-length `'******'` | Customize mask input content recording logic. The default returns a fixed-length mask regardless of input length to prevent length leakage |
-| `maskTextSelector` | `string`                                          | `'*'`                   | CSS selector for elements whose text content should be masked                                                                              |
-| `blockSelector`    | `string`                                          | `undefined`             | CSS selector for elements that should be blocked from recording. Blocked elements are replaced with a placeholder of the same dimensions   |
-| `ignoreSelector`   | `string`                                          | `undefined`             | CSS selector for elements whose input events should be ignored                                                                             |
+| Key                | Type                                              | Default                 | Description                                                                                                                                                                  |
+| ------------------ | ------------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sanitizeMetaHref` | `boolean`                                         | `true`                  | Strip credentials, query string, and fragment from `window.location.href` in rrweb Meta events before sending. URLs may still appear in transport metadata and DOM snapshots |
+| `maskAllInputs`    | `boolean`                                         | `true`                  | Mask all input content                                                                                                                                                       |
+| `maskInputOptions` | `MaskInputOptions`                                | `{ password: true }`    | Selectively mask specific input types (used only when `maskAllInputs` is `false`)                                                                                            |
+| `maskInputFn`      | `(value: string, element: HTMLElement) => string` | Fixed-length `'******'` | Customize mask input content recording logic. The default returns a fixed-length mask regardless of input length to prevent length leakage                                   |
+| `maskTextSelector` | `string`                                          | `'*'`                   | CSS selector for elements whose text content should be masked                                                                                                                |
+| `blockSelector`    | `string`                                          | `undefined`             | CSS selector for elements that should be blocked from recording. Blocked elements are replaced with a placeholder of the same dimensions                                     |
+| `ignoreSelector`   | `string`                                          | `undefined`             | CSS selector for elements whose input events should be ignored                                                                                                               |
 
 #### `maskInputOptions`
 

--- a/experimental/instrumentation-replay/src/const.ts
+++ b/experimental/instrumentation-replay/src/const.ts
@@ -19,6 +19,7 @@ export const defaultReplayInstrumentationOptions: ReplayInstrumentationOptions =
   recordCanvas: false,
   recordCrossOriginIframes: false,
   beforeSend: undefined,
+  sanitizeMetaHref: true,
   recordAfter: 'load',
   samplingRate: 1,
   inactivityThresholdMs: 60_000,

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -1,4 +1,13 @@
-import { genShortID } from '@grafana/faro-core';
+import {
+  BaseTransport,
+  genShortID,
+  getTransportBody,
+  initializeFaro,
+  type TransportBody,
+  type TransportItem,
+} from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+import { EventType } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn } from './const';
 import { ReplayInstrumentation } from './instrumentation';
@@ -8,6 +17,21 @@ import { MaskInputFn, ReplayInstrumentationOptions } from './types';
 jest.mock('@grafana/rrweb', () => ({
   record: jest.fn(),
 }));
+
+class BatchedBodyTransport extends BaseTransport {
+  readonly name = '@grafana/transport-batched-body-mock';
+  readonly version = 'test';
+
+  sentBodies: TransportBody[] = [];
+
+  send(items: TransportItem | TransportItem[]): void {
+    this.sentBodies.push(getTransportBody(Array.isArray(items) ? items : [items]));
+  }
+
+  override isBatched(): boolean {
+    return true;
+  }
+}
 
 function createSeededRandom(seed: number): () => number {
   let current = seed >>> 0;
@@ -70,6 +94,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: undefined,
         ignoreSelector: undefined,
         beforeSend: undefined,
+        sanitizeMetaHref: true,
         samplingRate: 1,
         inactivityThresholdMs: 60_000,
       };
@@ -97,6 +122,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: '.block-me',
         ignoreSelector: '.ignore-me',
         beforeSend: beforeSendFn,
+        sanitizeMetaHref: false,
         samplingRate: 1,
         inactivityThresholdMs: 30_000,
       };
@@ -135,6 +161,7 @@ describe('ReplayInstrumentation', () => {
         blockSelector: undefined,
         ignoreSelector: undefined,
         beforeSend: undefined,
+        sanitizeMetaHref: true,
         samplingRate: 1,
         inactivityThresholdMs: 60_000,
       };
@@ -457,6 +484,306 @@ describe('ReplayInstrumentation', () => {
 
       expect(beforeSend).toHaveBeenCalled();
       expect(mockPushEvent).not.toHaveBeenCalledWith('faro.session_recording.event', expect.anything());
+    });
+
+    it('should strip query string and fragment from Meta event href by default', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'https://example.com/app/dashboard?code=abc&token=xyz#fragment', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('https://example.com/app/dashboard');
+    });
+
+    it('should not modify non-Meta events', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const nonMetaEvent = {
+        type: 3,
+        data: { href: 'https://example.com/page?secret=value' },
+        timestamp: Date.now(),
+      };
+      emitCallback(nonMetaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('https://example.com/page?secret=value');
+    });
+
+    it('should preserve Meta event href when sanitizeMetaHref is false', () => {
+      instrumentation = new ReplayInstrumentation({ sanitizeMetaHref: false });
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'https://example.com/app?keep=this#and-this', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('https://example.com/app?keep=this#and-this');
+    });
+
+    it('should strip Meta event href before beforeSend sees the event', () => {
+      const beforeSend = jest.fn((event) => event);
+
+      instrumentation = new ReplayInstrumentation({ beforeSend });
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'https://example.com/path?token=secret', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      expect(beforeSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ href: 'https://example.com/path' }),
+        })
+      );
+    });
+
+    it('should strip Meta event href again after beforeSend returns a replacement event', () => {
+      const beforeSend: ReplayInstrumentationOptions['beforeSend'] = jest.fn(() => ({
+        type: EventType.Meta,
+        data: { href: 'https://example.com/reintroduced?token=secret#hash', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      })) as ReplayInstrumentationOptions['beforeSend'];
+
+      instrumentation = new ReplayInstrumentation({ beforeSend });
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'https://example.com/path?token=secret', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('https://example.com/reintroduced');
+    });
+
+    it('should strip credentials from Meta event href', () => {
+      instrumentation = new ReplayInstrumentation();
+      const hrefWithCredentials = new URL('https://example.com/app?token=secret#hash');
+      hrefWithCredentials.username = 'user';
+      hrefWithCredentials.password = 'password';
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: hrefWithCredentials.href, width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('https://example.com/app');
+    });
+
+    it('should leave malformed href untouched on Meta events', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'not-a-valid-url', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('not-a-valid-url');
+    });
+
+    it('should handle Meta event with missing href', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBeUndefined();
+    });
+
+    it('should leave malformed Meta event without data untouched', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed).toEqual(metaEvent);
+    });
+
+    it('should handle file:// URLs without corrupting them', () => {
+      instrumentation = new ReplayInstrumentation();
+
+      mockGetSession.mockReturnValue({
+        id: 'test-session',
+        attributes: { isSampled: 'true' },
+      });
+      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
+      instrumentation['metas'] = { addListener: mockAddListener } as any;
+
+      instrumentation.initialize();
+
+      const metaEvent = {
+        type: EventType.Meta,
+        data: { href: 'file:///android_asset/www/index.html?token=secret#hash', width: 1920, height: 1080 },
+        timestamp: Date.now(),
+      };
+      emitCallback(metaEvent);
+
+      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
+      const parsed = JSON.parse(pushed![1].event);
+      expect(parsed.data.href).toBe('file:///android_asset/www/index.html');
+    });
+
+    it('should keep Meta event href sanitized when batched after a non-replay event', () => {
+      jest.useFakeTimers();
+      try {
+        const transport = new BatchedBodyTransport();
+        instrumentation = new ReplayInstrumentation();
+        const { api } = initializeFaro(
+          mockConfig({
+            instrumentations: [instrumentation],
+            transports: [transport],
+            metas: [{ page: { url: 'https://example.com/callback?code=abc#fragment' } }],
+            batching: {
+              enabled: true,
+              sendTimeout: 1,
+              itemLimit: 10,
+            },
+          })
+        );
+
+        api.setSession({ id: 'test-session', attributes: { isSampled: 'true' } });
+        jest.advanceTimersByTime(1);
+        transport.sentBodies = [];
+
+        api.pushEvent('custom.event');
+        emitCallback({
+          type: EventType.Meta,
+          data: { href: 'https://example.com/app/dashboard?token=secret#hash', width: 1920, height: 1080 },
+          timestamp: Date.now(),
+        });
+        jest.advanceTimersByTime(1);
+
+        expect(transport.sentBodies).toHaveLength(1);
+        expect(transport.sentBodies[0]!.meta.page?.url).toBe('https://example.com/callback?code=abc#fragment');
+
+        const replayEvent = transport.sentBodies[0]!.events?.find(
+          (event) => event.name === 'faro.session_recording.event'
+        );
+        expect(replayEvent).toBeDefined();
+
+        const replayEventPayload = replayEvent!.attributes!['event'];
+        expect(replayEventPayload).toBeDefined();
+
+        const rrwebEvent = JSON.parse(replayEventPayload!);
+        expect(rrwebEvent.data.href).toBe('https://example.com/app/dashboard');
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should handle errors when pushing events gracefully', () => {

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -1,6 +1,6 @@
 import { BaseInstrumentation, clampSamplingRate, VERSION } from '@grafana/faro-core';
 import { record, type recordOptions } from '@grafana/rrweb';
-import type { eventWithTime } from '@grafana/rrweb-types';
+import { EventType, type eventWithTime } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn, defaultReplayInstrumentationOptions } from './const';
 import type { ReplayInstrumentationOptions } from './types';
@@ -270,8 +270,37 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     }, threshold);
   }
 
+  private sanitizeMetaHref(event: eventWithTime): void {
+    if (event.type !== EventType.Meta || this.options.sanitizeMetaHref === false) {
+      return;
+    }
+
+    const data = event.data;
+    if (data == null || typeof data !== 'object' || !('href' in data) || typeof data.href !== 'string') {
+      return;
+    }
+
+    data.href = this.sanitizeUrl(data.href);
+  }
+
+  private sanitizeUrl(href: string): string {
+    try {
+      const url = new URL(href);
+      url.username = '';
+      url.password = '';
+      url.search = '';
+      url.hash = '';
+      return url.href;
+    } catch {
+      // Malformed URL — leave as-is rather than risk breaking the event.
+      return href;
+    }
+  }
+
   private handleEvent(event: eventWithTime, _isCheckout?: boolean): void {
     try {
+      this.sanitizeMetaHref(event);
+
       // Apply beforeSend transformation if provided
       let processedEvent: eventWithTime | null | undefined = event;
       if (this.options.beforeSend) {
@@ -279,6 +308,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
         if (processedEvent === null || processedEvent === undefined) {
           return;
         }
+        this.sanitizeMetaHref(processedEvent);
       }
 
       this.api.pushEvent(faroSessionReplayEventName, {

--- a/experimental/instrumentation-replay/src/types.ts
+++ b/experimental/instrumentation-replay/src/types.ts
@@ -94,6 +94,21 @@ export interface ReplayInstrumentationOptions {
   inactivityThresholdMs?: number;
 
   /**
+   * Strip credentials, query string, and fragment from `window.location.href` in
+   * rrweb Meta events before they are sent.
+   *
+   * URLs routinely contain sensitive data (OAuth codes, tokens in fragments, PII in
+   * query parameters). This option removes `username`, `password`, `search`, and
+   * `hash` from replay Meta event hrefs.
+   *
+   * This does not sanitize URLs in Faro transport metadata or arbitrary URLs
+   * serialized inside rrweb DOM snapshots.
+   *
+   * @default true
+   */
+  sanitizeMetaHref?: boolean;
+
+  /**
    * The fraction of globally-sampled sessions that should also record a session replay.
    * Expressed as a number between 0 and 1.
    *


### PR DESCRIPTION
## Summary

- Strip credentials, query string, and fragment from `window.location.href` in rrweb Meta events (type 4) before replay events are pushed to the Faro transport
- On by default; opt-out via `sanitizeMetaHref: false`
- rrweb Meta event sanitization runs before replay `beforeSend`, so that hook sees the cleaned URL, and is applied again if `beforeSend` returns a replacement event
- Uses URL field mutation (`username`, `password`, `search`, and `hash`) so `file://`, `blob:`, and other non-HTTP URL schemes are not rebuilt through `origin + pathname`
- Scope note: this does not sanitize Faro transport metadata or arbitrary URLs serialized inside rrweb DOM snapshots

Addresses finding F-6 (P1) from AppSec review ASE26012.

Ref: https://github.com/grafana/session-replay/issues/92

## Test plan

- [x] `yarn jest --config experimental/instrumentation-replay/jest.config.js --runTestsByPath experimental/instrumentation-replay/src/instrumentation.test.ts`
- [x] Replay package lint (`quality:lint:eslint`, `quality:lint:prettier`, `quality:lint:md`)
- [x] Replay package build
- [x] Replay circular dependency check
- [x] CI passes