### PR TITLE
test(react): add react-router v5–v8 version matrix tests

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -2,15 +2,97 @@ const path = require('path');
 
 const { jestBaseConfig } = require('../../jest.config.base.js');
 
-module.exports = {
-  ...jestBaseConfig,
-  roots: ['packages/react/src'],
+const repoRoot = path.join(__dirname, '..', '..');
+const matrixTsconfig = path.join(__dirname, 'tsconfig.matrix.json');
+const matrixEsmTsconfig = path.join(__dirname, 'tsconfig.matrix.esm.json');
+const setupFile = path.join(__dirname, 'jest.setup.ts');
+const fetchEnv = path.join(__dirname, 'jsdom-fetch.env.js');
+
+const matrixDir = '<rootDir>/packages/react/src/router/__matrix__';
+
+// Shared mapper from the base config (maps @grafana/faro-core to source).
+const baseMapper = jestBaseConfig.moduleNameMapper;
+
+// Pin react/react-dom to the v18 alias for the react-router v5 suite (RR v5 does
+// not run on React 19). RTL resolves react/react-dom through these mappings too.
+const react18Mapper = {
+  '^react$': '<rootDir>/node_modules/react-18',
+  '^react/(.*)$': '<rootDir>/node_modules/react-18/$1',
+  '^react-dom$': '<rootDir>/node_modules/react-dom-18',
+  '^react-dom/(.*)$': '<rootDir>/node_modules/react-dom-18/$1',
+};
+
+const routerMapper = (alias) => ({
+  '^react-router$': `<rootDir>/node_modules/${alias}`,
+  '^react-router/(.*)$': `<rootDir>/node_modules/${alias}/$1`,
+});
+
+// CJS project (react-router v5/v6/v7). ts-jest compiles to CommonJS.
+const cjsProject = ({ displayName, testMatch, moduleNameMapper }) => ({
+  displayName,
+  testEnvironment: fetchEnv,
+  rootDir: repoRoot,
+  setupFilesAfterEnv: [setupFile],
+  testMatch,
+  moduleNameMapper: { ...baseMapper, ...moduleNameMapper },
   transform: {
-    '^.+\\.(ts|tsx)?$': [
-      'ts-jest',
-      {
-        tsconfig: path.join(__dirname, 'tsconfig.spec.json'),
-      },
-    ],
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: matrixTsconfig }],
   },
+});
+
+module.exports = {
+  projects: [
+    // Existing unit tests (mocked deps, profiler). Unchanged behaviour, React 19, CJS.
+    {
+      ...jestBaseConfig,
+      displayName: 'react',
+      rootDir: repoRoot,
+      roots: ['packages/react/src'],
+      testPathIgnorePatterns: ['/node_modules/', '/__matrix__/'],
+      transform: {
+        '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: path.join(__dirname, 'tsconfig.spec.json') }],
+      },
+    },
+
+    // react-router v5 — runs on React 18 (see react18Mapper).
+    cjsProject({
+      displayName: 'rr-v5',
+      testMatch: [`${matrixDir}/v5.test.tsx`],
+      moduleNameMapper: react18Mapper,
+    }),
+
+    // react-router v6 — react-router resolves to the v6 alias.
+    cjsProject({
+      displayName: 'rr-v6',
+      testMatch: [`${matrixDir}/v6.test.tsx`],
+      moduleNameMapper: routerMapper('react-router-v6'),
+    }),
+
+    // react-router v7 — uses the plain `react-router` devDependency (7.x).
+    cjsProject({
+      displayName: 'rr-v7',
+      testMatch: [`${matrixDir}/v7.test.tsx`],
+      moduleNameMapper: {},
+    }),
+
+    // react-router v8 — ESM-only package, so this project runs in ESM mode.
+    {
+      displayName: 'rr-v8',
+      testEnvironment: fetchEnv,
+      rootDir: repoRoot,
+      setupFilesAfterEnv: [setupFile],
+      testMatch: [`${matrixDir}/v8.test.tsx`],
+      extensionsToTreatAsEsm: ['.ts', '.tsx'],
+      // react-router v8 is exports-only (no main/module field), which jest's ESM
+      // resolver can't resolve from a bare directory, so map to the dist entries.
+      moduleNameMapper: {
+        ...baseMapper,
+        '^react-router$': '<rootDir>/node_modules/react-router-v8/dist/production/index.js',
+        '^react-router/dom$': '<rootDir>/node_modules/react-router-v8/dist/production/dom-export.js',
+      },
+      transform: {
+        '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: matrixEsmTsconfig, useESM: true }],
+      },
+    },
+  ],
 };

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -83,10 +83,16 @@ module.exports = {
       setupFilesAfterEnv: [setupFile],
       testMatch: [`${matrixDir}/v8.test.tsx`],
       extensionsToTreatAsEsm: ['.ts', '.tsx'],
+      // NOTE: unlike the CJS projects, this project does NOT map @grafana/faro-core
+      // to its TS source. In ESM mode the built (CommonJS) @grafana/faro-web-sdk
+      // `require()`s faro-core, and requiring an ESM-transformed .ts source throws
+      // "Must use import to load ES Module" on Node 22. Letting faro-core resolve to
+      // its built CJS dist keeps that chain consistently CommonJS. Requires faro-core
+      // and faro-web-sdk to be built first (CI builds before testing).
+      //
       // react-router v8 is exports-only (no main/module field), which jest's ESM
       // resolver can't resolve from a bare directory, so map to the dist entries.
       moduleNameMapper: {
-        ...baseMapper,
         '^react-router$': '<rootDir>/node_modules/react-router-v8/dist/production/index.js',
         '^react-router/dom$': '<rootDir>/node_modules/react-router-v8/dist/production/dom-export.js',
       },

--- a/packages/react/jest.setup.ts
+++ b/packages/react/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/react/jsdom-fetch.env.js
+++ b/packages/react/jsdom-fetch.env.js
@@ -1,0 +1,31 @@
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
+
+// jsdom does not expose the Fetch API (or a few other web globals) that
+// react-router data routers rely on during navigation. Node provides native
+// implementations, so copy them into the jsdom realm.
+//
+// The Fetch family must be internally consistent: Node's Request validates that
+// the `signal` it receives is a Node AbortSignal, so we OVERWRITE jsdom's
+// AbortController/AbortSignal with Node's rather than only filling gaps.
+const FETCH_FAMILY = ['fetch', 'Request', 'Response', 'Headers', 'AbortController', 'AbortSignal', 'ReadableStream'];
+const FILL_IF_MISSING = ['structuredClone', 'TextEncoder', 'TextDecoder'];
+
+class JsdomFetchEnvironment extends JSDOMEnvironment {
+  constructor(config, context) {
+    super(config, context);
+
+    for (const name of FETCH_FAMILY) {
+      if (typeof globalThis[name] !== 'undefined') {
+        this.global[name] = globalThis[name];
+      }
+    }
+
+    for (const name of FILL_IF_MISSING) {
+      if (this.global[name] === undefined && typeof globalThis[name] !== 'undefined') {
+        this.global[name] = globalThis[name];
+      }
+    }
+  }
+}
+
+module.exports = JsdomFetchEnvironment;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,9 @@
     "watch:compile": "yarn build:compile:cjs -w",
     "clean": "rimraf dist/ yarn-error.log",
     "quality": "run-s 'quality:*'",
-    "quality:test": "jest --passWithNoTests",
+    "quality:test": "run-s quality:test:cjs quality:test:esm",
+    "quality:test:cjs": "jest --passWithNoTests --selectProjects react rr-v5 rr-v6 rr-v7",
+    "quality:test:esm": "NODE_OPTIONS=--experimental-vm-modules jest --selectProjects rr-v8",
     "quality:format": "prettier --cache --cache-location=../../.cache/prettier/react --ignore-path ../../.prettierignore -w \"./**/*.{js,jsx,ts,tsx,css,scss,md,yaml,yml,json}\"",
     "quality:lint": "run-s quality:lint:eslint quality:lint:prettier quality:lint:md",
     "quality:lint:eslint": "eslint --cache --cache-location ../../.cache/eslint/react \"./**/*.{js,jsx,ts,tsx}\"",
@@ -61,11 +63,21 @@
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
     "@types/hoist-non-react-statics": "3.3.7",
     "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "history-v4": "npm:history@4.10.1",
     "react": "19.2.7",
+    "react-18": "npm:react@18.3.1",
     "react-dom": "19.2.7",
-    "react-router": "7.18.0"
+    "react-dom-18": "npm:react-dom@18.3.1",
+    "react-router": "7.18.0",
+    "react-router-dom-v5": "npm:react-router-dom@5.3.4",
+    "react-router-v6": "npm:react-router@6.30.4",
+    "react-router-v8": "npm:react-router@8.0.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/react/src/router/__matrix__/faroApiMock.ts
+++ b/packages/react/src/router/__matrix__/faroApiMock.ts
@@ -1,0 +1,39 @@
+// Imported explicitly so this works under both CommonJS (v5/v6/v7) and ESM (v8)
+// jest projects — ESM mode does not inject the `jest` global.
+import { jest } from '@jest/globals';
+
+import { setDependencies } from '../../dependencies';
+
+export interface RouteChangeCall {
+  name: string;
+  attributes: Record<string, string> | undefined;
+}
+
+export interface FaroApiMock {
+  pushEvent: jest.Mock;
+  /** All pushEvent calls, normalized to { name, attributes }. */
+  events: () => RouteChangeCall[];
+  /** pushEvent calls for the `route_change` event only. */
+  routeChanges: () => RouteChangeCall[];
+}
+
+/**
+ * Wires a mock Faro `api` into the react package's dependency holder and returns
+ * helpers to inspect the emitted events. Call inside `beforeEach`.
+ */
+export function installFaroApiMock(): FaroApiMock {
+  const pushEvent = jest.fn();
+
+  const apiMock = { pushEvent } as any;
+  const internalLoggerMock = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() } as any;
+
+  setDependencies(internalLoggerMock, apiMock);
+
+  const events = (): RouteChangeCall[] => pushEvent.mock.calls.map(([name, attributes]) => ({ name, attributes }));
+
+  return {
+    pushEvent,
+    events,
+    routeChanges: () => events().filter((call) => call.name === 'route_change'),
+  };
+}

--- a/packages/react/src/router/__matrix__/shared.tsx
+++ b/packages/react/src/router/__matrix__/shared.tsx
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import { FaroRoutes } from '../v6v7/FaroRoutes';
+import {
+  initializeReactRouterV6DataRouterInstrumentation,
+  initializeReactRouterV6Instrumentation,
+} from '../v6v7/initialize';
+import { getRouteFromLocation } from '../v6v7/utils';
+import { withFaroRouterInstrumentation } from '../v6v7/withFaroRouterInstrumentation';
+
+import { installFaroApiMock } from './faroApiMock';
+
+/**
+ * Version-specific react-router exports injected by each `vN.test.tsx`. The
+ * hooks/components must all originate from the SAME react-router instance so
+ * that the router context resolves correctly during rendering.
+ */
+export interface RouterMatrixDeps {
+  // Injected into faro's dependency holder (what the instrumentation actually calls).
+  createRoutesFromChildren: any;
+  matchRoutes: any;
+  Routes: any;
+  useLocation: any;
+  useNavigationType: any;
+  // Used by the tests to build route trees, render and navigate.
+  Route: any;
+  MemoryRouter: any;
+  useNavigate: any;
+  createMemoryRouter: any;
+  RouterProvider: any;
+}
+
+function loc(pathname: string) {
+  return { pathname, search: '', hash: '', state: null, key: 'test' };
+}
+
+export function runRouterMatrixSuite(version: string, deps: RouterMatrixDeps): void {
+  const {
+    createRoutesFromChildren,
+    matchRoutes,
+    Routes,
+    useLocation,
+    useNavigationType,
+    Route,
+    MemoryRouter,
+    useNavigate,
+    createMemoryRouter,
+    RouterProvider,
+  } = deps;
+
+  const v6Deps = { createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType };
+
+  describe(`react-router ${version}`, () => {
+    let faro: ReturnType<typeof installFaroApiMock>;
+
+    beforeEach(() => {
+      faro = installFaroApiMock();
+    });
+
+    describe('getRouteFromLocation (real matchRoutes)', () => {
+      beforeEach(() => {
+        initializeReactRouterV6Instrumentation(v6Deps);
+      });
+
+      it('resolves a dynamic param to its route pattern', () => {
+        const routes = createRoutesFromChildren(<Route path="/users/:id" element={<i />} />);
+
+        expect(getRouteFromLocation(routes, loc('/users/42'))).toBe('/users/:id');
+      });
+
+      it('resolves a nested dynamic param to the full pattern', () => {
+        const routes = createRoutesFromChildren(
+          <Route path="users" element={<i />}>
+            <Route path=":id" element={<i />} />
+          </Route>
+        );
+
+        expect(getRouteFromLocation(routes, loc('/users/42'))).toBe('/users/:id');
+      });
+
+      it('falls back to the raw pathname when nothing matches', () => {
+        const routes = createRoutesFromChildren(<Route path="/users/:id" element={<i />} />);
+
+        expect(getRouteFromLocation(routes, loc('/nope'))).toBe('/nope');
+      });
+    });
+
+    describe('FaroRoutes (component routes)', () => {
+      beforeEach(() => {
+        initializeReactRouterV6Instrumentation(v6Deps);
+      });
+
+      it('emits a route_change with the route pattern on navigation', () => {
+        function Nav() {
+          const navigate = useNavigate();
+          return (
+            <button type="button" onClick={() => navigate('/users/42')}>
+              go
+            </button>
+          );
+        }
+
+        const { getByText } = render(
+          <MemoryRouter initialEntries={['/']}>
+            <Nav />
+            <FaroRoutes>
+              <Route path="/" element={<div>home</div>} />
+              <Route path="/users/:id" element={<div>user</div>} />
+            </FaroRoutes>
+          </MemoryRouter>
+        );
+
+        fireEvent.click(getByText('go'));
+
+        const changes = faro.routeChanges();
+        const last = changes[changes.length - 1];
+        expect(last?.attributes?.toRoute).toBe('/users/:id');
+      });
+
+      it('threads the previous route into fromRoute on a second navigation', () => {
+        function Nav() {
+          const navigate = useNavigate();
+          return (
+            <>
+              <button type="button" onClick={() => navigate('/users/1')}>
+                first
+              </button>
+              <button type="button" onClick={() => navigate('/teams/2')}>
+                second
+              </button>
+            </>
+          );
+        }
+
+        const { getByText } = render(
+          <MemoryRouter initialEntries={['/']}>
+            <Nav />
+            <FaroRoutes>
+              <Route path="/" element={<div>home</div>} />
+              <Route path="/users/:id" element={<div>user</div>} />
+              <Route path="/teams/:id" element={<div>team</div>} />
+            </FaroRoutes>
+          </MemoryRouter>
+        );
+
+        fireEvent.click(getByText('first'));
+        fireEvent.click(getByText('second'));
+
+        const last = faro.routeChanges().at(-1);
+        expect(last?.attributes?.toRoute).toBe('/teams/:id');
+        expect(last?.attributes?.fromRoute).toBe('/users/:id');
+      });
+    });
+
+    describe('withFaroRouterInstrumentation (data router)', () => {
+      it('emits a route_change with the route pattern on navigation', async () => {
+        initializeReactRouterV6DataRouterInstrumentation({ matchRoutes });
+
+        const router = createMemoryRouter(
+          [
+            { path: '/', element: <div>home</div> },
+            { path: '/users/:id', element: <div>user</div> },
+          ],
+          { initialEntries: ['/'] }
+        );
+
+        withFaroRouterInstrumentation(router);
+
+        render(<RouterProvider router={router} />);
+
+        await act(async () => {
+          await router.navigate('/users/42');
+        });
+
+        const last = faro.routeChanges().at(-1);
+        expect(last?.attributes?.toRoute).toBe('/users/:id');
+      });
+    });
+  });
+}

--- a/packages/react/src/router/__matrix__/v5.test.tsx
+++ b/packages/react/src/router/__matrix__/v5.test.tsx
@@ -1,0 +1,48 @@
+// This project pins react/react-dom to v18 (RR v5 does not run on React 19) and
+// uses the real react-router-dom@5 + history@4 aliases.
+import { act, render } from '@testing-library/react';
+import { createMemoryHistory } from 'history-v4';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router-dom-v5';
+
+import { FaroRoute } from '../v4v5/FaroRoute';
+import { initializeReactRouterV4V5Instrumentation } from '../v4v5/initialize';
+
+import { installFaroApiMock } from './faroApiMock';
+
+describe('react-router v5', () => {
+  let faro: ReturnType<typeof installFaroApiMock>;
+
+  beforeEach(() => {
+    faro = installFaroApiMock();
+  });
+
+  // The v4/v5 instrumentation builds an "active event" whose route is filled in
+  // by <FaroRoute> as it renders, and flushes it on the NEXT navigation. So to
+  // observe the pattern for a page, we navigate away from it.
+  it('emits the matched route pattern of the page being left on navigation', () => {
+    const history = createMemoryHistory({ initialEntries: ['/'] });
+
+    initializeReactRouterV4V5Instrumentation({ history, Route });
+
+    render(
+      <Router history={history}>
+        <Switch>
+          <FaroRoute exact path="/" />
+          <FaroRoute path="/users/:id" />
+          <FaroRoute path="/teams/:id" />
+        </Switch>
+      </Router>
+    );
+
+    act(() => {
+      history.push('/users/42');
+    });
+    act(() => {
+      history.push('/teams/7');
+    });
+
+    const routes = faro.routeChanges().map((call) => call.attributes?.route);
+    expect(routes).toEqual(['/', '/users/:id']);
+  });
+});

--- a/packages/react/src/router/__matrix__/v6.test.tsx
+++ b/packages/react/src/router/__matrix__/v6.test.tsx
@@ -1,0 +1,28 @@
+// `react-router` resolves to the v6 alias via this project's moduleNameMapper.
+import {
+  createMemoryRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  MemoryRouter,
+  Route,
+  RouterProvider,
+  Routes,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+} from 'react-router';
+
+import { runRouterMatrixSuite } from './shared';
+
+runRouterMatrixSuite('v6', {
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+  Route,
+  MemoryRouter,
+  useNavigate,
+  createMemoryRouter,
+  RouterProvider,
+});

--- a/packages/react/src/router/__matrix__/v7.test.tsx
+++ b/packages/react/src/router/__matrix__/v7.test.tsx
@@ -1,0 +1,28 @@
+// `react-router` resolves to the plain devDependency (7.x) in this project.
+import {
+  createMemoryRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  MemoryRouter,
+  Route,
+  RouterProvider,
+  Routes,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+} from 'react-router';
+
+import { runRouterMatrixSuite } from './shared';
+
+runRouterMatrixSuite('v7', {
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+  Route,
+  MemoryRouter,
+  useNavigate,
+  createMemoryRouter,
+  RouterProvider,
+});

--- a/packages/react/src/router/__matrix__/v8.test.tsx
+++ b/packages/react/src/router/__matrix__/v8.test.tsx
@@ -1,0 +1,29 @@
+// `react-router` resolves to the v8 alias (ESM-only) via this project's mapper.
+// In v8, RouterProvider moved to the `react-router/dom` entry point.
+import {
+  createMemoryRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+} from 'react-router';
+import { RouterProvider } from 'react-router/dom';
+
+import { runRouterMatrixSuite } from './shared';
+
+runRouterMatrixSuite('v8', {
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+  Route,
+  MemoryRouter,
+  useNavigate,
+  createMemoryRouter,
+  RouterProvider,
+});

--- a/packages/react/tsconfig.bundle.json
+++ b/packages/react/tsconfig.bundle.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "../../.cache/tsc/react.bundle.tsbuildinfo"
   },
   "include": ["./src"],
-  "exclude": ["./**/*.test.ts"]
+  "exclude": ["./**/*.test.ts", "**/__matrix__/**"]
 }

--- a/packages/react/tsconfig.cjs.json
+++ b/packages/react/tsconfig.cjs.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../.cache/tsc/react.cjs.tsbuildinfo"
   },
   "include": ["./src"],
-  "exclude": ["**/*.test.ts"],
+  "exclude": ["**/*.test.ts", "**/__matrix__/**"],
   "references": [
     { "path": "../core/tsconfig.cjs.json" },
     { "path": "../web-sdk/tsconfig.cjs.json" },

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../.cache/tsc/react.esm.tsbuildinfo"
   },
   "include": ["./src"],
-  "exclude": ["**/*.test.ts"],
+  "exclude": ["**/*.test.ts", "**/__matrix__/**"],
   "references": [
     { "path": "../core/tsconfig.esm.json" },
     { "path": "../web-sdk/tsconfig.esm.json" },

--- a/packages/react/tsconfig.matrix.esm.json
+++ b/packages/react/tsconfig.matrix.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.matrix.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022"
+  }
+}

--- a/packages/react/tsconfig.matrix.json
+++ b/packages/react/tsconfig.matrix.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.spec.json",
+  "compilerOptions": {
+    "composite": false,
+    "isolatedModules": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}

--- a/packages/react/tsconfig.spec.json
+++ b/packages/react/tsconfig.spec.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "../../.cache/tsc/react.spec.tsbuildinfo"
   },
   "include": ["./src"],
+  "exclude": ["**/__matrix__/**"],
   "references": [
     { "path": "../core/tsconfig.spec.json" },
     { "path": "../web-sdk/tsconfig.spec.json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 10
   cacheKey: 10c0
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.5.0
+  resolution: "@adobe/css-tools@npm:4.5.0"
+  checksum: 10c0/fc969e1117098eb4cccdb73beb2508daa0e52760af1183d6288bafea59204943490ab3ede28593032ffb8929c0cee270b2a53254fe61139ab00604ea8fc33cea
+  languageName: node
+  linkType: hard
+
 "@asamuzakjp/css-color@npm:^3.2.0":
   version: 3.2.0
   resolution: "@asamuzakjp/css-color@npm:3.2.0"
@@ -18,7 +25,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.29.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
@@ -348,6 +355,13 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/c49883b0327e8683b770dc823205af5c697da216e590dcf5bf53f3f031e7e381de450b164f8f99853f0837a3de5cb793298e2be6697a0f6e452bb9dd34b5165e
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
   languageName: node
   linkType: hard
 
@@ -695,12 +709,22 @@ __metadata:
   dependencies:
     "@grafana/faro-web-sdk": "npm:^2.7.1"
     "@grafana/faro-web-tracing": "npm:^2.7.1"
+    "@testing-library/dom": "npm:10.4.1"
+    "@testing-library/jest-dom": "npm:6.9.1"
+    "@testing-library/react": "npm:16.3.2"
     "@types/hoist-non-react-statics": "npm:3.3.7"
     "@types/react": "npm:19.2.17"
+    "@types/react-dom": "npm:19.2.3"
+    history-v4: "npm:history@4.10.1"
     hoist-non-react-statics: "npm:^3.3.2"
     react: "npm:19.2.7"
+    react-18: "npm:react@18.3.1"
     react-dom: "npm:19.2.7"
+    react-dom-18: "npm:react-dom@18.3.1"
     react-router: "npm:7.18.0"
+    react-router-dom-v5: "npm:react-router-dom@5.3.4"
+    react-router-v6: "npm:react-router@6.30.4"
+    react-router-v8: "npm:react-router@8.0.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2266,6 +2290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
@@ -2929,6 +2960,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:6.9.1":
+  version: 6.9.1
+  resolution: "@testing-library/jest-dom@npm:6.9.1"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  checksum: 10c0/4291ebd2f0f38d14cefac142c56c337941775a5807e2a3d6f1a14c2fbd6be76a18e498ed189e95bedc97d9e8cf1738049bc76c85b5bc5e23fae7c9e10f7b3a12
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:16.3.2":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
+  languageName: node
+  linkType: hard
+
 "@ts-graphviz/adapter@npm:^2.0.6":
   version: 2.0.6
   resolution: "@ts-graphviz/adapter@npm:2.0.6"
@@ -3024,6 +3105,13 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
   languageName: node
   linkType: hard
 
@@ -3833,7 +3921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.2.0":
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
@@ -3912,6 +4000,22 @@ __metadata:
   dependencies:
     sprintf-js: "npm:~1.0.2"
   checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "aria-query@npm:5.3.2"
+  checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
   languageName: node
   linkType: hard
 
@@ -4856,6 +4960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-es@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "cookie-es@npm:3.1.1"
+  checksum: 10c0/62cf0c325cc547b52477b351e9b5d068b3ffc74f7d143cdf7af854648dd1015fca3aed1498b355365e24b0746333f0b15688ed3a535abecc5ed0a046ae956a84
+  languageName: node
+  linkType: hard
+
 "cookie@npm:^1.0.1":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
@@ -4902,6 +5013,13 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
   languageName: node
   linkType: hard
 
@@ -5154,7 +5272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:^2.0.0":
+"dequal@npm:^2.0.0, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
@@ -5299,6 +5417,20 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 
@@ -6816,7 +6948,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"history-v4@npm:history@4.10.1, history@npm:^4.9.0":
+  version: 4.10.1
+  resolution: "history@npm:4.10.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.1.2"
+    loose-envify: "npm:^1.2.0"
+    resolve-pathname: "npm:^3.0.0"
+    tiny-invariant: "npm:^1.0.2"
+    tiny-warning: "npm:^1.0.0"
+    value-equal: "npm:^1.0.1"
+  checksum: 10c0/35377694e4f10f2cf056a9cb1a8ee083e04e4b4717a63baeee4afd565658a62c7e73700bf9e82aa53dbe1ec94e0a25a83c080d63bad8ee6b274a98d2fbc5ed4c
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -7560,6 +7706,13 @@ __metadata:
   dependencies:
     is-docker: "npm:^2.0.0"
   checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
+  languageName: node
+  linkType: hard
+
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
   languageName: node
   linkType: hard
 
@@ -8847,7 +9000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -8887,6 +9040,15 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+  languageName: node
+  linkType: hard
+
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
   languageName: node
   linkType: hard
 
@@ -10713,6 +10875,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^1.7.0":
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
+  dependencies:
+    isarray: "npm:0.0.1"
+  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
@@ -10916,6 +11087,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
+  languageName: node
+  linkType: hard
+
 "pretty-ms@npm:^7.0.1":
   version: 7.0.1
   resolution: "pretty-ms@npm:7.0.1"
@@ -10986,7 +11168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -11060,6 +11242,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-18@npm:react@18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
+  languageName: node
+  linkType: hard
+
+"react-dom-18@npm:react-dom@18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    scheduler: "npm:^0.23.2"
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.1.0":
   version: 19.2.7
   resolution: "react-dom@npm:19.2.7"
@@ -11085,10 +11288,79 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
+  languageName: node
+  linkType: hard
+
+"react-router-dom-v5@npm:react-router-dom@5.3.4":
+  version: 5.3.4
+  resolution: "react-router-dom@npm:5.3.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.13"
+    history: "npm:^4.9.0"
+    loose-envify: "npm:^1.3.1"
+    prop-types: "npm:^15.6.2"
+    react-router: "npm:5.3.4"
+    tiny-invariant: "npm:^1.0.2"
+    tiny-warning: "npm:^1.0.0"
+  peerDependencies:
+    react: ">=15"
+  checksum: 10c0/f04f727e2ed2e9d1d3830af02cc61690ff67b1524c0d18690582bfba0f4d14142ccc88fb6da6befad644fddf086f5ae4c2eb7048c67da8a0b0929c19426421b0
+  languageName: node
+  linkType: hard
+
+"react-router-v6@npm:react-router@6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
+  dependencies:
+    "@remix-run/router": "npm:1.23.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
+  languageName: node
+  linkType: hard
+
+"react-router-v8@npm:react-router@8.0.1":
+  version: 8.0.1
+  resolution: "react-router@npm:8.0.1"
+  dependencies:
+    cookie-es: "npm:^3.1.1"
+  peerDependencies:
+    react: ">=19.2.7"
+    react-dom: ">=19.2.7"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/7ffcac5caf209b6988a0e045fd044f5f8e91e7f677475f707becd514f316f6c2d556f90e371c5a41f6033da891a2d97370b1c5d443ba96991ab0f4f71252c8ba
+  languageName: node
+  linkType: hard
+
+"react-router@npm:5.3.4":
+  version: 5.3.4
+  resolution: "react-router@npm:5.3.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.13"
+    history: "npm:^4.9.0"
+    hoist-non-react-statics: "npm:^3.1.0"
+    loose-envify: "npm:^1.3.1"
+    path-to-regexp: "npm:^1.7.0"
+    prop-types: "npm:^15.6.2"
+    react-is: "npm:^16.6.0"
+    tiny-invariant: "npm:^1.0.2"
+    tiny-warning: "npm:^1.0.0"
+  peerDependencies:
+    react: ">=15"
+  checksum: 10c0/e15c00dfef199249b4c6e6d98e5e76cc352ce66f3270f13df37cc069ddf7c05e43281e8c308fc407e4435d72924373baef1d2890e0f6b0b1eb423cf47315a053
   languageName: node
   linkType: hard
 
@@ -11329,6 +11601,13 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
+  languageName: node
+  linkType: hard
+
+"resolve-pathname@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-pathname@npm:3.0.0"
+  checksum: 10c0/c6ec49b670dc35b9a303c47fa83ba9348a71e92d64a4c4bb85e1b659a29b407aa1ac1cb14a9b5b502982132ca77482bd80534bca147439d66880d35a137fe723
   languageName: node
   linkType: hard
 
@@ -11737,6 +12016,15 @@ __metadata:
   dependencies:
     xmlchars: "npm:^2.2.0"
   checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
   languageName: node
   linkType: hard
 
@@ -12534,6 +12822,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-invariant@npm:^1.0.2":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
+  languageName: node
+  linkType: hard
+
+"tiny-warning@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "tiny-warning@npm:1.0.3"
+  checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.2.4":
   version: 1.2.4
   resolution: "tinyexec@npm:1.2.4"
@@ -13166,6 +13468,13 @@ __metadata:
   version: 7.0.2
   resolution: "validate-npm-package-name@npm:7.0.2"
   checksum: 10c0/adf32e943148e13e8df13d06b855493908e6ae7a847610e8543c6291cbf42f40e653249a5b2275e2e615e3224c574ade5a9064a9e2d1ab629386284ea99e8f39
+  languageName: node
+  linkType: hard
+
+"value-equal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "value-equal@npm:1.0.1"
+  checksum: 10c0/79068098355483ef29f4d3753999ad880875b87625d7e9055cad9346ea4b7662aad3a66f87976801b0dd7a6f828ba973d28b1669ebcd37eaf88cc5f687c1a691
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds behavioral router-instrumentation tests that run against **real** react-router v5/v6/v7/v8, closing a gap where the only existing router test mocked every dependency.

_PR description authored by Claude on Domas's behalf._