### PR TITLE
fix(web-sdk): report service worker time as 0 when no service worker is used

### DIFF
--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.test.ts
@@ -42,7 +42,7 @@ describe('performanceUtils', () => {
       responseTime: '0',
       responseStatus: '200',
       fetchTime: '305',
-      serviceWorkerTime: '237',
+      serviceWorkerTime: '0',
       decodedBodySize: '530675',
       encodedBodySize: '126111',
       cacheHitStatus: 'fullLoad',
@@ -67,7 +67,7 @@ describe('performanceUtils', () => {
       responseTime: '0',
       responseStatus: '200',
       fetchTime: '370',
-      serviceWorkerTime: '778',
+      serviceWorkerTime: '0',
       decodedBodySize: '10526',
       encodedBodySize: '10526',
       cacheHitStatus: 'fullLoad',
@@ -225,5 +225,12 @@ describe('performanceUtils', () => {
     expect(createFaroResourceTiming({ initiatorType: 'initiatorType-test' } as any).initiatorType).toBe(
       'initiatorType-test'
     );
+  });
+
+  it('reports serviceWorkerTime as 0 when the request is not intercepted by a service worker (workerStart === 0)', () => {
+    // Per the W3C Resource Timing spec, workerStart is 0 when no service worker handles the request.
+    // fetchStart is a timeOrigin-relative timestamp (page age), not a duration, so fetchStart - 0
+    // must not be reported as the service worker time.
+    expect(createFaroResourceTiming({ fetchStart: 179315969, workerStart: 0 } as any).serviceWorkerTime).toBe('0');
   });
 });

--- a/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
+++ b/packages/web-sdk/src/instrumentations/performance/performanceUtils.ts
@@ -107,7 +107,10 @@ export function createFaroResourceTiming(resourceEntryRaw: PerformanceResourceTi
     requestTime: toFaroPerformanceTimingString(responseStart - requestStart),
     responseTime: toFaroPerformanceTimingString(responseEnd - responseStart),
     fetchTime: toFaroPerformanceTimingString(responseEnd - fetchStart),
-    serviceWorkerTime: toFaroPerformanceTimingString(fetchStart - workerStart),
+    // workerStart is 0 when the request is not intercepted by a service worker (W3C Resource Timing spec).
+    // fetchStart is a timeOrigin-relative timestamp, not a duration, so guard against reporting it as the
+    // service worker time when no service worker handled the request.
+    serviceWorkerTime: toFaroPerformanceTimingString(workerStart > 0 ? fetchStart - workerStart : 0),
     decodedBodySize: toFaroPerformanceTimingString(decodedBodySize),
     encodedBodySize: toFaroPerformanceTimingString(encodedBodySize),
     cacheHitStatus: getCacheType(),


### PR DESCRIPTION
## Why

The "Service worker time" series in the resource timings breakdown reported implausible values (p75 of hours to days) for apps that do not use a service worker.

`PerformanceResourceTiming.workerStart` is `0` when a request is not intercepted by a service worker (per the [W3C Resource Timing spec](https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-workerstart), also confirmed on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/workerStart)). Since `fetchStart` is a `timeOrigin`-relative **timestamp**, not a duration, the existing `fetchStart - workerStart` calculation emitted the page-relative timestamp as the service worker time for every non-intercepted request. The value therefore grew with the page's age — in long-lived sessions it reached hours or days.

Most pages register no service worker, so this affected the majority of resource entries.

## What

- Guard the calculation in `createFaroResourceTiming` so service worker time is computed only when a service worker actually handled the request (`workerStart > 0`), and is `0` otherwise.
- Add a test for the no-service-worker case (`workerStart === 0`).
- Update two existing test fixtures whose `workerStart: 0` data previously asserted the timestamp as the service worker time.

## Links

<!-- Add issues the PR solves or other useful links here. -->

## Checklist

- [x] Tests added
- [ ] Changelog updated <!-- generated from the conventional commit on release -->
- [ ] Documentation updated <!-- no public API or behavior contract change -->