### PR TITLE
feat(hackathon): remote sampling config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Features
+
+- **web-sdk:** add opt-in `remoteConfig` option for a remotely-configured session sampling rate. When provided, the SDK initializes instrumentation immediately, buffers outgoing telemetry in a bounded in-memory queue, resolves the per-app sampling rate (cache-first, with a hard timeout and ETag-based background revalidation), finalizes the session sampling decision exactly once, then flushes-or-drops the buffer. `initializeFaro()` remains synchronous; when `remoteConfig` is absent, behavior is unchanged.
+
 ## [2.7.1](https://github.com/grafana/faro-web-sdk/compare/v2.7.0...v2.7.1) (2026-06-03)
 
 ### Bug Fixes

--- a/packages/core/src/api/apiTestHelpers.ts
+++ b/packages/core/src/api/apiTestHelpers.ts
@@ -28,6 +28,10 @@ export const mockTransports: Transports = {
   unpause: function (): void {
     throw new Error('Function not implemented.');
   },
+  hold: jest.fn(),
+  flushHeld: jest.fn(),
+  dropHeld: jest.fn(),
+  isHolding: jest.fn(),
 };
 
 export const mockTracesApi: TracesAPI = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,7 @@ export * from './semantic';
 export { BaseTransport, getTransportBody, TransportItemType, transportItemTypeToBodyKey } from './transports';
 export type {
   BeforeSendHook,
+  HoldOptions,
   SendFn,
   Transport,
   TransportBody,

--- a/packages/core/src/transports/hold.test.ts
+++ b/packages/core/src/transports/hold.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import { mockConfig, mockInternalLogger } from '../testUtils';
+import { unpatchedConsole } from '../unpatchedConsole';
+import { VERSION } from '../version';
+
+import { BaseTransport } from './base';
+import { TransportItemType } from './const';
+import { initializeTransports } from './initialize';
+import type { Transport, TransportItem } from './types';
+
+class CollectingTransport extends BaseTransport implements Transport {
+  readonly name = '@grafana/transport-collecting';
+  readonly version = VERSION;
+
+  sentItems: TransportItem[] = [];
+
+  send(items: TransportItem | TransportItem[]): void | Promise<void> {
+    const itemsArray = Array.isArray(items) ? items : [items];
+    this.sentItems.push(...itemsArray);
+  }
+}
+
+const generateItem = (message = 'hi'): TransportItem => ({
+  type: TransportItemType.LOG,
+  payload: {
+    context: {},
+    level: 'info' as any,
+    message,
+    timestamp: '2023-01-27T09:53:01.035Z',
+  } as any,
+  meta: {},
+});
+
+function makeTransports() {
+  const transport = new CollectingTransport();
+  const metas = {
+    add: jest.fn(),
+    remove: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    value: {},
+  } as any;
+
+  const transports = initializeTransports(
+    unpatchedConsole,
+    mockInternalLogger,
+    mockConfig({ batching: { enabled: false }, transports: [transport] }),
+    metas
+  );
+  transports.add(transport);
+
+  return { transport, transports };
+}
+
+describe('transports hold buffer', () => {
+  it('buffers items while holding instead of sending them', () => {
+    const { transport, transports } = makeTransports();
+
+    transports.hold();
+    transports.execute(generateItem('a'));
+    transports.execute(generateItem('b'));
+
+    expect(transports.isHolding()).toBe(true);
+    expect(transport.sentItems).toHaveLength(0);
+  });
+
+  it('flushHeld sends all buffered items and resumes streaming', () => {
+    const { transport, transports } = makeTransports();
+
+    transports.hold();
+    transports.execute(generateItem('a'));
+    transports.execute(generateItem('b'));
+
+    transports.flushHeld();
+
+    expect(transports.isHolding()).toBe(false);
+    expect(transport.sentItems).toHaveLength(2);
+
+    // streams normally after flush
+    transports.execute(generateItem('c'));
+    expect(transport.sentItems).toHaveLength(3);
+  });
+
+  it('dropHeld discards buffered items and resumes streaming', () => {
+    const { transport, transports } = makeTransports();
+
+    transports.hold();
+    transports.execute(generateItem('a'));
+
+    transports.dropHeld();
+
+    expect(transports.isHolding()).toBe(false);
+    expect(transport.sentItems).toHaveLength(0);
+
+    transports.execute(generateItem('c'));
+    expect(transport.sentItems).toHaveLength(1);
+  });
+
+  it('invokes onBufferFull once when the byte cap is exceeded', () => {
+    const { transports } = makeTransports();
+    const onBufferFull = jest.fn();
+
+    // Tiny cap so a single item exceeds it.
+    transports.hold({ maxBufferBytes: 10, onBufferFull });
+
+    transports.execute(generateItem('first'));
+    transports.execute(generateItem('second'));
+
+    expect(onBufferFull).toHaveBeenCalledTimes(1);
+  });
+
+  it('hold is a no-op when already holding; flush/drop are no-ops when not holding', () => {
+    const { transport, transports } = makeTransports();
+
+    expect(() => transports.flushHeld()).not.toThrow();
+    expect(() => transports.dropHeld()).not.toThrow();
+
+    transports.hold();
+    transports.hold();
+    transports.execute(generateItem('a'));
+    transports.flushHeld();
+
+    expect(transport.sentItems).toHaveLength(1);
+  });
+});

--- a/packages/core/src/transports/index.ts
+++ b/packages/core/src/transports/index.ts
@@ -9,6 +9,7 @@ export { registerInitialTransports } from './registerInitial';
 export type {
   BatchExecutorOptions,
   BeforeSendHook,
+  HoldOptions,
   SendFn,
   Transport,
   TransportBody,

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -6,7 +6,9 @@ import type { UnpatchedConsole } from '../unpatchedConsole';
 
 import { BatchExecutor } from './batchExecutor';
 import { TransportItemType } from './const';
-import type { BeforeSendHook, Transport, TransportItem, Transports } from './types';
+import type { BeforeSendHook, HoldOptions, Transport, TransportItem, Transports } from './types';
+
+const defaultMaxBufferBytes = 64 * 1024;
 
 export function initializeTransports(
   unpatchedConsole: UnpatchedConsole,
@@ -21,6 +23,25 @@ export function initializeTransports(
   let paused = config.paused;
 
   let beforeSendHooks: BeforeSendHook[] = [];
+
+  // Pre-decision hold buffer. While holding, outgoing signals are buffered in-memory instead of
+  // being sent or dropped, so an opt-in feature (e.g. remote config) can defer the send/drop
+  // decision without losing early telemetry. Bounded by a byte cap to keep host-page memory safe.
+  let holding = false;
+  let heldItems: TransportItem[] = [];
+  let heldBytes = 0;
+  let maxHeldBytes = defaultMaxBufferBytes;
+  let bufferFullNotified = false;
+  let onBufferFull: HoldOptions['onBufferFull'];
+
+  const estimateItemBytes = (item: TransportItem): number => {
+    try {
+      return JSON.stringify(item).length;
+    } catch (err) {
+      internalLogger.debug('Failed to estimate held item size\n', err);
+      return 0;
+    }
+  };
 
   const add: Transports['add'] = (...newTransports) => {
     internalLogger.debug('Adding transports');
@@ -128,12 +149,69 @@ export function initializeTransports(
       return;
     }
 
+    if (holding) {
+      heldItems.push(item);
+      heldBytes += estimateItemBytes(item);
+
+      if (!bufferFullNotified && heldBytes > maxHeldBytes) {
+        bufferFullNotified = true;
+        onBufferFull?.();
+      }
+
+      return;
+    }
+
     if (config.batching?.enabled) {
       batchExecutor?.addItem(item);
     }
 
     instantSend(item);
   };
+
+  const hold: Transports['hold'] = (options) => {
+    if (holding) {
+      return;
+    }
+
+    internalLogger.debug('Holding transports');
+    holding = true;
+    heldItems = [];
+    heldBytes = 0;
+    bufferFullNotified = false;
+    maxHeldBytes = options?.maxBufferBytes ?? defaultMaxBufferBytes;
+    onBufferFull = options?.onBufferFull;
+  };
+
+  const releaseHold = (): TransportItem[] => {
+    const buffered = heldItems;
+    holding = false;
+    heldItems = [];
+    heldBytes = 0;
+    bufferFullNotified = false;
+    onBufferFull = undefined;
+    return buffered;
+  };
+
+  const flushHeld: Transports['flushHeld'] = () => {
+    if (!holding) {
+      return;
+    }
+
+    internalLogger.debug('Flushing held transports buffer');
+    const buffered = releaseHold();
+    buffered.forEach((item) => execute(item));
+  };
+
+  const dropHeld: Transports['dropHeld'] = () => {
+    if (!holding) {
+      return;
+    }
+
+    internalLogger.debug('Dropping held transports buffer');
+    releaseHold();
+  };
+
+  const isHolding: Transports['isHolding'] = () => holding;
 
   const getBeforeSendHooks: Transports['getBeforeSendHooks'] = () => [...beforeSendHooks];
 
@@ -188,6 +266,10 @@ export function initializeTransports(
       return [...transports];
     },
     unpause,
+    hold,
+    flushHeld,
+    dropHeld,
+    isHolding,
   };
 }
 /**

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -48,6 +48,36 @@ export interface Transports {
   transports: Transport[];
   pause: () => void;
   unpause: () => void;
+  /**
+   * Start holding (buffering) outgoing signals in a bounded in-memory queue instead of sending them.
+   * Used by opt-in features (e.g. remote config) that need to defer a send/drop decision without
+   * losing early telemetry. While holding, `execute` enqueues items rather than transporting them.
+   *
+   * `onBufferFull` is invoked once if the buffered byte size exceeds `maxBufferBytes` before the
+   * hold is released, allowing the caller to finalize early.
+   */
+  hold: (options?: HoldOptions) => void;
+  /**
+   * Release the hold and send all buffered items through the normal `execute` path, then resume
+   * streaming. No-op if not currently holding.
+   */
+  flushHeld: () => void;
+  /**
+   * Release the hold and discard all buffered items, then resume streaming. No-op if not currently
+   * holding.
+   */
+  dropHeld: () => void;
+  /**
+   * Whether the transports are currently holding (buffering) outgoing signals.
+   */
+  isHolding: () => boolean;
+}
+
+export interface HoldOptions {
+  // Maximum total byte size of buffered items before `onBufferFull` fires (default: 65536 / 64KB).
+  maxBufferBytes?: number;
+  // Invoked once when the buffered byte size first exceeds `maxBufferBytes`.
+  onBufferFull?: () => void;
 }
 
 export interface BatchExecutorOptions {

--- a/packages/web-sdk/src/config/index.ts
+++ b/packages/web-sdk/src/config/index.ts
@@ -2,4 +2,4 @@ export { getWebInstrumentations } from './getWebInstrumentations';
 
 export { makeCoreConfig } from './makeCoreConfig';
 
-export type { BrowserConfig, GetWebInstrumentationsOptions } from './types';
+export type { BrowserConfig, GetWebInstrumentationsOptions, RemoteConfigOptions } from './types';

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -20,6 +20,13 @@ export interface RemoteConfigOptions {
    */
   url?: string;
   /**
+   * Full, explicit remote-config endpoint URL, used verbatim (no app key is appended and no path is
+   * derived from it). Intended for OSS users whose backend does not follow the Grafana Cloud
+   * `/collect/{appKey}` → `/config/{appKey}` pattern. When set, it takes precedence over both `url`
+   * and the collector-derived URL, and a resolvable app key is not required.
+   */
+  configEndpoint?: string;
+  /**
    * Hard timeout (ms) for the cold-cache fetch before the SDK finalizes the sampling decision with
    * the cached/bundled default (default: 1500).
    */

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -4,6 +4,31 @@ export interface BrowserConfig extends Partial<Omit<Config, 'app' | 'parseStackt
   url?: string;
   apiKey?: string;
   requestCompression?: boolean;
+  /**
+   * Opt-in remote configuration. When provided, the SDK fetches a per-app config (currently the
+   * session sampling rate) from the collector and applies it to the current session via the
+   * defer-and-buffer lifecycle. When omitted, initialization behavior is unchanged.
+   */
+  remoteConfig?: RemoteConfigOptions;
+}
+
+export interface RemoteConfigOptions {
+  /**
+   * Base URL of the remote-config endpoint (same host as the collector). The SDK requests
+   * `${url}/config/${appKey}`. When omitted, it is derived from the collector `url`
+   * (the `/collect/{appKey}` URL) by swapping `/collect` for `/config`.
+   */
+  url?: string;
+  /**
+   * Hard timeout (ms) for the cold-cache fetch before the SDK finalizes the sampling decision with
+   * the cached/bundled default (default: 1500).
+   */
+  timeoutMs?: number;
+  /**
+   * Maximum total byte size of buffered telemetry before the SDK finalizes early as "sampled"
+   * (keep) and flushes, bounding host-page memory (default: 65536 / 64KB).
+   */
+  maxBufferBytes?: number;
 }
 
 export interface GetWebInstrumentationsOptions {

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -1,5 +1,8 @@
 export { getWebInstrumentations, makeCoreConfig } from './config';
-export type { BrowserConfig } from './config';
+export type { BrowserConfig, RemoteConfigOptions } from './config';
+
+export { REMOTE_CONFIG_SCHEMA_VERSION } from './remoteConfig';
+export type { CachedRemoteConfig, RemoteConfigResponse } from './remoteConfig';
 
 export { defaultEventDomain } from './consts';
 

--- a/packages/web-sdk/src/initialize.test.ts
+++ b/packages/web-sdk/src/initialize.test.ts
@@ -1,0 +1,54 @@
+import type { BrowserConfig } from './config';
+import { initializeFaro } from './initialize';
+import * as remoteConfig from './remoteConfig';
+
+function makeConfig(overrides: Partial<BrowserConfig> = {}): BrowserConfig {
+  return {
+    url: 'https://collector.example.com/collect/abc123',
+    app: { name: 'test', version: '1.0.0' },
+    isolate: true,
+    preventGlobalExposure: true,
+    instrumentations: [],
+    ...overrides,
+  };
+}
+
+describe('initializeFaro remote config wiring', () => {
+  let prepareSpy: jest.SpyInstance;
+  let engageSpy: jest.SpyInstance;
+  const fetchMock = jest.fn(() => Promise.reject(new Error('should not fetch')));
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    fetchMock.mockClear();
+    global.fetch = fetchMock as any;
+    prepareSpy = jest.spyOn(remoteConfig, 'prepareRemoteConfig');
+    engageSpy = jest.spyOn(remoteConfig, 'engageRemoteConfig').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('does not engage remote config and never fetches when remoteConfig is absent', () => {
+    const faro = initializeFaro(makeConfig());
+
+    expect(faro).toBeDefined();
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(engageSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns synchronously and engages remote config when enabled', () => {
+    const faro = initializeFaro(makeConfig({ remoteConfig: {} }));
+
+    // synchronous: a Faro instance is returned immediately, not a Promise
+    expect(faro).toBeDefined();
+    expect(typeof (faro as unknown as Promise<unknown>).then).not.toBe('function');
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+    expect(engageSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-sdk/src/initialize.ts
+++ b/packages/web-sdk/src/initialize.ts
@@ -1,8 +1,9 @@
-import { initializeFaro as coreInit } from '@grafana/faro-core';
+import { initializeFaro as coreInit, createInternalLogger } from '@grafana/faro-core';
 import type { Faro } from '@grafana/faro-core';
 
 import { makeCoreConfig } from './config';
 import type { BrowserConfig } from './config';
+import { engageRemoteConfig, prepareRemoteConfig } from './remoteConfig';
 
 export function initializeFaro(config: BrowserConfig): Faro {
   const coreConfig = makeCoreConfig(config);
@@ -11,5 +12,24 @@ export function initializeFaro(config: BrowserConfig): Faro {
     return undefined!;
   }
 
-  return coreInit(coreConfig);
+  // Opt-in remote config. Synchronous: the network fetch + sampling decision happen internally via
+  // the defer-and-buffer lifecycle, so the consumer never awaits. When `remoteConfig` is absent,
+  // initialization behavior is unchanged. The pre-init phase may apply a warm-cache rate to
+  // `coreConfig` before the session decision is made.
+  const remoteConfigPrep = config.remoteConfig
+    ? prepareRemoteConfig({
+        config: coreConfig,
+        collectorUrl: config.url,
+        options: config.remoteConfig,
+        internalLogger: createInternalLogger(coreConfig.unpatchedConsole, coreConfig.internalLoggerLevel),
+      })
+    : undefined;
+
+  const faro = coreInit(coreConfig);
+
+  if (faro && remoteConfigPrep) {
+    engageRemoteConfig(faro, remoteConfigPrep);
+  }
+
+  return faro;
 }

--- a/packages/web-sdk/src/initialize.ts
+++ b/packages/web-sdk/src/initialize.ts
@@ -14,8 +14,8 @@ export function initializeFaro(config: BrowserConfig): Faro {
 
   // Opt-in remote config. Synchronous: the network fetch + sampling decision happen internally via
   // the defer-and-buffer lifecycle, so the consumer never awaits. When `remoteConfig` is absent,
-  // initialization behavior is unchanged. The pre-init phase may apply a warm-cache rate to
-  // `coreConfig` before the session decision is made.
+  // initialization behavior is unchanged. The pre-init phase forces keep-all before the session
+  // decision is made; every new session then consults the live remote rate before finalizing.
   const remoteConfigPrep = config.remoteConfig
     ? prepareRemoteConfig({
         config: coreConfig,

--- a/packages/web-sdk/src/instrumentations/session/index.ts
+++ b/packages/web-sdk/src/instrumentations/session/index.ts
@@ -10,6 +10,7 @@ export {
   VolatileSessionsManager,
   defaultSessionTrackingConfig,
   isSampled,
+  markSessionNotSampled,
 } from './sessionManager';
 
 export type { FaroUserSession } from './sessionManager';

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/index.ts
@@ -12,6 +12,8 @@ export {
 
 export { isSampled } from './sampling';
 
+export { markSessionNotSampled } from './sessionManagerUtils';
+
 export type { FaroUserSession } from './types';
 
 export { getSessionManagerByConfig } from './getSessionManagerByConfig';

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sampling.ts
@@ -1,6 +1,11 @@
 import { clampSamplingRate, faro } from '@grafana/faro-core';
 
-export function isSampled(): boolean {
+export function isSampled(providedRate?: number): boolean {
+  if (providedRate !== undefined) {
+    const samplingRate = clampSamplingRate(providedRate);
+    return Math.random() < samplingRate;
+  }
+
   const sendAllSignals = 1;
   const sessionTracking = faro.config.sessionTracking;
   const rawSamplingRate =

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -13,6 +13,7 @@ import {
   createUserSessionObject,
   getUserSessionUpdater,
   isUserSessionValid,
+  markSessionNotSampled,
 } from './sessionManagerUtils';
 import type { FaroUserSession } from './types';
 import { VolatileSessionsManager } from './VolatileSessionManager';
@@ -750,6 +751,67 @@ describe('sessionManagerUtils', () => {
         serviceName: 'my-new-service',
         previousServiceName: 'my-service',
       });
+    });
+  });
+
+  describe('markSessionNotSampled', () => {
+    // Seed a live keep-all session into both faro.metas and storage, mirroring what the cold-cache
+    // remote-config lifecycle does before init (force keep-all so the session is isSampled='true').
+    function seedKeepAllSession(faro: ReturnType<typeof initializeFaro>) {
+      const sessionMeta: MetaSession = { id: mockSessionId, attributes: { isSampled: 'true', foo: 'bar' } };
+      faro.api.setSession(sessionMeta);
+      VolatileSessionsManager.storeUserSession(
+        createUserSessionObjectWithMeta(sessionMeta, { isSampled: true, sessionId: mockSessionId })
+      );
+      return sessionMeta;
+    }
+
+    function createUserSessionObjectWithMeta(
+      sessionMeta: MetaSession,
+      { isSampled, sessionId }: { isSampled: boolean; sessionId: string }
+    ): FaroUserSession {
+      return { ...createUserSessionObject({ sessionId, isSampled }), sessionMeta };
+    }
+
+    it('flips the live session meta isSampled to "false" in place without changing the id', () => {
+      const faro = initializeFaro(mockConfig({}));
+      seedKeepAllSession(faro);
+
+      // pre-condition: keep-all session
+      expect(faro.metas.value.session?.attributes?.['isSampled']).toBe('true');
+
+      markSessionNotSampled(VolatileSessionsManager);
+
+      expect(faro.metas.value.session?.id).toBe(mockSessionId);
+      expect(faro.metas.value.session?.attributes?.['isSampled']).toBe('false');
+      // unrelated attributes are preserved
+      expect(faro.metas.value.session?.attributes?.['foo']).toBe('bar');
+    });
+
+    it('does NOT re-derive the decision probabilistically (never calls isSampled)', () => {
+      const faro = initializeFaro(mockConfig({}));
+      seedKeepAllSession(faro);
+
+      const isSampledSpy = jest.spyOn(samplingModule, 'isSampled');
+
+      markSessionNotSampled(VolatileSessionsManager);
+
+      expect(isSampledSpy).not.toHaveBeenCalled();
+    });
+
+    it('persists isSampled=false to the stored session, keeping the same id', () => {
+      const faro = initializeFaro(mockConfig({}));
+      seedKeepAllSession(faro);
+
+      const stored = VolatileSessionsManager.fetchUserSession();
+      expect(stored?.isSampled).toBe(true);
+
+      markSessionNotSampled(VolatileSessionsManager);
+
+      const afterFlip = VolatileSessionsManager.fetchUserSession();
+      expect(afterFlip?.sessionId).toBe(stored?.sessionId);
+      expect(afterFlip?.isSampled).toBe(false);
+      expect(afterFlip?.sessionMeta?.attributes?.['isSampled']).toBe('false');
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -170,7 +170,7 @@ export function getSessionMetaUpdateHandler({
 /**
  * Force the *current* session to be treated as not-sampled, in place.
  *
- * This is used by the remote-config cold-cache lifecycle: the session was created keep-all
+ * This is used by the remote-config defer-and-buffer lifecycle: the session was created keep-all
  * (`isSampled='true'`) so its before-send hook never pre-drops while the remote rate is resolving.
  * Once the remote decision lands as "not sampled", we flip the live session so the existing session
  * before-send hook drops all subsequent items for this session.

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -5,7 +5,7 @@ import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../uti
 
 import { isSampled } from './sampling';
 import { SESSION_EXPIRATION_TIME, SESSION_INACTIVITY_TIME } from './sessionConstants';
-import type { FaroUserSession } from './types';
+import type { FaroUserSession, SessionManager } from './types';
 
 type CreateUserSessionObjectParams = {
   sessionId?: string;
@@ -165,6 +165,62 @@ export function getSessionMetaUpdateHandler({
       }
     }
   };
+}
+
+/**
+ * Force the *current* session to be treated as not-sampled, in place.
+ *
+ * This is used by the remote-config cold-cache lifecycle: the session was created keep-all
+ * (`isSampled='true'`) so its before-send hook never pre-drops while the remote rate is resolving.
+ * Once the remote decision lands as "not sampled", we flip the live session so the existing session
+ * before-send hook drops all subsequent items for this session.
+ *
+ * Critically this does NOT:
+ * - create a new session id (the current session continues), or
+ * - go through `faro.api.setSession` (which would trigger the meta update handler and re-derive the
+ *   sampling decision probabilistically via `isSampled()`, undoing the forced value).
+ *
+ * Instead it mutates the live session meta attributes in place (items snapshot `metas.value` at send
+ * time, so subsequent items observe the change) and persists `isSampled=false` to the stored session
+ * so resumes/updates keep the same decision.
+ *
+ * The active `SessionManager` (volatile or persistent) is passed in by the caller to avoid a circular
+ * dependency between this module and `getSessionManagerByConfig`.
+ */
+export function markSessionNotSampled(SessionManager: SessionManager): void {
+  const liveSession = faro.metas?.value?.session;
+
+  if (liveSession != null) {
+    liveSession.attributes = {
+      ...liveSession.attributes,
+      isSampled: 'false',
+    };
+  }
+
+  const sessionTrackingConfig = faro.config?.sessionTracking;
+  const isPersistentSessions = sessionTrackingConfig?.persistent;
+
+  if ((isPersistentSessions && !isLocalStorageAvailable) || (!isPersistentSessions && !isSessionStorageAvailable)) {
+    return;
+  }
+
+  const storedSession = SessionManager.fetchUserSession();
+
+  if (storedSession != null) {
+    SessionManager.storeUserSession({
+      ...storedSession,
+      isSampled: false,
+      sessionMeta: storedSession.sessionMeta
+        ? {
+            ...storedSession.sessionMeta,
+            attributes: {
+              ...storedSession.sessionMeta.attributes,
+              isSampled: 'false',
+            },
+          }
+        : storedSession.sessionMeta,
+    });
+  }
 }
 
 function removeUndefinedValues(obj: Record<string, string | undefined>): Record<string, string> {

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -192,7 +192,7 @@ export function markSessionNotSampled(SessionManager: SessionManager): void {
 
   if (liveSession != null) {
     liveSession.attributes = {
-      ...liveSession.attributes,
+      ...(liveSession.attributes ?? {}),
       isSampled: 'false',
     };
   }
@@ -214,7 +214,7 @@ export function markSessionNotSampled(SessionManager: SessionManager): void {
         ? {
             ...storedSession.sessionMeta,
             attributes: {
-              ...storedSession.sessionMeta.attributes,
+              ...(storedSession.sessionMeta.attributes ?? {}),
               isSampled: 'false',
             },
           }

--- a/packages/web-sdk/src/remoteConfig/applySampling.ts
+++ b/packages/web-sdk/src/remoteConfig/applySampling.ts
@@ -1,0 +1,9 @@
+import { clampSamplingRate } from '@grafana/faro-core';
+
+/**
+ * Compute a one-time sampled decision for the given rate. Mirrors `isSampled()` but takes an
+ * explicit rate so the decision can be made exactly once at finalize time.
+ */
+export function decideSampled(sampleRate: number): boolean {
+  return Math.random() < clampSamplingRate(sampleRate);
+}

--- a/packages/web-sdk/src/remoteConfig/applySampling.ts
+++ b/packages/web-sdk/src/remoteConfig/applySampling.ts
@@ -1,9 +1,0 @@
-import { clampSamplingRate } from '@grafana/faro-core';
-
-/**
- * Compute a one-time sampled decision for the given rate. Mirrors `isSampled()` but takes an
- * explicit rate so the decision can be made exactly once at finalize time.
- */
-export function decideSampled(sampleRate: number): boolean {
-  return Math.random() < clampSamplingRate(sampleRate);
-}

--- a/packages/web-sdk/src/remoteConfig/cache.test.ts
+++ b/packages/web-sdk/src/remoteConfig/cache.test.ts
@@ -1,0 +1,42 @@
+import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
+
+import { getCacheKey, readCachedConfig, writeCachedConfig } from './cache';
+import { REMOTE_CONFIG_SCHEMA_VERSION } from './types';
+
+describe('remoteConfig cache', () => {
+  const appKey = 'abc123';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('keys the cache by app key and schema version', () => {
+    expect(getCacheKey(appKey)).toBe(`faro_remote_config_v${REMOTE_CONFIG_SCHEMA_VERSION}_${appKey}`);
+  });
+
+  it('round-trips a written config', () => {
+    writeCachedConfig(appKey, { config: { version: '1', sampleRate: 0.5 }, etag: 'e1' }, mockInternalLogger);
+
+    const read = readCachedConfig(appKey, mockInternalLogger);
+    expect(read).toEqual({ config: { version: '1', sampleRate: 0.5 }, etag: 'e1' });
+  });
+
+  it('returns null on a cold cache', () => {
+    expect(readCachedConfig(appKey, mockInternalLogger)).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    window.localStorage.setItem(getCacheKey(appKey), '{ not json');
+    expect(readCachedConfig(appKey, mockInternalLogger)).toBeNull();
+  });
+
+  it('returns null when the cached schema version does not match', () => {
+    window.localStorage.setItem(getCacheKey(appKey), JSON.stringify({ config: { version: '999', sampleRate: 0.5 } }));
+    expect(readCachedConfig(appKey, mockInternalLogger)).toBeNull();
+  });
+
+  it('returns null when the cached payload fails validation', () => {
+    window.localStorage.setItem(getCacheKey(appKey), JSON.stringify({ config: { version: '1', sampleRate: 5 } }));
+    expect(readCachedConfig(appKey, mockInternalLogger)).toBeNull();
+  });
+});

--- a/packages/web-sdk/src/remoteConfig/cache.test.ts
+++ b/packages/web-sdk/src/remoteConfig/cache.test.ts
@@ -15,10 +15,10 @@ describe('remoteConfig cache', () => {
   });
 
   it('round-trips a written config', () => {
-    writeCachedConfig(appKey, { config: { version: '1', sampleRate: 0.5 }, etag: 'e1' }, mockInternalLogger);
+    writeCachedConfig(appKey, { config: { version: '1', sampleRate: 0.5 } }, mockInternalLogger);
 
     const read = readCachedConfig(appKey, mockInternalLogger);
-    expect(read).toEqual({ config: { version: '1', sampleRate: 0.5 }, etag: 'e1' });
+    expect(read).toEqual({ config: { version: '1', sampleRate: 0.5 } });
   });
 
   it('returns null on a cold cache', () => {

--- a/packages/web-sdk/src/remoteConfig/cache.ts
+++ b/packages/web-sdk/src/remoteConfig/cache.ts
@@ -1,0 +1,55 @@
+import type { InternalLogger } from '@grafana/faro-core';
+
+import { getItem, setItem, webStorageType } from '../utils/webStorage';
+
+import { isValidRemoteConfig } from './fetcher';
+import { REMOTE_CONFIG_SCHEMA_VERSION } from './types';
+import type { CachedRemoteConfig } from './types';
+
+/**
+ * Build the `localStorage` cache key for an app, scoped by schema version so a version bump
+ * invalidates all previously cached configs.
+ */
+export function getCacheKey(appKey: string): string {
+  return `faro_remote_config_v${REMOTE_CONFIG_SCHEMA_VERSION}_${appKey}`;
+}
+
+/**
+ * Read the cached config for an app synchronously. Returns `null` on a cold cache, malformed
+ * payload, or a payload whose schema version does not match the current one.
+ */
+export function readCachedConfig(appKey: string, internalLogger: InternalLogger): CachedRemoteConfig | null {
+  try {
+    const raw = getItem(getCacheKey(appKey), webStorageType.local);
+
+    if (raw == null) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as CachedRemoteConfig;
+
+    if (!parsed?.config || !isValidRemoteConfig(parsed.config)) {
+      return null;
+    }
+
+    if (parsed.config.version !== REMOTE_CONFIG_SCHEMA_VERSION) {
+      return null;
+    }
+
+    return parsed;
+  } catch (err) {
+    internalLogger.debug('Failed to read cached remote config\n', err);
+    return null;
+  }
+}
+
+/**
+ * Persist the resolved config (and its `ETag`) for the next page load.
+ */
+export function writeCachedConfig(appKey: string, value: CachedRemoteConfig, internalLogger: InternalLogger): void {
+  try {
+    setItem(getCacheKey(appKey), JSON.stringify(value), webStorageType.local);
+  } catch (err) {
+    internalLogger.debug('Failed to write cached remote config\n', err);
+  }
+}

--- a/packages/web-sdk/src/remoteConfig/cache.ts
+++ b/packages/web-sdk/src/remoteConfig/cache.ts
@@ -44,7 +44,7 @@ export function readCachedConfig(appKey: string, internalLogger: InternalLogger)
 }
 
 /**
- * Persist the resolved config (and its `ETag`) for the next page load.
+ * Persist the resolved config for the next page load.
  */
 export function writeCachedConfig(appKey: string, value: CachedRemoteConfig, internalLogger: InternalLogger): void {
   try {

--- a/packages/web-sdk/src/remoteConfig/fetcher.test.ts
+++ b/packages/web-sdk/src/remoteConfig/fetcher.test.ts
@@ -1,0 +1,130 @@
+import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
+
+import { buildConfigUrl, extractAppKey, fetchRemoteConfig, isValidRemoteConfig } from './fetcher';
+
+describe('remoteConfig fetcher', () => {
+  describe('extractAppKey', () => {
+    it('extracts the app key from a collector URL', () => {
+      expect(extractAppKey('https://collector.example.com/collect/abc123')).toBe('abc123');
+      expect(extractAppKey('https://collector.example.com/collect/abc123?foo=bar')).toBe('abc123');
+    });
+
+    it('returns null when no key segment is present', () => {
+      expect(extractAppKey('https://collector.example.com/collect')).toBeNull();
+      expect(extractAppKey(undefined)).toBeNull();
+    });
+  });
+
+  describe('buildConfigUrl', () => {
+    it('uses an explicit base url when provided', () => {
+      expect(buildConfigUrl('abc123', undefined, 'https://cfg.example.com')).toBe(
+        'https://cfg.example.com/config/abc123'
+      );
+      expect(buildConfigUrl('abc123', undefined, 'https://cfg.example.com/')).toBe(
+        'https://cfg.example.com/config/abc123'
+      );
+    });
+
+    it('derives the config url from the collector url', () => {
+      expect(buildConfigUrl('abc123', 'https://collector.example.com/collect/abc123')).toBe(
+        'https://collector.example.com/config/abc123'
+      );
+    });
+
+    it('returns null when it cannot derive a url', () => {
+      expect(buildConfigUrl('abc123', undefined)).toBeNull();
+      expect(buildConfigUrl('abc123', 'https://example.com/no-collect-here')).toBeNull();
+    });
+  });
+
+  describe('isValidRemoteConfig', () => {
+    it('accepts a valid config with and without sampleRate', () => {
+      expect(isValidRemoteConfig({ version: '1', sampleRate: 0.5 })).toBe(true);
+      expect(isValidRemoteConfig({ version: '1' })).toBe(true);
+      expect(isValidRemoteConfig({ version: '1', sampleRate: 0 })).toBe(true);
+      expect(isValidRemoteConfig({ version: '1', sampleRate: 1 })).toBe(true);
+    });
+
+    it('rejects malformed configs', () => {
+      expect(isValidRemoteConfig(null)).toBe(false);
+      expect(isValidRemoteConfig('nope')).toBe(false);
+      expect(isValidRemoteConfig({})).toBe(false);
+      expect(isValidRemoteConfig({ version: 1 })).toBe(false);
+      expect(isValidRemoteConfig({ version: '1', sampleRate: 1.5 })).toBe(false);
+      expect(isValidRemoteConfig({ version: '1', sampleRate: -0.1 })).toBe(false);
+      expect(isValidRemoteConfig({ version: '1', sampleRate: 'x' })).toBe(false);
+    });
+  });
+
+  describe('fetchRemoteConfig', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.clearAllMocks();
+    });
+
+    it('returns updated with the parsed config and ETag on 200', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ version: '1', sampleRate: 0.25 }),
+        headers: { get: (name: string) => (name === 'ETag' ? 'etag-1' : null) },
+      }) as any;
+
+      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger);
+
+      expect(result).toEqual({
+        kind: 'updated',
+        value: { config: { version: '1', sampleRate: 0.25 }, etag: 'etag-1' },
+      });
+    });
+
+    it('sends If-None-Match and returns not-modified on 304', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        status: 304,
+        ok: false,
+        headers: { get: () => null },
+      });
+      global.fetch = fetchMock as any;
+
+      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger, 'etag-1');
+
+      expect(result).toEqual({ kind: 'not-modified' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://x/config/k',
+        expect.objectContaining({ headers: { 'If-None-Match': 'etag-1' } })
+      );
+    });
+
+    it('returns error on a non-ok status', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 500,
+        ok: false,
+        headers: { get: () => null },
+      }) as any;
+
+      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger);
+      expect(result).toEqual({ kind: 'error' });
+    });
+
+    it('returns error on a malformed body', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ not: 'valid' }),
+        headers: { get: () => null },
+      }) as any;
+
+      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger);
+      expect(result).toEqual({ kind: 'error' });
+    });
+
+    it('returns error (never throws) when fetch rejects', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as any;
+
+      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger);
+      expect(result).toEqual({ kind: 'error' });
+    });
+  });
+});

--- a/packages/web-sdk/src/remoteConfig/fetcher.test.ts
+++ b/packages/web-sdk/src/remoteConfig/fetcher.test.ts
@@ -64,37 +64,20 @@ describe('remoteConfig fetcher', () => {
       jest.clearAllMocks();
     });
 
-    it('returns updated with the parsed config and ETag on 200', async () => {
+    it('returns updated with the parsed config on 200', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         status: 200,
         ok: true,
         json: async () => ({ version: '1', sampleRate: 0.25 }),
-        headers: { get: (name: string) => (name === 'ETag' ? 'etag-1' : null) },
+        headers: { get: () => null },
       }) as any;
 
       const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger);
 
       expect(result).toEqual({
         kind: 'updated',
-        value: { config: { version: '1', sampleRate: 0.25 }, etag: 'etag-1' },
+        value: { config: { version: '1', sampleRate: 0.25 } },
       });
-    });
-
-    it('sends If-None-Match and returns not-modified on 304', async () => {
-      const fetchMock = jest.fn().mockResolvedValue({
-        status: 304,
-        ok: false,
-        headers: { get: () => null },
-      });
-      global.fetch = fetchMock as any;
-
-      const result = await fetchRemoteConfig('https://x/config/k', 1500, mockInternalLogger, 'etag-1');
-
-      expect(result).toEqual({ kind: 'not-modified' });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://x/config/k',
-        expect.objectContaining({ headers: { 'If-None-Match': 'etag-1' } })
-      );
     });
 
     it('returns error on a non-ok status', async () => {

--- a/packages/web-sdk/src/remoteConfig/fetcher.ts
+++ b/packages/web-sdk/src/remoteConfig/fetcher.ts
@@ -1,0 +1,136 @@
+import type { InternalLogger } from '@grafana/faro-core';
+
+import { REMOTE_CONFIG_SCHEMA_VERSION } from './types';
+import type { CachedRemoteConfig, RemoteConfigResponse } from './types';
+
+/**
+ * Outcome of a remote-config fetch.
+ * - `updated`: the endpoint returned a fresh config (200).
+ * - `not-modified`: the endpoint returned 304 (the cached config is still current).
+ * - `error`: anything went wrong (network, timeout, parse, non-2xx/304). The caller falls back to
+ *   the cached/bundled default; the SDK never throws out of init.
+ */
+export type FetchResult = { kind: 'updated'; value: CachedRemoteConfig } | { kind: 'not-modified' } | { kind: 'error' };
+
+/**
+ * Validate the response DTO. `sampleRate`, when present, must be a finite number in `[0, 1]`.
+ */
+export function isValidRemoteConfig(value: unknown): value is RemoteConfigResponse {
+  if (typeof value !== 'object' || value == null) {
+    return false;
+  }
+
+  const config = value as Partial<RemoteConfigResponse>;
+
+  if (typeof config.version !== 'string') {
+    return false;
+  }
+
+  if (config.sampleRate !== undefined) {
+    if (typeof config.sampleRate !== 'number' || !isFinite(config.sampleRate)) {
+      return false;
+    }
+
+    if (config.sampleRate < 0 || config.sampleRate > 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Extract the app key from a collector URL of the form `https://host/collect/{appKey}`.
+ * Returns `null` when no key segment is present.
+ */
+export function extractAppKey(collectorUrl: string | undefined): string | null {
+  if (!collectorUrl) {
+    return null;
+  }
+
+  const match = collectorUrl.match(/\/collect\/([^/?#]+)/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Build the config URL. When an explicit base `url` is provided, requests `${url}/config/${appKey}`.
+ * Otherwise derives it from the collector URL by swapping the `/collect[/{key}]` suffix for
+ * `/config/{appKey}`.
+ */
+export function buildConfigUrl(appKey: string, collectorUrl: string | undefined, baseUrl?: string): string | null {
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/$/, '')}/config/${appKey}`;
+  }
+
+  if (collectorUrl) {
+    const swapped = collectorUrl.replace(/\/collect(?:\/[^/?#]*)?(?=$|[?#])/, `/config/${appKey}`);
+
+    if (swapped !== collectorUrl) {
+      return swapped;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Fetch the remote config with a hard timeout and conditional (`If-None-Match`) revalidation.
+ * Never throws — all failures resolve to `{ kind: 'error' }`.
+ */
+export async function fetchRemoteConfig(
+  url: string,
+  timeoutMs: number,
+  internalLogger: InternalLogger,
+  etag?: string
+): Promise<FetchResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const headers: Record<string, string> = {};
+
+    if (etag) {
+      headers['If-None-Match'] = etag;
+    }
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    });
+
+    if (response.status === 304) {
+      return { kind: 'not-modified' };
+    }
+
+    if (!response.ok) {
+      internalLogger.debug(`Remote config fetch returned non-ok status ${response.status}`);
+      return { kind: 'error' };
+    }
+
+    const body = (await response.json()) as unknown;
+
+    if (!isValidRemoteConfig(body)) {
+      internalLogger.debug('Remote config response failed validation\n', body);
+      return { kind: 'error' };
+    }
+
+    if (body.version !== REMOTE_CONFIG_SCHEMA_VERSION) {
+      internalLogger.debug(`Remote config schema version mismatch: ${body.version}`);
+      return { kind: 'error' };
+    }
+
+    return {
+      kind: 'updated',
+      value: {
+        config: body,
+        etag: response.headers.get('ETag') ?? undefined,
+      },
+    };
+  } catch (err) {
+    internalLogger.debug('Remote config fetch failed\n', err);
+    return { kind: 'error' };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/web-sdk/src/remoteConfig/fetcher.ts
+++ b/packages/web-sdk/src/remoteConfig/fetcher.ts
@@ -6,11 +6,10 @@ import type { CachedRemoteConfig, RemoteConfigResponse } from './types';
 /**
  * Outcome of a remote-config fetch.
  * - `updated`: the endpoint returned a fresh config (200).
- * - `not-modified`: the endpoint returned 304 (the cached config is still current).
- * - `error`: anything went wrong (network, timeout, parse, non-2xx/304). The caller falls back to
+ * - `error`: anything went wrong (network, timeout, parse, non-2xx). The caller falls back to
  *   the cached/bundled default; the SDK never throws out of init.
  */
-export type FetchResult = { kind: 'updated'; value: CachedRemoteConfig } | { kind: 'not-modified' } | { kind: 'error' };
+export type FetchResult = { kind: 'updated'; value: CachedRemoteConfig } | { kind: 'error' };
 
 /**
  * Validate the response DTO. `sampleRate`, when present, must be a finite number in `[0, 1]`.
@@ -74,34 +73,22 @@ export function buildConfigUrl(appKey: string, collectorUrl: string | undefined,
 }
 
 /**
- * Fetch the remote config with a hard timeout and conditional (`If-None-Match`) revalidation.
- * Never throws — all failures resolve to `{ kind: 'error' }`.
+ * Fetch the remote config with a hard timeout. Never throws — all failures resolve to
+ * `{ kind: 'error' }`.
  */
 export async function fetchRemoteConfig(
   url: string,
   timeoutMs: number,
-  internalLogger: InternalLogger,
-  etag?: string
+  internalLogger: InternalLogger
 ): Promise<FetchResult> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const headers: Record<string, string> = {};
-
-    if (etag) {
-      headers['If-None-Match'] = etag;
-    }
-
     const response = await fetch(url, {
       method: 'GET',
-      headers,
       signal: controller.signal,
     });
-
-    if (response.status === 304) {
-      return { kind: 'not-modified' };
-    }
 
     if (!response.ok) {
       internalLogger.debug(`Remote config fetch returned non-ok status ${response.status}`);
@@ -124,7 +111,6 @@ export async function fetchRemoteConfig(
       kind: 'updated',
       value: {
         config: body,
-        etag: response.headers.get('ETag') ?? undefined,
       },
     };
   } catch (err) {

--- a/packages/web-sdk/src/remoteConfig/index.ts
+++ b/packages/web-sdk/src/remoteConfig/index.ts
@@ -1,0 +1,5 @@
+export { DEFAULT_MAX_BUFFER_BYTES, DEFAULT_TIMEOUT_MS, engageRemoteConfig, prepareRemoteConfig } from './remoteConfig';
+export type { PreInitResult, RemoteConfigFaro } from './remoteConfig';
+
+export { REMOTE_CONFIG_SCHEMA_VERSION } from './types';
+export type { CachedRemoteConfig, RemoteConfigResponse } from './types';

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
@@ -185,7 +185,7 @@ describe('remoteConfig orchestrator', () => {
     it('forces keep-all and never applies a warm cached rate instantly (the warm path now defers)', () => {
       window.localStorage.setItem(
         getCacheKey(appKey),
-        JSON.stringify({ config: { version: '1', sampleRate: 0.1 }, etag: 'e1' })
+        JSON.stringify({ config: { version: '1', sampleRate: 0.1 } })
       );
       const config = mockSessionConfig({ samplingRate: 0.5 });
 
@@ -194,9 +194,8 @@ describe('remoteConfig orchestrator', () => {
       // Unified deferred path: even with a warm cache, the rate is NOT applied to the live config now.
       expect(prep.mode).toBe('deferred');
       expect(config.sessionTracking!.samplingRate).toBe(1);
-      // The cached rate becomes the fallback (for 304 / fetch-failure), plus the etag is carried.
+      // The cached rate becomes the fallback (for fetch-failure).
       expect(prep.fallbackRate).toBe(0.1);
-      expect(prep.cachedEtag).toBe('e1');
       expect(prep.cacheId).toBe(appKey);
     });
 
@@ -205,7 +204,7 @@ describe('remoteConfig orchestrator', () => {
       // The cached entry is keyed by the app ID (config.app.name), NOT the configEndpoint URL.
       window.localStorage.setItem(
         getCacheKey('my-app'),
-        JSON.stringify({ config: { version: '1', sampleRate: 0.2 }, etag: 'e9' })
+        JSON.stringify({ config: { version: '1', sampleRate: 0.2 } })
       );
       const config = mockSessionConfig({ samplingRate: 0.5 });
       (config as any).app = { name: 'my-app' };
@@ -222,7 +221,6 @@ describe('remoteConfig orchestrator', () => {
       // The cached rate is the fallback, not the live rate (live is forced to keep-all).
       expect(config.sessionTracking!.samplingRate).toBe(1);
       expect(prep.fallbackRate).toBe(0.2);
-      expect(prep.cachedEtag).toBe('e9');
     });
 
     it('cold cache (no entry) stashes the local rate as fallback and forces keep-all (1) before init', () => {
@@ -235,8 +233,6 @@ describe('remoteConfig orchestrator', () => {
       // ...and the live config is forced to keep-all so the session is created isSampled='true' and
       // its before-send hook never pre-drops before the remote decision lands.
       expect(config.sessionTracking!.samplingRate).toBe(1);
-      // No cache entry => no etag to revalidate against.
-      expect(prep.cachedEtag).toBeUndefined();
     });
 
     it('cold cache stashes undefined fallback when no local rate is set', () => {
@@ -259,17 +255,16 @@ describe('remoteConfig orchestrator', () => {
       maxBufferBytes: 64 * 1024,
     };
 
-    it('the warm path now HOLDS and conditionally fetches (sends If-None-Match)', () => {
+    it('the warm path now HOLDS and fetches the live rate', () => {
       // fetch stays pending so the hold is observable.
       fetchSpy.mockReturnValue(new Promise(() => {}));
       const faro = makeMockFaro(mockSessionConfig());
 
-      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.2 });
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.2 });
 
       // Warm no longer streams instantly — it holds while the live rate is fetched.
       expect(faro.transports.isHolding()).toBe(true);
-      // The cached etag is sent so the server can answer 304.
-      expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), 1500, mockInternalLogger, 'e1');
+      expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), 1500, mockInternalLogger);
     });
 
     it('buffers early telemetry then flushes when finalized as sampled', async () => {
@@ -323,8 +318,8 @@ describe('remoteConfig orchestrator', () => {
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
 
       const faro = makeMockFaro(mockSessionConfig());
-      // Warm: cached/fallback rate is 1.0, etag present.
-      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 1 });
+      // Warm: cached/fallback rate is 1.0.
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 1 });
 
       (faro as any).push('early');
       await Promise.resolve();
@@ -336,40 +331,6 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.dropped).toBe(1);
       // The live config reflects the fetched rate.
       expect(faro.config.sessionTracking!.samplingRate).toBe(0);
-    });
-
-    it('304 (not-modified) finalizes against the cached/fallback rate — keep', async () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.3); // 0.3 < 0.5 => sampled
-      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
-
-      const faro = makeMockFaro(mockSessionConfig());
-      // Warm cache: 304 means "your cache is current" → defer to the cached/fallback rate 0.5.
-      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.5 });
-
-      (faro as any).push('early');
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(faro.transports.isHolding()).toBe(false);
-      // 0.3 < 0.5 => sampled => flushed.
-      expect(faro.sent).toContain('early');
-      expect(faro.config.sessionTracking!.samplingRate).toBe(0.5);
-    });
-
-    it('304 (not-modified) finalizes against the cached/fallback rate — drop', async () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 !< 0.5 => not sampled
-      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
-
-      const faro = makeMockFaro(mockSessionConfig());
-      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.5 });
-
-      (faro as any).push('early');
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(faro.transports.isHolding()).toBe(false);
-      expect(faro.sent).not.toContain('early');
-      expect(faro.dropped).toBe(1);
     });
 
     it('falls back to the fallback rate on fetch error — fallback keeps the session', async () => {
@@ -498,8 +459,8 @@ describe('remoteConfig orchestrator', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // (a) the endpoint is fetched verbatim — not transformed (no etag on a cold cache).
-      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger, undefined);
+      // (a) the endpoint is fetched verbatim — not transformed.
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
       // (b) the resolved config is cached under the app-ID-derived key — never the endpoint URL.
       expect(window.localStorage.getItem(getCacheKey('my-app'))).not.toBeNull();
       expect(window.localStorage.getItem(getCacheKey(configEndpoint))).toBeNull();
@@ -527,7 +488,7 @@ describe('remoteConfig orchestrator', () => {
       await Promise.resolve();
 
       // The endpoint is still fetched verbatim — the fetch lifecycle is unaffected.
-      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger, undefined);
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
       // No write to localStorage — no missing/colliding key.
       expect(setItemSpy).not.toHaveBeenCalled();
       expect(faro.transports.isHolding()).toBe(false);

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
@@ -1,0 +1,367 @@
+import type { Config } from '@grafana/faro-core';
+import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
+
+import { getCacheKey } from './cache';
+import * as fetcher from './fetcher';
+import { engageRemoteConfig, prepareRemoteConfig } from './remoteConfig';
+import type { RemoteConfigFaro } from './remoteConfig';
+
+const collectorUrl = 'https://collector.example.com/collect/abc123';
+const appKey = 'abc123';
+
+function mockSessionConfig(overrides: Partial<NonNullable<Config['sessionTracking']>> = {}): Config {
+  return {
+    sessionTracking: { enabled: true, samplingRate: 1, ...overrides },
+  } as unknown as Config;
+}
+
+/**
+ * A mock faro whose transports implement the real hold-buffer semantics so the lifecycle can be
+ * exercised end-to-end without spinning up a full Faro instance.
+ */
+function makeMockFaro(config: Config): RemoteConfigFaro & { sent: string[]; dropped: number } {
+  let holding = false;
+  let buffer: string[] = [];
+  let bytes = 0;
+  let maxBytes = Infinity;
+  let notified = false;
+  let onFull: (() => void) | undefined;
+
+  const sent: string[] = [];
+  let dropped = 0;
+
+  const faro: RemoteConfigFaro & { sent: string[]; dropped: number; push: (item: string) => void } = {
+    config,
+    internalLogger: mockInternalLogger,
+    sent,
+    dropped,
+    transports: {
+      hold: (options) => {
+        holding = true;
+        buffer = [];
+        bytes = 0;
+        notified = false;
+        maxBytes = options?.maxBufferBytes ?? Infinity;
+        onFull = options?.onBufferFull;
+      },
+      flushHeld: () => {
+        if (!holding) {
+          return;
+        }
+        holding = false;
+        sent.push(...buffer);
+        buffer = [];
+      },
+      dropHeld: () => {
+        if (!holding) {
+          return;
+        }
+        holding = false;
+        dropped += buffer.length;
+        faro.dropped = dropped;
+        buffer = [];
+      },
+      isHolding: () => holding,
+    },
+    push: (item: string) => {
+      if (holding) {
+        buffer.push(item);
+        bytes += item.length;
+        if (!notified && bytes > maxBytes) {
+          notified = true;
+          onFull?.();
+        }
+        return;
+      }
+      sent.push(item);
+    },
+  };
+
+  return faro;
+}
+
+describe('remoteConfig orchestrator', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+    fetchSpy = jest.spyOn(fetcher, 'fetchRemoteConfig');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('prepareRemoteConfig', () => {
+    it('disables when a local custom sampler is present', () => {
+      const config = mockSessionConfig({ sampler: () => 1 });
+      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
+      expect(prep.mode).toBe('disabled');
+    });
+
+    it('disables when the app key cannot be resolved', () => {
+      const config = mockSessionConfig();
+      const prep = prepareRemoteConfig({
+        config,
+        collectorUrl: 'https://example.com/no-key',
+        options: {},
+        internalLogger: mockInternalLogger,
+      });
+      expect(prep.mode).toBe('disabled');
+    });
+
+    it('warm cache applies the cached rate to the config before init', () => {
+      window.localStorage.setItem(
+        getCacheKey(appKey),
+        JSON.stringify({ config: { version: '1', sampleRate: 0.1 }, etag: 'e1' })
+      );
+      const config = mockSessionConfig({ samplingRate: 0.5 });
+
+      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
+
+      expect(prep.mode).toBe('warm');
+      expect(config.sessionTracking!.samplingRate).toBe(0.1);
+    });
+
+    it('cold cache stashes the local rate and forces keep-all (1) before init', () => {
+      const config = mockSessionConfig({ samplingRate: 0.5 });
+      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
+
+      expect(prep.mode).toBe('cold');
+      // The local rate is stashed so finalize can fall back to it on fetch failure...
+      expect(prep.originalSamplingRate).toBe(0.5);
+      // ...and the live config is forced to keep-all so the session is created isSampled='true' and
+      // its before-send hook never pre-drops before the remote decision lands.
+      expect(config.sessionTracking!.samplingRate).toBe(1);
+    });
+
+    it('cold cache stashes undefined when no local rate is set', () => {
+      const config = mockSessionConfig({ samplingRate: undefined });
+      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
+
+      expect(prep.mode).toBe('cold');
+      expect(prep.originalSamplingRate).toBeUndefined();
+      expect(config.sessionTracking!.samplingRate).toBe(1);
+    });
+  });
+
+  describe('engageRemoteConfig - warm cache', () => {
+    it('triggers a background revalidation and does not hold', () => {
+      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
+      const faro = makeMockFaro(mockSessionConfig());
+
+      engageRemoteConfig(faro, {
+        mode: 'warm',
+        appKey,
+        configUrl: 'https://collector.example.com/config/abc123',
+        timeoutMs: 1500,
+        maxBufferBytes: 64 * 1024,
+        cachedEtag: 'e1',
+      });
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), 1500, mockInternalLogger, 'e1');
+    });
+  });
+
+  describe('engageRemoteConfig - cold cache (defer-and-buffer)', () => {
+    const coldPrep = {
+      mode: 'cold' as const,
+      appKey,
+      configUrl: 'https://collector.example.com/config/abc123',
+      timeoutMs: 1500,
+      maxBufferBytes: 64 * 1024,
+    };
+
+    it('buffers early telemetry then flushes when finalized as sampled', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 1 => sampled
+      let resolveFetch: (v: fetcher.FetchResult) => void;
+      fetchSpy.mockReturnValue(new Promise<fetcher.FetchResult>((resolve) => (resolveFetch = resolve)));
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, coldPrep);
+
+      // early error arrives while pending
+      (faro as any).push('early-error');
+      expect(faro.transports.isHolding()).toBe(true);
+      expect(faro.sent).toHaveLength(0);
+
+      resolveFetch!({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).toContain('early-error');
+
+      // streams normally after finalize
+      (faro as any).push('later');
+      expect(faro.sent).toContain('later');
+    });
+
+    it('buffers early telemetry then drops when finalized as not sampled', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.9); // 0.9 < 0 is false => not sampled
+      let resolveFetch: (v: fetcher.FetchResult) => void;
+      fetchSpy.mockReturnValue(new Promise<fetcher.FetchResult>((resolve) => (resolveFetch = resolve)));
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, coldPrep);
+
+      (faro as any).push('early-error');
+
+      resolveFetch!({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).not.toContain('early-error');
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('falls back to the stashed local rate on fetch error — local keeps the session', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+      fetchSpy.mockResolvedValue({ kind: 'error' });
+
+      // Live config was forced to keep-all in prepare; the *stashed* local rate (1) is the fallback.
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 1 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // fallback rate 1 => 0.5 < 1 => sampled => flushed
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).toContain('early');
+    });
+
+    it('falls back to the stashed local rate on fetch error — local drops the session', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 < 0.5 is false => not sampled
+      fetchSpy.mockResolvedValue({ kind: 'error' });
+
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      // Stashed local rate is 0.5 even though the live config was forced to keep-all (1).
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // fallback honors the *local* 0.5 (not the keep-all 1) => 0.7 !< 0.5 => dropped
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).not.toContain('early');
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('remote rate is the single source of truth: local 0.5 + remote 0.1 gates solely by 0.1', async () => {
+      // random in [0.1, 0.5): local 0.5 would KEEP, remote 0.1 must DROP. Proves remote-only gating.
+      jest.spyOn(Math, 'random').mockReturnValue(0.3);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0.1 } } });
+
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).not.toContain('early');
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('remote 1.0 keeps a session that local 0.5 would have dropped', async () => {
+      // random 0.7: local 0.5 would DROP, remote 1.0 must KEEP.
+      jest.spyOn(Math, 'random').mockReturnValue(0.7);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).toContain('early');
+    });
+
+    it('remote 0 drops the session regardless of a permissive local rate', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 0 is false => not sampled
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
+
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 1 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).not.toContain('early');
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('finalizes against the local rate on an unexpected 304 (no etag sent on cold path)', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 !< 0.5 => not sampled
+      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
+
+      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
+      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Does not leave the app held; finalizes against the stashed local 0.5.
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('finalizes early as sampled (keep) when the buffer cap is reached', async () => {
+      // fetch stays pending so only the cap can finalize
+      fetchSpy.mockReturnValue(new Promise(() => {}));
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...coldPrep, maxBufferBytes: 5 });
+
+      (faro as any).push('aaaaaa'); // exceeds 5-byte cap
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).toContain('aaaaaa');
+    });
+
+    it('applies the remote rate to the config (remote overrides local)', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0.2 } } });
+
+      const config = mockSessionConfig({ samplingRate: 0.9 });
+      const faro = makeMockFaro(config);
+      engageRemoteConfig(faro, coldPrep);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(config.sessionTracking!.samplingRate).toBe(0.2);
+    });
+
+    it('does not re-resolve after the decision is finalized once', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      const dropSpy = jest.spyOn(faro.transports, 'dropHeld');
+      const flushSpy = jest.spyOn(faro.transports, 'flushHeld');
+
+      engageRemoteConfig(faro, { ...coldPrep, maxBufferBytes: 1 });
+
+      // cap fires first (keep), then fetch resolves — finalize must be a no-op the second time
+      (faro as any).push('x');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      expect(dropSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
@@ -111,6 +111,89 @@ describe('remoteConfig orchestrator', () => {
       expect(prep.mode).toBe('disabled');
     });
 
+    it('proceeds with a configEndpoint, keying the cache by the app ID when there is no app key', () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      const config = mockSessionConfig();
+      // No resolvable app key, but an app ID (config.app.name) is available for cache scoping.
+      (config as any).app = { name: 'my-app' };
+
+      const prep = prepareRemoteConfig({
+        config,
+        collectorUrl: 'https://example.com/no-key',
+        options: { configEndpoint },
+        internalLogger: mockInternalLogger,
+      });
+
+      // No app key resolvable, but the explicit endpoint keeps remote config enabled.
+      expect(prep.mode).toBe('cold');
+      expect(prep.appKey).toBeUndefined();
+      // configUrl is the endpoint used verbatim — not transformed into a /config/{appKey} URL.
+      expect(prep.configUrl).toBe(configEndpoint);
+      // The cache is keyed by the app ID — NEVER the configEndpoint URL.
+      expect(prep.cacheId).toBe('my-app');
+    });
+
+    it('proceeds with a configEndpoint but skips caching when neither an app key nor an app ID exists', () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      const config = mockSessionConfig();
+      // No app key (collector has no key) and no app ID (config.app is absent).
+
+      const prep = prepareRemoteConfig({
+        config,
+        collectorUrl: 'https://example.com/no-key',
+        options: { configEndpoint },
+        internalLogger: mockInternalLogger,
+      });
+
+      // The fetch still proceeds (cold lifecycle), but with no identity to key the cache by.
+      expect(prep.mode).toBe('cold');
+      expect(prep.appKey).toBeUndefined();
+      expect(prep.configUrl).toBe(configEndpoint);
+      // No app key + no app ID => no cacheId. The endpoint URL is never used as a key.
+      expect(prep.cacheId).toBeUndefined();
+    });
+
+    it('uses the configEndpoint verbatim (precedence over url and collector-derived URL)', () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      const config = mockSessionConfig();
+
+      const prep = prepareRemoteConfig({
+        config,
+        collectorUrl,
+        options: { configEndpoint, url: 'https://ignored.example.com' },
+        internalLogger: mockInternalLogger,
+      });
+
+      // Endpoint wins over both `url` and the collector-derived `/config/{appKey}` URL.
+      expect(prep.configUrl).toBe(configEndpoint);
+      // The app key is still extracted (kept on the result), and wins for cache scoping.
+      expect(prep.appKey).toBe(appKey);
+      expect(prep.cacheId).toBe(appKey);
+    });
+
+    it('warm cache is keyed by the app ID when there is no app key', () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      // The cached entry is keyed by the app ID (config.app.name), NOT the configEndpoint URL.
+      window.localStorage.setItem(
+        getCacheKey('my-app'),
+        JSON.stringify({ config: { version: '1', sampleRate: 0.2 }, etag: 'e9' })
+      );
+      const config = mockSessionConfig({ samplingRate: 0.5 });
+      (config as any).app = { name: 'my-app' };
+
+      const prep = prepareRemoteConfig({
+        config,
+        collectorUrl: 'https://example.com/no-key',
+        options: { configEndpoint },
+        internalLogger: mockInternalLogger,
+      });
+
+      expect(prep.mode).toBe('warm');
+      expect(prep.cacheId).toBe('my-app');
+      // The cached rate read via the app-ID-keyed entry is applied to the live config.
+      expect(config.sessionTracking!.samplingRate).toBe(0.2);
+    });
+
     it('warm cache applies the cached rate to the config before init', () => {
       window.localStorage.setItem(
         getCacheKey(appKey),
@@ -154,6 +237,7 @@ describe('remoteConfig orchestrator', () => {
       engageRemoteConfig(faro, {
         mode: 'warm',
         appKey,
+        cacheId: appKey,
         configUrl: 'https://collector.example.com/config/abc123',
         timeoutMs: 1500,
         maxBufferBytes: 64 * 1024,
@@ -169,6 +253,7 @@ describe('remoteConfig orchestrator', () => {
     const coldPrep = {
       mode: 'cold' as const,
       appKey,
+      cacheId: appKey,
       configUrl: 'https://collector.example.com/config/abc123',
       timeoutMs: 1500,
       maxBufferBytes: 64 * 1024,
@@ -343,6 +428,61 @@ describe('remoteConfig orchestrator', () => {
       await Promise.resolve();
 
       expect(config.sessionTracking!.samplingRate).toBe(0.2);
+    });
+
+    it('fetches the configEndpoint verbatim and keys the cache by the app ID when there is no app key', async () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 1 => sampled
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      // No appKey: the cache is keyed by the app ID (config.app.name), NOT the endpoint URL.
+      engageRemoteConfig(faro, {
+        mode: 'cold',
+        cacheId: 'my-app',
+        configUrl: configEndpoint,
+        timeoutMs: 1500,
+        maxBufferBytes: 64 * 1024,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // (a) the endpoint is fetched verbatim — not transformed.
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
+      // (b) the resolved config is cached under the app-ID-derived key — never the endpoint URL.
+      expect(window.localStorage.getItem(getCacheKey('my-app'))).not.toBeNull();
+      expect(window.localStorage.getItem(getCacheKey(configEndpoint))).toBeNull();
+      expect(faro.transports.isHolding()).toBe(false);
+    });
+
+    it('fetches the configEndpoint verbatim but reads/writes nothing when there is no cacheId', async () => {
+      const configEndpoint = 'https://oss.example.com/my/explicit/config';
+      jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 1 => sampled
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+
+      const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+      const faro = makeMockFaro(mockSessionConfig());
+      // No appKey AND no app ID => no cacheId. The full cold lifecycle still runs.
+      engageRemoteConfig(faro, {
+        mode: 'cold',
+        cacheId: undefined,
+        configUrl: configEndpoint,
+        timeoutMs: 1500,
+        maxBufferBytes: 64 * 1024,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The endpoint is still fetched verbatim — the fetch lifecycle is unaffected.
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
+      // But localStorage is never touched (no read, no write) — no missing/colliding key.
+      expect(setItemSpy).not.toHaveBeenCalled();
+      expect(getItemSpy).not.toHaveBeenCalled();
+      expect(faro.transports.isHolding()).toBe(false);
     });
 
     it('does not re-resolve after the decision is finalized once', async () => {

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
@@ -183,10 +183,7 @@ describe('remoteConfig orchestrator', () => {
     });
 
     it('forces keep-all and never applies a warm cached rate instantly (the warm path now defers)', () => {
-      window.localStorage.setItem(
-        getCacheKey(appKey),
-        JSON.stringify({ config: { version: '1', sampleRate: 0.1 } })
-      );
+      window.localStorage.setItem(getCacheKey(appKey), JSON.stringify({ config: { version: '1', sampleRate: 0.1 } }));
       const config = mockSessionConfig({ samplingRate: 0.5 });
 
       const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
@@ -202,10 +199,7 @@ describe('remoteConfig orchestrator', () => {
     it('warm cache keyed by the app ID carries the cached rate as the fallback (no instant apply)', () => {
       const configEndpoint = 'https://oss.example.com/my/explicit/config';
       // The cached entry is keyed by the app ID (config.app.name), NOT the configEndpoint URL.
-      window.localStorage.setItem(
-        getCacheKey('my-app'),
-        JSON.stringify({ config: { version: '1', sampleRate: 0.2 } })
-      );
+      window.localStorage.setItem(getCacheKey('my-app'), JSON.stringify({ config: { version: '1', sampleRate: 0.2 } }));
       const config = mockSessionConfig({ samplingRate: 0.5 });
       (config as any).app = { name: 'my-app' };
 

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.test.ts
@@ -4,7 +4,7 @@ import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
 import { getCacheKey } from './cache';
 import * as fetcher from './fetcher';
 import { engageRemoteConfig, prepareRemoteConfig } from './remoteConfig';
-import type { RemoteConfigFaro } from './remoteConfig';
+import type { PreInitResult, RemoteConfigFaro } from './remoteConfig';
 
 const collectorUrl = 'https://collector.example.com/collect/abc123';
 const appKey = 'abc123';
@@ -80,6 +80,15 @@ function makeMockFaro(config: Config): RemoteConfigFaro & { sent: string[]; drop
   return faro;
 }
 
+/**
+ * Drive the JSDOM `document.visibilityState` and fire a `visibilitychange` event so the
+ * finalize-on-unload listener runs.
+ */
+function fireVisibilityHidden(): void {
+  Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
 describe('remoteConfig orchestrator', () => {
   let fetchSpy: jest.SpyInstance;
 
@@ -87,6 +96,8 @@ describe('remoteConfig orchestrator', () => {
     window.localStorage.clear();
     jest.restoreAllMocks();
     fetchSpy = jest.spyOn(fetcher, 'fetchRemoteConfig');
+    // Reset visibility between tests (a prior unload test may have left it 'hidden').
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
   });
 
   afterEach(() => {
@@ -125,7 +136,7 @@ describe('remoteConfig orchestrator', () => {
       });
 
       // No app key resolvable, but the explicit endpoint keeps remote config enabled.
-      expect(prep.mode).toBe('cold');
+      expect(prep.mode).toBe('deferred');
       expect(prep.appKey).toBeUndefined();
       // configUrl is the endpoint used verbatim — not transformed into a /config/{appKey} URL.
       expect(prep.configUrl).toBe(configEndpoint);
@@ -145,8 +156,8 @@ describe('remoteConfig orchestrator', () => {
         internalLogger: mockInternalLogger,
       });
 
-      // The fetch still proceeds (cold lifecycle), but with no identity to key the cache by.
-      expect(prep.mode).toBe('cold');
+      // The fetch still proceeds (deferred lifecycle), but with no identity to key the cache by.
+      expect(prep.mode).toBe('deferred');
       expect(prep.appKey).toBeUndefined();
       expect(prep.configUrl).toBe(configEndpoint);
       // No app key + no app ID => no cacheId. The endpoint URL is never used as a key.
@@ -171,7 +182,25 @@ describe('remoteConfig orchestrator', () => {
       expect(prep.cacheId).toBe(appKey);
     });
 
-    it('warm cache is keyed by the app ID when there is no app key', () => {
+    it('forces keep-all and never applies a warm cached rate instantly (the warm path now defers)', () => {
+      window.localStorage.setItem(
+        getCacheKey(appKey),
+        JSON.stringify({ config: { version: '1', sampleRate: 0.1 }, etag: 'e1' })
+      );
+      const config = mockSessionConfig({ samplingRate: 0.5 });
+
+      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
+
+      // Unified deferred path: even with a warm cache, the rate is NOT applied to the live config now.
+      expect(prep.mode).toBe('deferred');
+      expect(config.sessionTracking!.samplingRate).toBe(1);
+      // The cached rate becomes the fallback (for 304 / fetch-failure), plus the etag is carried.
+      expect(prep.fallbackRate).toBe(0.1);
+      expect(prep.cachedEtag).toBe('e1');
+      expect(prep.cacheId).toBe(appKey);
+    });
+
+    it('warm cache keyed by the app ID carries the cached rate as the fallback (no instant apply)', () => {
       const configEndpoint = 'https://oss.example.com/my/explicit/config';
       // The cached entry is keyed by the app ID (config.app.name), NOT the configEndpoint URL.
       window.localStorage.setItem(
@@ -188,70 +217,41 @@ describe('remoteConfig orchestrator', () => {
         internalLogger: mockInternalLogger,
       });
 
-      expect(prep.mode).toBe('warm');
+      expect(prep.mode).toBe('deferred');
       expect(prep.cacheId).toBe('my-app');
-      // The cached rate read via the app-ID-keyed entry is applied to the live config.
-      expect(config.sessionTracking!.samplingRate).toBe(0.2);
+      // The cached rate is the fallback, not the live rate (live is forced to keep-all).
+      expect(config.sessionTracking!.samplingRate).toBe(1);
+      expect(prep.fallbackRate).toBe(0.2);
+      expect(prep.cachedEtag).toBe('e9');
     });
 
-    it('warm cache applies the cached rate to the config before init', () => {
-      window.localStorage.setItem(
-        getCacheKey(appKey),
-        JSON.stringify({ config: { version: '1', sampleRate: 0.1 }, etag: 'e1' })
-      );
-      const config = mockSessionConfig({ samplingRate: 0.5 });
-
-      const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
-
-      expect(prep.mode).toBe('warm');
-      expect(config.sessionTracking!.samplingRate).toBe(0.1);
-    });
-
-    it('cold cache stashes the local rate and forces keep-all (1) before init', () => {
+    it('cold cache (no entry) stashes the local rate as fallback and forces keep-all (1) before init', () => {
       const config = mockSessionConfig({ samplingRate: 0.5 });
       const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
 
-      expect(prep.mode).toBe('cold');
-      // The local rate is stashed so finalize can fall back to it on fetch failure...
-      expect(prep.originalSamplingRate).toBe(0.5);
+      expect(prep.mode).toBe('deferred');
+      // With no cache entry the local rate is the fallback for fetch failure...
+      expect(prep.fallbackRate).toBe(0.5);
       // ...and the live config is forced to keep-all so the session is created isSampled='true' and
       // its before-send hook never pre-drops before the remote decision lands.
       expect(config.sessionTracking!.samplingRate).toBe(1);
+      // No cache entry => no etag to revalidate against.
+      expect(prep.cachedEtag).toBeUndefined();
     });
 
-    it('cold cache stashes undefined when no local rate is set', () => {
+    it('cold cache stashes undefined fallback when no local rate is set', () => {
       const config = mockSessionConfig({ samplingRate: undefined });
       const prep = prepareRemoteConfig({ config, collectorUrl, options: {}, internalLogger: mockInternalLogger });
 
-      expect(prep.mode).toBe('cold');
-      expect(prep.originalSamplingRate).toBeUndefined();
+      expect(prep.mode).toBe('deferred');
+      expect(prep.fallbackRate).toBeUndefined();
       expect(config.sessionTracking!.samplingRate).toBe(1);
     });
   });
 
-  describe('engageRemoteConfig - warm cache', () => {
-    it('triggers a background revalidation and does not hold', () => {
-      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
-      const faro = makeMockFaro(mockSessionConfig());
-
-      engageRemoteConfig(faro, {
-        mode: 'warm',
-        appKey,
-        cacheId: appKey,
-        configUrl: 'https://collector.example.com/config/abc123',
-        timeoutMs: 1500,
-        maxBufferBytes: 64 * 1024,
-        cachedEtag: 'e1',
-      });
-
-      expect(faro.transports.isHolding()).toBe(false);
-      expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), 1500, mockInternalLogger, 'e1');
-    });
-  });
-
-  describe('engageRemoteConfig - cold cache (defer-and-buffer)', () => {
-    const coldPrep = {
-      mode: 'cold' as const,
+  describe('engageRemoteConfig - unified deferred lifecycle', () => {
+    const deferredPrep: PreInitResult = {
+      mode: 'deferred',
       appKey,
       cacheId: appKey,
       configUrl: 'https://collector.example.com/config/abc123',
@@ -259,13 +259,26 @@ describe('remoteConfig orchestrator', () => {
       maxBufferBytes: 64 * 1024,
     };
 
+    it('the warm path now HOLDS and conditionally fetches (sends If-None-Match)', () => {
+      // fetch stays pending so the hold is observable.
+      fetchSpy.mockReturnValue(new Promise(() => {}));
+      const faro = makeMockFaro(mockSessionConfig());
+
+      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.2 });
+
+      // Warm no longer streams instantly — it holds while the live rate is fetched.
+      expect(faro.transports.isHolding()).toBe(true);
+      // The cached etag is sent so the server can answer 304.
+      expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), 1500, mockInternalLogger, 'e1');
+    });
+
     it('buffers early telemetry then flushes when finalized as sampled', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 1 => sampled
       let resolveFetch: (v: fetcher.FetchResult) => void;
       fetchSpy.mockReturnValue(new Promise<fetcher.FetchResult>((resolve) => (resolveFetch = resolve)));
 
       const faro = makeMockFaro(mockSessionConfig());
-      engageRemoteConfig(faro, coldPrep);
+      engageRemoteConfig(faro, deferredPrep);
 
       // early error arrives while pending
       (faro as any).push('early-error');
@@ -290,7 +303,7 @@ describe('remoteConfig orchestrator', () => {
       fetchSpy.mockReturnValue(new Promise<fetcher.FetchResult>((resolve) => (resolveFetch = resolve)));
 
       const faro = makeMockFaro(mockSessionConfig());
-      engageRemoteConfig(faro, coldPrep);
+      engageRemoteConfig(faro, deferredPrep);
 
       (faro as any).push('early-error');
 
@@ -303,13 +316,68 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.dropped).toBe(1);
     });
 
-    it('falls back to the stashed local rate on fetch error — local keeps the session', async () => {
+    it('a changed rate fetched on the WARM path overrides the cached rate (cached 1.0, fetch 0 => drop)', async () => {
+      // The visitor's warm cache says keep-all (1.0). The operator just set the live rate to 0%.
+      // The freshly fetched 0 must win for THIS session: drop + flip the session to not-sampled.
+      jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 0 is false => not sampled
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      // Warm: cached/fallback rate is 1.0, etag present.
+      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 1 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      // The fetched 0 overrode the cached 1.0 — buffer dropped (not-sampled), not sent.
+      expect(faro.sent).not.toContain('early');
+      expect(faro.dropped).toBe(1);
+      // The live config reflects the fetched rate.
+      expect(faro.config.sessionTracking!.samplingRate).toBe(0);
+    });
+
+    it('304 (not-modified) finalizes against the cached/fallback rate — keep', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.3); // 0.3 < 0.5 => sampled
+      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      // Warm cache: 304 means "your cache is current" → defer to the cached/fallback rate 0.5.
+      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      // 0.3 < 0.5 => sampled => flushed.
+      expect(faro.sent).toContain('early');
+      expect(faro.config.sessionTracking!.samplingRate).toBe(0.5);
+    });
+
+    it('304 (not-modified) finalizes against the cached/fallback rate — drop', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 !< 0.5 => not sampled
+      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, cachedEtag: 'e1', fallbackRate: 0.5 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).not.toContain('early');
+      expect(faro.dropped).toBe(1);
+    });
+
+    it('falls back to the fallback rate on fetch error — fallback keeps the session', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0.5);
       fetchSpy.mockResolvedValue({ kind: 'error' });
 
-      // Live config was forced to keep-all in prepare; the *stashed* local rate (1) is the fallback.
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 1 });
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 1 });
 
       (faro as any).push('early');
       await Promise.resolve();
@@ -320,31 +388,29 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.sent).toContain('early');
     });
 
-    it('falls back to the stashed local rate on fetch error — local drops the session', async () => {
+    it('falls back to the fallback rate on fetch error — fallback drops the session', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 < 0.5 is false => not sampled
       fetchSpy.mockResolvedValue({ kind: 'error' });
 
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      // Stashed local rate is 0.5 even though the live config was forced to keep-all (1).
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.5 });
 
       (faro as any).push('early');
       await Promise.resolve();
       await Promise.resolve();
 
-      // fallback honors the *local* 0.5 (not the keep-all 1) => 0.7 !< 0.5 => dropped
       expect(faro.transports.isHolding()).toBe(false);
       expect(faro.sent).not.toContain('early');
       expect(faro.dropped).toBe(1);
     });
 
-    it('remote rate is the single source of truth: local 0.5 + remote 0.1 gates solely by 0.1', async () => {
-      // random in [0.1, 0.5): local 0.5 would KEEP, remote 0.1 must DROP. Proves remote-only gating.
+    it('a fetched rate is the single source of truth: cached/local 0.5 + fetched 0.1 gates by 0.1', async () => {
+      // random in [0.1, 0.5): fallback 0.5 would KEEP, fetched 0.1 must DROP. Proves fetch-only gating.
       jest.spyOn(Math, 'random').mockReturnValue(0.3);
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0.1 } } });
 
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.5 });
 
       (faro as any).push('early');
       await Promise.resolve();
@@ -355,13 +421,13 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.dropped).toBe(1);
     });
 
-    it('remote 1.0 keeps a session that local 0.5 would have dropped', async () => {
-      // random 0.7: local 0.5 would DROP, remote 1.0 must KEEP.
+    it('fetched 1.0 keeps a session that the fallback 0.5 would have dropped', async () => {
+      // random 0.7: fallback 0.5 would DROP, fetched 1.0 must KEEP.
       jest.spyOn(Math, 'random').mockReturnValue(0.7);
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
 
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.5 });
 
       (faro as any).push('early');
       await Promise.resolve();
@@ -371,12 +437,12 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.sent).toContain('early');
     });
 
-    it('remote 0 drops the session regardless of a permissive local rate', async () => {
+    it('fetched 0 drops the session regardless of a permissive fallback rate', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 0 is false => not sampled
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
 
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 1 });
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 1 });
 
       (faro as any).push('early');
       await Promise.resolve();
@@ -387,28 +453,12 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.dropped).toBe(1);
     });
 
-    it('finalizes against the local rate on an unexpected 304 (no etag sent on cold path)', async () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.7); // 0.7 !< 0.5 => not sampled
-      fetchSpy.mockResolvedValue({ kind: 'not-modified' });
-
-      const faro = makeMockFaro(mockSessionConfig({ samplingRate: 1 }));
-      engageRemoteConfig(faro, { ...coldPrep, originalSamplingRate: 0.5 });
-
-      (faro as any).push('early');
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // Does not leave the app held; finalizes against the stashed local 0.5.
-      expect(faro.transports.isHolding()).toBe(false);
-      expect(faro.dropped).toBe(1);
-    });
-
     it('finalizes early as sampled (keep) when the buffer cap is reached', async () => {
       // fetch stays pending so only the cap can finalize
       fetchSpy.mockReturnValue(new Promise(() => {}));
 
       const faro = makeMockFaro(mockSessionConfig());
-      engageRemoteConfig(faro, { ...coldPrep, maxBufferBytes: 5 });
+      engageRemoteConfig(faro, { ...deferredPrep, maxBufferBytes: 5 });
 
       (faro as any).push('aaaaaa'); // exceeds 5-byte cap
 
@@ -416,13 +466,13 @@ describe('remoteConfig orchestrator', () => {
       expect(faro.sent).toContain('aaaaaa');
     });
 
-    it('applies the remote rate to the config (remote overrides local)', async () => {
+    it('applies the fetched rate to the config (fetch overrides local/cache)', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0);
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0.2 } } });
 
       const config = mockSessionConfig({ samplingRate: 0.9 });
       const faro = makeMockFaro(config);
-      engageRemoteConfig(faro, coldPrep);
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.9 });
 
       await Promise.resolve();
       await Promise.resolve();
@@ -438,7 +488,7 @@ describe('remoteConfig orchestrator', () => {
       const faro = makeMockFaro(mockSessionConfig());
       // No appKey: the cache is keyed by the app ID (config.app.name), NOT the endpoint URL.
       engageRemoteConfig(faro, {
-        mode: 'cold',
+        mode: 'deferred',
         cacheId: 'my-app',
         configUrl: configEndpoint,
         timeoutMs: 1500,
@@ -448,8 +498,8 @@ describe('remoteConfig orchestrator', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // (a) the endpoint is fetched verbatim — not transformed.
-      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
+      // (a) the endpoint is fetched verbatim — not transformed (no etag on a cold cache).
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger, undefined);
       // (b) the resolved config is cached under the app-ID-derived key — never the endpoint URL.
       expect(window.localStorage.getItem(getCacheKey('my-app'))).not.toBeNull();
       expect(window.localStorage.getItem(getCacheKey(configEndpoint))).toBeNull();
@@ -461,13 +511,12 @@ describe('remoteConfig orchestrator', () => {
       jest.spyOn(Math, 'random').mockReturnValue(0); // 0 < 1 => sampled
       fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
 
-      const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
       const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
 
       const faro = makeMockFaro(mockSessionConfig());
-      // No appKey AND no app ID => no cacheId. The full cold lifecycle still runs.
+      // No appKey AND no app ID => no cacheId. The full deferred lifecycle still runs.
       engageRemoteConfig(faro, {
-        mode: 'cold',
+        mode: 'deferred',
         cacheId: undefined,
         configUrl: configEndpoint,
         timeoutMs: 1500,
@@ -478,10 +527,9 @@ describe('remoteConfig orchestrator', () => {
       await Promise.resolve();
 
       // The endpoint is still fetched verbatim — the fetch lifecycle is unaffected.
-      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger);
-      // But localStorage is never touched (no read, no write) — no missing/colliding key.
+      expect(fetchSpy).toHaveBeenCalledWith(configEndpoint, 1500, mockInternalLogger, undefined);
+      // No write to localStorage — no missing/colliding key.
       expect(setItemSpy).not.toHaveBeenCalled();
-      expect(getItemSpy).not.toHaveBeenCalled();
       expect(faro.transports.isHolding()).toBe(false);
     });
 
@@ -493,7 +541,7 @@ describe('remoteConfig orchestrator', () => {
       const dropSpy = jest.spyOn(faro.transports, 'dropHeld');
       const flushSpy = jest.spyOn(faro.transports, 'flushHeld');
 
-      engageRemoteConfig(faro, { ...coldPrep, maxBufferBytes: 1 });
+      engageRemoteConfig(faro, { ...deferredPrep, maxBufferBytes: 1 });
 
       // cap fires first (keep), then fetch resolves — finalize must be a no-op the second time
       (faro as any).push('x');
@@ -502,6 +550,85 @@ describe('remoteConfig orchestrator', () => {
 
       expect(flushSpy).toHaveBeenCalledTimes(1);
       expect(dropSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('engageRemoteConfig - finalize-on-unload', () => {
+    const deferredPrep: PreInitResult = {
+      mode: 'deferred',
+      appKey,
+      cacheId: appKey,
+      configUrl: 'https://collector.example.com/config/abc123',
+      timeoutMs: 1500,
+      maxBufferBytes: 64 * 1024,
+    };
+
+    it('finalizes against the fallback + flushes the held buffer when the page hides mid-hold (no loss)', () => {
+      // fetch never resolves — only the unload path can finalize.
+      fetchSpy.mockReturnValue(new Promise(() => {}));
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0.5 });
+
+      // telemetry buffered while holding
+      (faro as any).push('early');
+      expect(faro.transports.isHolding()).toBe(true);
+
+      // visitor leaves the page mid-hold
+      fireVisibilityHidden();
+
+      // buffered telemetry is flushed (not dropped) so nothing is lost
+      expect(faro.transports.isHolding()).toBe(false);
+      expect(faro.sent).toContain('early');
+      expect(faro.dropped).toBe(0);
+    });
+
+    it('removes the unload listeners after a normal finalize (no leak, no double-fire)', async () => {
+      const addSpy = jest.spyOn(document, 'addEventListener');
+      const removeSpy = jest.spyOn(document, 'removeEventListener');
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 1 } } });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, deferredPrep);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // both listeners (visibilitychange + pagehide) were registered then removed on finalize.
+      const visAdds = addSpy.mock.calls.filter(([type]) => type === 'visibilitychange');
+      const visRemoves = removeSpy.mock.calls.filter(([type]) => type === 'visibilitychange');
+      const pageAdds = addSpy.mock.calls.filter(([type]) => type === 'pagehide');
+      const pageRemoves = removeSpy.mock.calls.filter(([type]) => type === 'pagehide');
+      expect(visAdds).toHaveLength(1);
+      expect(visRemoves).toHaveLength(1);
+      expect(pageAdds).toHaveLength(1);
+      expect(pageRemoves).toHaveLength(1);
+
+      // A later page-hide must NOT re-finalize (already removed + finalize is one-shot).
+      const flushSpy = jest.spyOn(faro.transports, 'flushHeld');
+      fireVisibilityHidden();
+      expect(flushSpy).not.toHaveBeenCalled();
+    });
+
+    it('an unload after the fetch already finalized is a no-op', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      fetchSpy.mockResolvedValue({ kind: 'updated', value: { config: { version: '1', sampleRate: 0 } } });
+
+      const faro = makeMockFaro(mockSessionConfig());
+      engageRemoteConfig(faro, { ...deferredPrep, fallbackRate: 0 });
+
+      (faro as any).push('early');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // fetched 0 dropped the buffer already.
+      expect(faro.dropped).toBe(1);
+
+      const flushSpy = jest.spyOn(faro.transports, 'flushHeld');
+      fireVisibilityHidden();
+      // unload must not flush after the decision is finalized.
+      expect(flushSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.ts
@@ -15,7 +15,7 @@ export const DEFAULT_TIMEOUT_MS = 1500;
 export const DEFAULT_MAX_BUFFER_BYTES = 64 * 1024;
 
 /**
- * Minimal surface of the registered Faro instance the cold-cache lifecycle needs. Kept narrow to
+ * Minimal surface of the registered Faro instance the deferred lifecycle needs. Kept narrow to
  * avoid a hard dependency on the full `Faro` type and to ease testing.
  */
 export interface RemoteConfigFaro {
@@ -30,11 +30,18 @@ export interface RemoteConfigFaro {
 }
 
 /**
- * Result of the synchronous pre-init phase. When `mode === 'cold'`, the caller must invoke
- * {@link startColdLifecycle} after Faro is initialized to engage the hold + fetch.
+ * Result of the synchronous pre-init phase.
+ *
+ * - `mode === 'disabled'`: remote sampling does not apply (a local custom sampler wins, or the config
+ *   URL could not be resolved). The lifecycle is a no-op.
+ * - `mode === 'deferred'`: every new session holds telemetry and consults the LIVE remote rate before
+ *   its sampling decision is finalized. The caller must invoke {@link engageRemoteConfig} after Faro
+ *   is initialized to engage the hold + conditional fetch. This is the single path for BOTH a cold
+ *   cache (no prior entry) and a warm cache (prior entry exists) — the warm rate is only a fallback,
+ *   never applied instantly, so an operator's live change is reliably reflected.
  */
 export interface PreInitResult {
-  mode: 'disabled' | 'warm' | 'cold';
+  mode: 'disabled' | 'deferred';
   appKey?: string;
   /**
    * Cache discriminator used to scope `localStorage` reads/writes. Resolves to the extracted app key
@@ -47,13 +54,18 @@ export interface PreInitResult {
   configUrl?: string;
   timeoutMs: number;
   maxBufferBytes: number;
+  /**
+   * The cached `ETag`, when a cache entry exists. Sent as `If-None-Match` so the conditional fetch can
+   * yield a 304 (`not-modified`) and we defer to the cached rate.
+   */
   cachedEtag?: string;
   /**
-   * Cold path only: the local/bundled `samplingRate` captured before it was overridden to `1` for
-   * the keep-all hold window. `finalize` falls back to this when the fetch does not yield a rate, so
-   * a fetch failure honors the local rate (not the temporary keep-all `1`).
+   * The rate to fall back to when the fetch does not yield a fresh rate (304, timeout, or error). It
+   * is the cached `sampleRate` when a cache entry exists, otherwise the local/bundled `samplingRate`
+   * captured before it was overridden to keep-all (`1`) for the hold window. `finalize` uses this so a
+   * fetch failure or 304 honors the cache/local rate (not the temporary keep-all `1`).
    */
-  originalSamplingRate?: number;
+  fallbackRate?: number;
 }
 
 interface PrepareParams {
@@ -64,12 +76,17 @@ interface PrepareParams {
 }
 
 /**
- * Synchronous pre-init phase. Resolves the app key + config URL and reads the cache.
+ * Synchronous pre-init phase. Resolves the app key + config URL, reads the cache for a fallback rate
+ * and etag, and unconditionally arms the deferred hold.
  *
  * - A local custom `sampler` wins over the remote rate (documented escape hatch) → `disabled`.
- * - Warm cache → applies the cached rate to `config.sessionTracking.samplingRate` immediately
- *   (before the session decision is made by the session instrumentation) and returns `warm`.
- * - Cold cache → returns `cold`; the caller engages the hold lifecycle after init.
+ * - The config URL cannot be resolved → `disabled`.
+ * - Otherwise → `deferred`. We ALWAYS force keep-all (`config.sessionTracking.samplingRate = 1`)
+ *   before init so the session is created with `isSampled='true'` and its before-send hook never
+ *   pre-drops, and we stash a `fallbackRate` (cached rate when present, else the original local/bundled
+ *   rate). The single source of truth for the current session becomes the decision made in `finalize`,
+ *   which always consults the LIVE remote rate. A warm cache no longer applies its rate instantly —
+ *   under this model the cache only feeds the 304-conditional path and the fetch-failure fallback.
  *
  * Never throws.
  */
@@ -102,31 +119,33 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
     // lifecycle still runs, but with no localStorage reads/writes.
     const cacheId = appKey ?? config.app?.name;
 
-    // With no cacheId we cannot read the cache, so the path is necessarily cold.
+    // Read the cache for a fallback rate + etag. The cached rate is NOT applied to the live config —
+    // it only serves the 304-conditional path (defer to cache) and the fetch-failure fallback.
     const cached = cacheId != null ? readCachedConfig(cacheId, internalLogger) : null;
 
-    if (cached != null) {
-      // Warm cache: apply the rate now so the session instrumentation samples with it. No buffering.
-      if (cached.config.sampleRate !== undefined && config.sessionTracking) {
-        config.sessionTracking.samplingRate = clampSamplingRate(cached.config.sampleRate);
-      }
-
-      return { mode: 'warm', appKey, cacheId, configUrl, timeoutMs, maxBufferBytes, cachedEtag: cached.etag };
-    }
-
-    // Cold cache: we have no rate yet, so we cannot let the session instrumentation make a sampling
-    // decision against the *local* rate now — that would gate the current session by both the local
-    // roll (via the session before-send hook) and the later remote roll (at finalize), and a remote
-    // rate could never override a local one. Instead, stash the local rate and force keep-all (`1`)
-    // before init so the session is created with `isSampled='true'` and its before-send hook never
-    // pre-drops. The single source of truth becomes the remote decision made in `finalize`.
+    // Fallback rate: the cached rate when a cache entry exists, else the local/bundled rate captured
+    // before we override it. `finalize` falls back to this on a 304/timeout/error.
     const originalSamplingRate = config.sessionTracking?.samplingRate;
+    const fallbackRate = cached?.config.sampleRate ?? originalSamplingRate;
 
+    // Unify warm + cold into a single deferred path: force keep-all (`1`) before init so the session
+    // is created with `isSampled='true'` and never pre-drops. The remote decision in `finalize` is the
+    // single source of truth, and it always consults the LIVE rate (so a stale warm rate cannot leak
+    // through). The cached rate, if any, survives as `fallbackRate`.
     if (config.sessionTracking) {
       config.sessionTracking.samplingRate = 1;
     }
 
-    return { mode: 'cold', appKey, cacheId, configUrl, timeoutMs, maxBufferBytes, originalSamplingRate };
+    return {
+      mode: 'deferred',
+      appKey,
+      cacheId,
+      configUrl,
+      timeoutMs,
+      maxBufferBytes,
+      cachedEtag: cached?.etag,
+      fallbackRate,
+    };
   } catch (err) {
     internalLogger.debug('Remote config: unexpected error during preparation\n', err);
     return disabled;
@@ -134,32 +153,36 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
 }
 
 /**
- * Post-init phase. Drives the defer-and-buffer lifecycle for a cold cache, and triggers background
- * revalidation for a warm cache. Synchronous: never awaits. Never throws.
+ * Post-init phase. Drives the unified defer-and-buffer lifecycle for every session: hold outgoing
+ * telemetry, conditionally fetch the live rate (sending `If-None-Match` when a cached etag exists),
+ * and finalize the sampling decision exactly once.
+ *
+ * - `updated` (200) → write the fresh config to the cache + finalize against the FETCHED rate. A
+ *   changed rate fetched here overrides any cached/local rate for the current session.
+ * - `not-modified` (304) → finalize against the cached/fallback rate (defer to cache).
+ * - timeout/error → finalize against the fallback rate (cached, else local/bundled).
+ *
+ * A one-shot unload listener finalizes immediately against the fallback rate (flushing the held
+ * buffer) so a visitor who leaves during the hold window does not lose buffered telemetry.
+ *
+ * Synchronous: never awaits. Never throws.
  */
 export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult): void {
   const { internalLogger } = faro;
 
   try {
     // Note: a missing `cacheId` is NOT a reason to bail — the no-identity configEndpoint path runs
-    // the full cold lifecycle, it just skips localStorage caching. Only `configUrl` is required.
+    // the full lifecycle, it just skips localStorage caching. Only `configUrl` is required.
     if (prep.mode === 'disabled' || prep.configUrl == null) {
       return;
     }
 
-    if (prep.mode === 'warm') {
-      // A warm cache implies a `cacheId` existed (we read a cached entry), so revalidation is safe.
-      // Revalidate in the background so the cache is fresh for the next load.
-      backgroundRevalidate(faro, prep.cacheId, prep.configUrl, prep.timeoutMs, prep.cachedEtag);
-      return;
-    }
-
-    // Cold cache: hold outgoing telemetry while we resolve the rate, bounding memory by a byte cap.
-    // The local rate was stashed in `prep.originalSamplingRate` and the live config was forced to
-    // keep-all (`1`) before init, so the current session is keep-all and `finalize` is the single
-    // source of truth for its sampling decision.
+    // The local rate was stashed in `prep.fallbackRate` and the live config was forced to keep-all
+    // (`1`) before init, so the current session is keep-all and `finalize` is the single source of
+    // truth for its sampling decision.
     let finalized = false;
-    const fallbackRate = prep.originalSamplingRate;
+    const fallbackRate = prep.fallbackRate;
+    let removeUnloadListener: (() => void) | undefined;
 
     const finalizeOnce = (sampleRate: number | undefined, sampledOverride?: boolean) => {
       if (finalized) {
@@ -167,6 +190,9 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
       }
 
       finalized = true;
+      // Always remove the unload listener once the decision is made so it cannot fire after finalize
+      // and cannot leak across the page's lifetime.
+      removeUnloadListener?.();
       finalize(faro, sampleRate, fallbackRate, sampledOverride);
     };
 
@@ -179,26 +205,35 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
       },
     });
 
-    fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger)
+    // Finalize-on-unload: if the visitor leaves while we are still holding, finalize immediately
+    // against the fallback rate and flush the held buffer so buffered telemetry is not lost. Covers
+    // the whole hold lifecycle. Guarded for non-browser/no-document environments.
+    removeUnloadListener = registerFinalizeOnUnload(() => {
+      internalLogger.debug('Remote config: page hidden while holding, finalizing against fallback');
+      // Flush (keep) on unload so the visitor's buffered telemetry survives the hold window.
+      finalizeOnce(fallbackRate, true);
+    });
+
+    fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger, prep.cachedEtag)
       .then((result) => {
         if (result.kind === 'updated') {
           // Skip the write entirely when there is no cacheId (no-identity configEndpoint path).
           if (prep.cacheId != null) {
             writeCachedConfig(prep.cacheId, result.value, internalLogger);
           }
+          // A freshly fetched rate overrides any cached/local rate for the current session.
           finalizeOnce(result.value.config.sampleRate);
           return;
         }
 
-        // Any non-update falls back to the stashed local/bundled rate. This includes an unexpected
-        // 304 (`not-modified`): the cold path sends no `If-None-Match`, so a 304 is anomalous — we
-        // still finalize against the local rate rather than leaving the app permanently held.
-        finalizeOnce(undefined);
+        // `not-modified` (304): the cached config is still current — defer to the cached rate (carried
+        // as `fallbackRate`). Any other non-update (`error`, timeout) also falls back to that rate.
+        finalizeOnce(fallbackRate);
       })
       .catch((err) => {
         // fetchRemoteConfig never rejects, but guard anyway so we never leave the buffer held.
         internalLogger.debug('Remote config: fetch unexpectedly rejected\n', err);
-        finalizeOnce(undefined);
+        finalizeOnce(fallbackRate);
       });
   } catch (err) {
     internalLogger.debug('Remote config: unexpected error while engaging lifecycle\n', err);
@@ -209,9 +244,52 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
 }
 
 /**
- * Finalize the cold-cache sampling decision exactly once. This is the single source of truth for
- * the current session's sampling decision on the cold path:
- * - resolve the effective rate as remote rate ?? stashed local/bundled rate ?? keep-all,
+ * Register a one-shot listener that finalizes the hold when the page is being unloaded. Listens for
+ * `visibilitychange` → hidden and `pagehide` (the reliable mobile/bfcache signals), invokes the
+ * callback once, and removes BOTH listeners immediately so nothing leaks and the callback never fires
+ * twice. Returns a disposer the caller invokes on a normal finalize so the listeners are always
+ * removed exactly once.
+ *
+ * Guards for non-browser / no-document environments by returning a no-op disposer.
+ */
+function registerFinalizeOnUnload(onUnload: () => void): () => void {
+  if (typeof document === 'undefined' || typeof document.addEventListener !== 'function') {
+    return () => {};
+  }
+
+  let removed = false;
+
+  const remove = () => {
+    if (removed) {
+      return;
+    }
+    removed = true;
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    document.removeEventListener('pagehide', onPageHide);
+  };
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      remove();
+      onUnload();
+    }
+  };
+
+  const onPageHide = () => {
+    remove();
+    onUnload();
+  };
+
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  document.addEventListener('pagehide', onPageHide);
+
+  return remove;
+}
+
+/**
+ * Finalize the sampling decision exactly once. This is the single source of truth for the current
+ * session's sampling decision:
+ * - resolve the effective rate as the provided rate (fetched or fallback) ?? keep-all,
  * - apply it to the live config so any subsequent *new* session uses it (the live config currently
  *   holds the temporary keep-all `1` set before init),
  * - decide sampled-or-not once for the current session,
@@ -220,7 +298,7 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
  *   place so the existing session before-send hook drops all post-finalize items too — without
  *   creating a new session id or re-deriving the decision probabilistically.
  *
- * `sampledOverride` forces the decision (used by the buffer-cap path: keep).
+ * `sampledOverride` forces the decision (used by the buffer-cap path: keep, and the unload path: keep).
  */
 function finalize(
   faro: RemoteConfigFaro,
@@ -228,8 +306,8 @@ function finalize(
   fallbackRate: number | undefined,
   sampledOverride?: boolean
 ): void {
-  // Effective rate: remote wins, else the stashed local/bundled rate, else keep-all. Never read the
-  // live config here — it was forced to `1` before init for the hold window.
+  // Effective rate: the resolved (fetched or fallback) rate, else the fallback rate, else keep-all.
+  // Never read the live config here — it was forced to `1` before init for the hold window.
   const effectiveRate = clampSamplingRate(sampleRate ?? fallbackRate ?? 1);
 
   if (faro.config.sessionTracking) {
@@ -249,33 +327,4 @@ function finalize(
     // The session was created keep-all; flip it so post-finalize streaming is suppressed too.
     markSessionNotSampled(getSessionManagerByConfig(faro.config.sessionTracking));
   }
-}
-
-/**
- * Conditionally revalidate the cached config in the background and update the cache for the next
- * load. Does not affect the current session.
- */
-function backgroundRevalidate(
-  faro: RemoteConfigFaro,
-  cacheId: string | undefined,
-  configUrl: string,
-  timeoutMs: number,
-  etag?: string
-): void {
-  const { internalLogger } = faro;
-
-  // No cacheId => nothing to revalidate against (no cached entry could exist). No-op.
-  if (cacheId == null) {
-    return;
-  }
-
-  fetchRemoteConfig(configUrl, timeoutMs, internalLogger, etag)
-    .then((result) => {
-      if (result.kind === 'updated') {
-        writeCachedConfig(cacheId, result.value, internalLogger);
-      }
-    })
-    .catch((err) => {
-      internalLogger.debug('Remote config: background revalidation failed\n', err);
-    });
 }

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.ts
@@ -2,9 +2,12 @@ import { clampSamplingRate } from '@grafana/faro-core';
 import type { Config, InternalLogger } from '@grafana/faro-core';
 
 import type { RemoteConfigOptions } from '../config';
-import { getSessionManagerByConfig, markSessionNotSampled } from '../instrumentations/session/sessionManager';
+import {
+  getSessionManagerByConfig,
+  isSampled,
+  markSessionNotSampled,
+} from '../instrumentations/session/sessionManager';
 
-import { decideSampled } from './applySampling';
 import { readCachedConfig, writeCachedConfig } from './cache';
 import { buildConfigUrl, extractAppKey, fetchRemoteConfig } from './fetcher';
 
@@ -33,6 +36,14 @@ export interface RemoteConfigFaro {
 export interface PreInitResult {
   mode: 'disabled' | 'warm' | 'cold';
   appKey?: string;
+  /**
+   * Cache discriminator used to scope `localStorage` reads/writes. Resolves to the extracted app key
+   * when available, otherwise to the app ID (`config.app?.name`). It is NEVER the `configEndpoint`
+   * URL — that is a manual fetch target and must not become a cache key. When neither an app key nor
+   * an app ID is available, this is `undefined` and all cache operations are skipped (no-ops), so the
+   * lifecycle still runs but never reads/writes a missing or colliding key.
+   */
+  cacheId?: string;
   configUrl?: string;
   timeoutMs: number;
   maxBufferBytes: number;
@@ -73,21 +84,26 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
       return disabled;
     }
 
-    const appKey = extractAppKey(collectorUrl);
+    const appKey = extractAppKey(collectorUrl) ?? undefined;
 
-    if (appKey == null) {
-      internalLogger.debug('Remote config: could not resolve app key, using bundled default');
-      return disabled;
-    }
-
-    const configUrl = buildConfigUrl(appKey, collectorUrl, options.url);
+    // Resolve the config URL. An explicit `configEndpoint` wins and is used verbatim (no app key
+    // required). Otherwise we need a resolvable app key to derive the Grafana `/config/{appKey}` URL.
+    const configUrl =
+      options.configEndpoint ?? (appKey != null ? buildConfigUrl(appKey, collectorUrl, options.url) : null);
 
     if (configUrl == null) {
       internalLogger.debug('Remote config: could not resolve config URL, using bundled default');
       return disabled;
     }
 
-    const cached = readCachedConfig(appKey, internalLogger);
+    // Cache discriminator: the app key when present, else the app ID (`config.app?.name`). The
+    // `configEndpoint` URL is a manual fetch target and must NEVER be used as a cache key. When
+    // neither is available `cacheId` is undefined and all cache operations are skipped — the
+    // lifecycle still runs, but with no localStorage reads/writes.
+    const cacheId = appKey ?? config.app?.name;
+
+    // With no cacheId we cannot read the cache, so the path is necessarily cold.
+    const cached = cacheId != null ? readCachedConfig(cacheId, internalLogger) : null;
 
     if (cached != null) {
       // Warm cache: apply the rate now so the session instrumentation samples with it. No buffering.
@@ -95,7 +111,7 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
         config.sessionTracking.samplingRate = clampSamplingRate(cached.config.sampleRate);
       }
 
-      return { mode: 'warm', appKey, configUrl, timeoutMs, maxBufferBytes, cachedEtag: cached.etag };
+      return { mode: 'warm', appKey, cacheId, configUrl, timeoutMs, maxBufferBytes, cachedEtag: cached.etag };
     }
 
     // Cold cache: we have no rate yet, so we cannot let the session instrumentation make a sampling
@@ -110,7 +126,7 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
       config.sessionTracking.samplingRate = 1;
     }
 
-    return { mode: 'cold', appKey, configUrl, timeoutMs, maxBufferBytes, originalSamplingRate };
+    return { mode: 'cold', appKey, cacheId, configUrl, timeoutMs, maxBufferBytes, originalSamplingRate };
   } catch (err) {
     internalLogger.debug('Remote config: unexpected error during preparation\n', err);
     return disabled;
@@ -125,13 +141,16 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
   const { internalLogger } = faro;
 
   try {
-    if (prep.mode === 'disabled' || prep.appKey == null || prep.configUrl == null) {
+    // Note: a missing `cacheId` is NOT a reason to bail — the no-identity configEndpoint path runs
+    // the full cold lifecycle, it just skips localStorage caching. Only `configUrl` is required.
+    if (prep.mode === 'disabled' || prep.configUrl == null) {
       return;
     }
 
     if (prep.mode === 'warm') {
+      // A warm cache implies a `cacheId` existed (we read a cached entry), so revalidation is safe.
       // Revalidate in the background so the cache is fresh for the next load.
-      backgroundRevalidate(faro, prep.appKey, prep.configUrl, prep.timeoutMs, prep.cachedEtag);
+      backgroundRevalidate(faro, prep.cacheId, prep.configUrl, prep.timeoutMs, prep.cachedEtag);
       return;
     }
 
@@ -163,7 +182,10 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
     fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger)
       .then((result) => {
         if (result.kind === 'updated') {
-          writeCachedConfig(prep.appKey!, result.value, internalLogger);
+          // Skip the write entirely when there is no cacheId (no-identity configEndpoint path).
+          if (prep.cacheId != null) {
+            writeCachedConfig(prep.cacheId, result.value, internalLogger);
+          }
           finalizeOnce(result.value.config.sampleRate);
           return;
         }
@@ -218,7 +240,7 @@ function finalize(
     return;
   }
 
-  const sampled = sampledOverride ?? decideSampled(effectiveRate);
+  const sampled = sampledOverride ?? isSampled(effectiveRate);
 
   if (sampled) {
     faro.transports.flushHeld();
@@ -235,17 +257,22 @@ function finalize(
  */
 function backgroundRevalidate(
   faro: RemoteConfigFaro,
-  appKey: string,
+  cacheId: string | undefined,
   configUrl: string,
   timeoutMs: number,
   etag?: string
 ): void {
   const { internalLogger } = faro;
 
+  // No cacheId => nothing to revalidate against (no cached entry could exist). No-op.
+  if (cacheId == null) {
+    return;
+  }
+
   fetchRemoteConfig(configUrl, timeoutMs, internalLogger, etag)
     .then((result) => {
       if (result.kind === 'updated') {
-        writeCachedConfig(appKey, result.value, internalLogger);
+        writeCachedConfig(cacheId, result.value, internalLogger);
       }
     })
     .catch((err) => {

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.ts
@@ -256,7 +256,7 @@ function registerFinalizeOnUnload(onUnload: () => void): () => void {
     }
     removed = true;
     document.removeEventListener('visibilitychange', onVisibilityChange);
-    document.removeEventListener('pagehide', onPageHide);
+    window.removeEventListener('pagehide', onPageHide);
   };
 
   const onVisibilityChange = () => {
@@ -272,7 +272,7 @@ function registerFinalizeOnUnload(onUnload: () => void): () => void {
   };
 
   document.addEventListener('visibilitychange', onVisibilityChange);
-  document.addEventListener('pagehide', onPageHide);
+  window.addEventListener('pagehide', onPageHide);
 
   return remove;
 }

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.ts
@@ -55,15 +55,10 @@ export interface PreInitResult {
   timeoutMs: number;
   maxBufferBytes: number;
   /**
-   * The cached `ETag`, when a cache entry exists. Sent as `If-None-Match` so the conditional fetch can
-   * yield a 304 (`not-modified`) and we defer to the cached rate.
-   */
-  cachedEtag?: string;
-  /**
-   * The rate to fall back to when the fetch does not yield a fresh rate (304, timeout, or error). It
+   * The rate to fall back to when the fetch does not yield a fresh rate (timeout or error). It
    * is the cached `sampleRate` when a cache entry exists, otherwise the local/bundled `samplingRate`
    * captured before it was overridden to keep-all (`1`) for the hold window. `finalize` uses this so a
-   * fetch failure or 304 honors the cache/local rate (not the temporary keep-all `1`).
+   * fetch failure honors the cache/local rate (not the temporary keep-all `1`).
    */
   fallbackRate?: number;
 }
@@ -76,8 +71,8 @@ interface PrepareParams {
 }
 
 /**
- * Synchronous pre-init phase. Resolves the app key + config URL, reads the cache for a fallback rate
- * and etag, and unconditionally arms the deferred hold.
+ * Synchronous pre-init phase. Resolves the app key + config URL, reads the cache for a fallback rate,
+ * and unconditionally arms the deferred hold.
  *
  * - A local custom `sampler` wins over the remote rate (documented escape hatch) → `disabled`.
  * - The config URL cannot be resolved → `disabled`.
@@ -86,7 +81,7 @@ interface PrepareParams {
  *   pre-drops, and we stash a `fallbackRate` (cached rate when present, else the original local/bundled
  *   rate). The single source of truth for the current session becomes the decision made in `finalize`,
  *   which always consults the LIVE remote rate. A warm cache no longer applies its rate instantly —
- *   under this model the cache only feeds the 304-conditional path and the fetch-failure fallback.
+ *   under this model the cache only feeds the fetch-failure fallback.
  *
  * Never throws.
  */
@@ -119,12 +114,12 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
     // lifecycle still runs, but with no localStorage reads/writes.
     const cacheId = appKey ?? config.app?.name;
 
-    // Read the cache for a fallback rate + etag. The cached rate is NOT applied to the live config —
-    // it only serves the 304-conditional path (defer to cache) and the fetch-failure fallback.
+    // Read the cache for a fallback rate. The cached rate is NOT applied to the live config —
+    // it only serves the fetch-failure fallback.
     const cached = cacheId != null ? readCachedConfig(cacheId, internalLogger) : null;
 
     // Fallback rate: the cached rate when a cache entry exists, else the local/bundled rate captured
-    // before we override it. `finalize` falls back to this on a 304/timeout/error.
+    // before we override it. `finalize` falls back to this on a timeout/error.
     const originalSamplingRate = config.sessionTracking?.samplingRate;
     const fallbackRate = cached?.config.sampleRate ?? originalSamplingRate;
 
@@ -143,7 +138,6 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
       configUrl,
       timeoutMs,
       maxBufferBytes,
-      cachedEtag: cached?.etag,
       fallbackRate,
     };
   } catch (err) {
@@ -154,12 +148,10 @@ export function prepareRemoteConfig({ config, collectorUrl, options, internalLog
 
 /**
  * Post-init phase. Drives the unified defer-and-buffer lifecycle for every session: hold outgoing
- * telemetry, conditionally fetch the live rate (sending `If-None-Match` when a cached etag exists),
- * and finalize the sampling decision exactly once.
+ * telemetry, fetch the live rate, and finalize the sampling decision exactly once.
  *
  * - `updated` (200) → write the fresh config to the cache + finalize against the FETCHED rate. A
  *   changed rate fetched here overrides any cached/local rate for the current session.
- * - `not-modified` (304) → finalize against the cached/fallback rate (defer to cache).
  * - timeout/error → finalize against the fallback rate (cached, else local/bundled).
  *
  * A one-shot unload listener finalizes immediately against the fallback rate (flushing the held
@@ -214,7 +206,7 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
       finalizeOnce(fallbackRate, true);
     });
 
-    fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger, prep.cachedEtag)
+    fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger)
       .then((result) => {
         if (result.kind === 'updated') {
           // Skip the write entirely when there is no cacheId (no-identity configEndpoint path).
@@ -226,8 +218,7 @@ export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult):
           return;
         }
 
-        // `not-modified` (304): the cached config is still current — defer to the cached rate (carried
-        // as `fallbackRate`). Any other non-update (`error`, timeout) also falls back to that rate.
+        // Any non-update (`error`, timeout) falls back to the cached/local rate.
         finalizeOnce(fallbackRate);
       })
       .catch((err) => {

--- a/packages/web-sdk/src/remoteConfig/remoteConfig.ts
+++ b/packages/web-sdk/src/remoteConfig/remoteConfig.ts
@@ -1,0 +1,254 @@
+import { clampSamplingRate } from '@grafana/faro-core';
+import type { Config, InternalLogger } from '@grafana/faro-core';
+
+import type { RemoteConfigOptions } from '../config';
+import { getSessionManagerByConfig, markSessionNotSampled } from '../instrumentations/session/sessionManager';
+
+import { decideSampled } from './applySampling';
+import { readCachedConfig, writeCachedConfig } from './cache';
+import { buildConfigUrl, extractAppKey, fetchRemoteConfig } from './fetcher';
+
+export const DEFAULT_TIMEOUT_MS = 1500;
+export const DEFAULT_MAX_BUFFER_BYTES = 64 * 1024;
+
+/**
+ * Minimal surface of the registered Faro instance the cold-cache lifecycle needs. Kept narrow to
+ * avoid a hard dependency on the full `Faro` type and to ease testing.
+ */
+export interface RemoteConfigFaro {
+  config: Config;
+  transports: {
+    hold: (options?: { maxBufferBytes?: number; onBufferFull?: () => void }) => void;
+    flushHeld: () => void;
+    dropHeld: () => void;
+    isHolding: () => boolean;
+  };
+  internalLogger: InternalLogger;
+}
+
+/**
+ * Result of the synchronous pre-init phase. When `mode === 'cold'`, the caller must invoke
+ * {@link startColdLifecycle} after Faro is initialized to engage the hold + fetch.
+ */
+export interface PreInitResult {
+  mode: 'disabled' | 'warm' | 'cold';
+  appKey?: string;
+  configUrl?: string;
+  timeoutMs: number;
+  maxBufferBytes: number;
+  cachedEtag?: string;
+  /**
+   * Cold path only: the local/bundled `samplingRate` captured before it was overridden to `1` for
+   * the keep-all hold window. `finalize` falls back to this when the fetch does not yield a rate, so
+   * a fetch failure honors the local rate (not the temporary keep-all `1`).
+   */
+  originalSamplingRate?: number;
+}
+
+interface PrepareParams {
+  config: Config;
+  collectorUrl: string | undefined;
+  options: RemoteConfigOptions;
+  internalLogger: InternalLogger;
+}
+
+/**
+ * Synchronous pre-init phase. Resolves the app key + config URL and reads the cache.
+ *
+ * - A local custom `sampler` wins over the remote rate (documented escape hatch) → `disabled`.
+ * - Warm cache → applies the cached rate to `config.sessionTracking.samplingRate` immediately
+ *   (before the session decision is made by the session instrumentation) and returns `warm`.
+ * - Cold cache → returns `cold`; the caller engages the hold lifecycle after init.
+ *
+ * Never throws.
+ */
+export function prepareRemoteConfig({ config, collectorUrl, options, internalLogger }: PrepareParams): PreInitResult {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+  const disabled: PreInitResult = { mode: 'disabled', timeoutMs, maxBufferBytes };
+
+  try {
+    if (typeof config.sessionTracking?.sampler === 'function') {
+      internalLogger.debug('Remote config: local sampler present, skipping remote sampling');
+      return disabled;
+    }
+
+    const appKey = extractAppKey(collectorUrl);
+
+    if (appKey == null) {
+      internalLogger.debug('Remote config: could not resolve app key, using bundled default');
+      return disabled;
+    }
+
+    const configUrl = buildConfigUrl(appKey, collectorUrl, options.url);
+
+    if (configUrl == null) {
+      internalLogger.debug('Remote config: could not resolve config URL, using bundled default');
+      return disabled;
+    }
+
+    const cached = readCachedConfig(appKey, internalLogger);
+
+    if (cached != null) {
+      // Warm cache: apply the rate now so the session instrumentation samples with it. No buffering.
+      if (cached.config.sampleRate !== undefined && config.sessionTracking) {
+        config.sessionTracking.samplingRate = clampSamplingRate(cached.config.sampleRate);
+      }
+
+      return { mode: 'warm', appKey, configUrl, timeoutMs, maxBufferBytes, cachedEtag: cached.etag };
+    }
+
+    // Cold cache: we have no rate yet, so we cannot let the session instrumentation make a sampling
+    // decision against the *local* rate now — that would gate the current session by both the local
+    // roll (via the session before-send hook) and the later remote roll (at finalize), and a remote
+    // rate could never override a local one. Instead, stash the local rate and force keep-all (`1`)
+    // before init so the session is created with `isSampled='true'` and its before-send hook never
+    // pre-drops. The single source of truth becomes the remote decision made in `finalize`.
+    const originalSamplingRate = config.sessionTracking?.samplingRate;
+
+    if (config.sessionTracking) {
+      config.sessionTracking.samplingRate = 1;
+    }
+
+    return { mode: 'cold', appKey, configUrl, timeoutMs, maxBufferBytes, originalSamplingRate };
+  } catch (err) {
+    internalLogger.debug('Remote config: unexpected error during preparation\n', err);
+    return disabled;
+  }
+}
+
+/**
+ * Post-init phase. Drives the defer-and-buffer lifecycle for a cold cache, and triggers background
+ * revalidation for a warm cache. Synchronous: never awaits. Never throws.
+ */
+export function engageRemoteConfig(faro: RemoteConfigFaro, prep: PreInitResult): void {
+  const { internalLogger } = faro;
+
+  try {
+    if (prep.mode === 'disabled' || prep.appKey == null || prep.configUrl == null) {
+      return;
+    }
+
+    if (prep.mode === 'warm') {
+      // Revalidate in the background so the cache is fresh for the next load.
+      backgroundRevalidate(faro, prep.appKey, prep.configUrl, prep.timeoutMs, prep.cachedEtag);
+      return;
+    }
+
+    // Cold cache: hold outgoing telemetry while we resolve the rate, bounding memory by a byte cap.
+    // The local rate was stashed in `prep.originalSamplingRate` and the live config was forced to
+    // keep-all (`1`) before init, so the current session is keep-all and `finalize` is the single
+    // source of truth for its sampling decision.
+    let finalized = false;
+    const fallbackRate = prep.originalSamplingRate;
+
+    const finalizeOnce = (sampleRate: number | undefined, sampledOverride?: boolean) => {
+      if (finalized) {
+        return;
+      }
+
+      finalized = true;
+      finalize(faro, sampleRate, fallbackRate, sampledOverride);
+    };
+
+    faro.transports.hold({
+      maxBufferBytes: prep.maxBufferBytes,
+      onBufferFull: () => {
+        // Buffer cap hit before the fetch resolved: finalize early as "sampled" (keep) + flush.
+        internalLogger.debug('Remote config: buffer cap reached, finalizing as sampled');
+        finalizeOnce(undefined, true);
+      },
+    });
+
+    fetchRemoteConfig(prep.configUrl, prep.timeoutMs, internalLogger)
+      .then((result) => {
+        if (result.kind === 'updated') {
+          writeCachedConfig(prep.appKey!, result.value, internalLogger);
+          finalizeOnce(result.value.config.sampleRate);
+          return;
+        }
+
+        // Any non-update falls back to the stashed local/bundled rate. This includes an unexpected
+        // 304 (`not-modified`): the cold path sends no `If-None-Match`, so a 304 is anomalous — we
+        // still finalize against the local rate rather than leaving the app permanently held.
+        finalizeOnce(undefined);
+      })
+      .catch((err) => {
+        // fetchRemoteConfig never rejects, but guard anyway so we never leave the buffer held.
+        internalLogger.debug('Remote config: fetch unexpectedly rejected\n', err);
+        finalizeOnce(undefined);
+      });
+  } catch (err) {
+    internalLogger.debug('Remote config: unexpected error while engaging lifecycle\n', err);
+    if (faro.transports.isHolding()) {
+      faro.transports.flushHeld();
+    }
+  }
+}
+
+/**
+ * Finalize the cold-cache sampling decision exactly once. This is the single source of truth for
+ * the current session's sampling decision on the cold path:
+ * - resolve the effective rate as remote rate ?? stashed local/bundled rate ?? keep-all,
+ * - apply it to the live config so any subsequent *new* session uses it (the live config currently
+ *   holds the temporary keep-all `1` set before init),
+ * - decide sampled-or-not once for the current session,
+ * - if sampled: flush the held buffer (the keep-all session lets post-finalize items stream),
+ * - if not sampled: drop the held buffer AND flip the current session to `isSampled='false'` in
+ *   place so the existing session before-send hook drops all post-finalize items too — without
+ *   creating a new session id or re-deriving the decision probabilistically.
+ *
+ * `sampledOverride` forces the decision (used by the buffer-cap path: keep).
+ */
+function finalize(
+  faro: RemoteConfigFaro,
+  sampleRate: number | undefined,
+  fallbackRate: number | undefined,
+  sampledOverride?: boolean
+): void {
+  // Effective rate: remote wins, else the stashed local/bundled rate, else keep-all. Never read the
+  // live config here — it was forced to `1` before init for the hold window.
+  const effectiveRate = clampSamplingRate(sampleRate ?? fallbackRate ?? 1);
+
+  if (faro.config.sessionTracking) {
+    faro.config.sessionTracking.samplingRate = effectiveRate;
+  }
+
+  if (!faro.transports.isHolding()) {
+    return;
+  }
+
+  const sampled = sampledOverride ?? decideSampled(effectiveRate);
+
+  if (sampled) {
+    faro.transports.flushHeld();
+  } else {
+    faro.transports.dropHeld();
+    // The session was created keep-all; flip it so post-finalize streaming is suppressed too.
+    markSessionNotSampled(getSessionManagerByConfig(faro.config.sessionTracking));
+  }
+}
+
+/**
+ * Conditionally revalidate the cached config in the background and update the cache for the next
+ * load. Does not affect the current session.
+ */
+function backgroundRevalidate(
+  faro: RemoteConfigFaro,
+  appKey: string,
+  configUrl: string,
+  timeoutMs: number,
+  etag?: string
+): void {
+  const { internalLogger } = faro;
+
+  fetchRemoteConfig(configUrl, timeoutMs, internalLogger, etag)
+    .then((result) => {
+      if (result.kind === 'updated') {
+        writeCachedConfig(appKey, result.value, internalLogger);
+      }
+    })
+    .catch((err) => {
+      internalLogger.debug('Remote config: background revalidation failed\n', err);
+    });
+}

--- a/packages/web-sdk/src/remoteConfig/types.ts
+++ b/packages/web-sdk/src/remoteConfig/types.ts
@@ -1,0 +1,22 @@
+/**
+ * The remote-config schema version. Bumping this invalidates all cached configs.
+ */
+export const REMOTE_CONFIG_SCHEMA_VERSION = '1';
+
+/**
+ * Response DTO returned by the collector's `GET /config/{appKey}` endpoint.
+ * `sampleRate` is omitted when unset.
+ */
+export interface RemoteConfigResponse {
+  sampleRate?: number;
+  version: string;
+}
+
+/**
+ * The shape persisted in `localStorage`. Holds the resolved response plus the `ETag` for
+ * conditional revalidation on the next load.
+ */
+export interface CachedRemoteConfig {
+  config: RemoteConfigResponse;
+  etag?: string;
+}

--- a/packages/web-sdk/src/remoteConfig/types.ts
+++ b/packages/web-sdk/src/remoteConfig/types.ts
@@ -13,10 +13,8 @@ export interface RemoteConfigResponse {
 }
 
 /**
- * The shape persisted in `localStorage`. Holds the resolved response plus the `ETag` for
- * conditional revalidation on the next load.
+ * The shape persisted in `localStorage`. Holds the resolved response.
  */
 export interface CachedRemoteConfig {
   config: RemoteConfigResponse;
-  etag?: string;
 }


### PR DESCRIPTION
## Why

Operators can't change an instrumented app's session sampling rate without the customer redeploying their own app. This adds opt-in **remote configuration** so Faro fetches the session sampling rate from the collector's `GET /config/{key}` on init and applies it — without blocking page load.

## What

- Opt-in `remoteConfig?: { url?, timeoutMs?, maxBufferBytes? }`; **`initializeFaro` stays synchronous** and the default (no `remoteConfig`) path is unchanged.
- Core transports gain a bounded `hold`/`flushHeld`/`dropHeld` pre-decision buffer primitive (default 64KB).
- New `web-sdk/remoteConfig` module: schema-versioned `localStorage` cache, `ETag` conditional fetch with a ~1.5s timeout, **warm-cache** fast path and **cold-cache defer-and-buffer**, finalize-once flush-or-drop, never throws (always falls back to bundled/cached default).
- Cold path forces keep-all before init and reconciles the session via `markSessionNotSampled` at finalize, so the **remote rate is the single source of truth** for the current session; a locally-defined custom `sampler` still wins.

> Hackathon limitation (documented, non-blocking): a cold + not-sampled session can leak its `session_start` event pre-hold; production follow-up is to engage the hold before instrumentation init.

## Links

- Endpoint slice: grafana/app-o11y-kwl-endpoint#1612
- Part of the cross-repo "remote sampling config" hackathon (endpoint + this SDK + plugin + terraform-provider).

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated (CHANGELOG only for the hackathon)