### PR TITLE
fix(ci): align Renovate npm cooldown with yarn 7-day age gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,11 @@
       "description": "Restrict ua-parser-js to version below 2.x.x as it changes licensing model with v2 onwards",
       "matchPackageNames": ["ua-parser-js"],
       "allowedVersions": "<2.0.0"
+    },
+    {
+      "description": "Enforce a 7-day release-age cooldown on ALL npm depTypes to match yarn's npmMinimalAgeGate (.yarnrc.yml). Placed last so it overrides the injected Grafana org preset rule (grafana-renovate-config//presets/npm) which only waits 3 days for runtime dependencies. Without this, Renovate proposes versions 3-7 days old that yarn then quarantines (YN0016), producing un-mergeable PRs.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate bot PRs (#2102, #2104, #2111) fail CI at `yarn install --immutable` with `YN0016 … quarantined` and stay open/un-mergeable.

Two release-age cooldowns are misaligned: yarn's `.yarnrc.yml` `npmMinimalAgeGate` is **7 days**, but the injected Grafana org Renovate preset waits only **3 days** for npm deps. A `packageRules` entry beats our top-level `minimumReleaseAge`, so Renovate proposes 3–7-day-old versions that yarn then quarantines while regenerating the lockfile (`renovate/artifacts` failure → `package.json`/`yarn.lock` mismatch → CI can't install).

## What

Add an explicit `packageRule` (placed last so it overrides the injected preset) enforcing a 7-day cooldown across all npm depTypes, matching the yarn gate:

```json
{ "matchDatasources": ["npm"], "minimumReleaseAge": "7 days" }
```

Effective once merged to `main`; the stuck bot PRs go green on their next Renovate rebase.

## Links

- Confirmed in Renovate logs: `YN0016: @opentelemetry/otlp-transformer@^0.219.0 … quarantined`.

## Checklist

- [ ] Tests added — n/a (CI config only)
- [ ] Changelog updated — n/a
- [ ] Documentation updated — n/a