### PR TITLE
docs(releasing): clarify two-person rule is Prevent self-review setting

### DIFF
--- a/docs/sources/developer/releasing.md
+++ b/docs/sources/developer/releasing.md
@@ -69,10 +69,10 @@ The `publish` job pauses on the `publish` GitHub Environment until a member of
 [`@grafana/frontend-o11y`](https://github.com/orgs/grafana/teams/frontend-o11y)
 approves the deployment.
 
-**A release requires two people.** GitHub does not allow you to approve your own
-deployment, so whoever merges the Release PR (and thereby triggers the publish
-run) **cannot** approve it. A _different_ member of `@grafana/frontend-o11y` must
-approve.
+**A release requires two people.** The `publish` environment has the
+**Prevent self-review** protection setting enabled, so whoever merges the Release
+PR (and thereby triggers the publish run) **cannot** approve it. A _different_
+member of `@grafana/frontend-o11y` must approve.
 
 To approve:
 
@@ -83,8 +83,8 @@ To approve:
    **Approve and deploy**.
 
 If you don't see the **Review deployments** button, it's almost always because
-you triggered the run yourself — ask another team member to approve. The CLI
-equivalent (for an eligible approver) is:
+you triggered the run yourself and **Prevent self-review** is enabled — ask
+another team member to approve. The CLI equivalent (for an eligible approver) is:
 
 ```sh
 # Find the pending environment id:


### PR DESCRIPTION
## Why

Follow-up to #2152. A review comment ([discussion](https://github.com/grafana/faro-web-sdk/pull/2152#discussion_r3479770756)) pointed out that the inability to approve your own deployment is **not** an inherent GitHub restriction — it's the **Prevent self-review** environment protection setting. The setting is intentionally enabled on the `publish` environment (verified: `prevent_self_review: true`).

## What

- Reworded the "two-person rule" section to attribute the behavior to the `publish` environment's **Prevent self-review** setting rather than a GitHub limitation.
- Updated the "Review deployments" troubleshooting note to reference the same setting.

## Links

- Follow-up to #2152
- Review comment: https://github.com/grafana/faro-web-sdk/pull/2152#discussion_r3479770756

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated