### PR TITLE
docs(releasing): document two-person publish approval

### DIFF
--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -13,13 +13,20 @@ No manual `lerna version` runs and no direct pushes to `main` are required.
 3. When a maintainer merges that Release PR, release-please creates the matching
    `vX.Y.Z` git tag and a GitHub Release. The merge commit (a push to `main`)
    re-runs `release-please.yml`. Because `release-please` outputs
-   `releases_created: true` on this run, the chained `test`, `e2e`, and
-   `publish` jobs in the same workflow execute.
+   `releases_created: true` on this run, the chained `test` and `publish` jobs
+   in the same workflow execute.
 4. The `publish` job runs `npm run publish -- from-package --yes` (which calls
    `lerna publish from-package`), gated by the `publish` GitHub Environment
    (manual approval, branch-restricted to `main`) and authenticated to npm via
    Trusted Publishing (OIDC). npm-provenance is enabled via
-   `NPM_CONFIG_PROVENANCE=true`.
+   `NPM_CONFIG_PROVENANCE=true`. See [Approving the publish](#approving-the-publish-two-person-rule)
+   for who must approve.
+
+While the Release PR is open, the workflow also refreshes `yarn.lock` and
+re-runs formatting on the PR branch, pushing a `chore: refresh yarn.lock and
+format release files` commit when needed. This commit is created through the
+GitHub API (so it is signed and satisfies the verified-signatures ruleset) — it
+is expected, not tampering.
 
 All publishable packages share one version because the config runs release-please
 in **single-component mode**: a single root entry in `packages` with an
@@ -55,6 +62,38 @@ Land a PR with a conventional commit prefix:
 
 The Release PR will appear (or update) within a few minutes of the merge to `main`.
 Review and merge it when you're ready to ship.
+
+## Approving the publish (two-person rule)
+
+The `publish` job pauses on the `publish` GitHub Environment until a member of
+[`@grafana/frontend-o11y`](https://github.com/orgs/grafana/teams/frontend-o11y)
+approves the deployment.
+
+**A release requires two people.** GitHub does not allow you to approve your own
+deployment, so whoever merges the Release PR (and thereby triggers the publish
+run) **cannot** approve it. A _different_ member of `@grafana/frontend-o11y` must
+approve.
+
+To approve:
+
+1. Open the workflow run under the repo
+   [Actions tab](https://github.com/grafana/faro-web-sdk/actions/workflows/release-please.yml).
+   The `publish` job shows as waiting.
+2. Click **Review deployments**, select the `publish` environment, then
+   **Approve and deploy**.
+
+If you don't see the **Review deployments** button, it's almost always because
+you triggered the run yourself — ask another team member to approve. The CLI
+equivalent (for an eligible approver) is:
+
+```sh
+# Find the pending environment id:
+gh api repos/grafana/faro-web-sdk/actions/runs/<run-id>/pending_deployments
+
+# Approve it:
+gh api repos/grafana/faro-web-sdk/actions/runs/<run-id>/pending_deployments \
+  -f 'environment_ids[]=<env-id>' -f state=approved -f comment="ok to publish"
+```
 
 ## Configuration
 


### PR DESCRIPTION
## Why

The `publish` job in `release-please.yml` is gated by the `publish` GitHub
Environment, which requires approval from `@grafana/frontend-o11y`. GitHub does
not allow approving your own deployment, so the person who merges the Release PR
(and triggers the publish run) cannot approve it — a release genuinely requires
a second team member. This was not documented, leading to confusion when no
"Review deployments" button appears for the triggering user.

While updating the docs I also found two inaccuracies in `releasing.md`.

## What

- Add an **"Approving the publish (two-person rule)"** section: the
  `@grafana/frontend-o11y` environment gate, the self-approval restriction, the
  **Review deployments** UI flow, and a `gh api` CLI fallback for eligible
  approvers.
- Remove the reference to a non-existent **`e2e`** job (the workflow only chains
  `release-please` → `test` → `publish`).
- Document the bot's signed `chore: refresh yarn.lock and format release files`
  commit on the Release PR so reviewers don't mistake it for tampering.

Docs-only change.

## Links

- Workflow run that surfaced the gap: https://github.com/grafana/faro-web-sdk/actions/runs/28172004525

## Checklist

- [ ] Tests added <!-- n/a, docs only -->
- [ ] Changelog updated <!-- n/a, docs only -->
- [x] Documentation updated
