### PR TITLE
fix(web-sdk): sync in-memory session id with stored session id on activity

### DIFF
--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -79,6 +79,14 @@ export function getUserSessionUpdater({
 
     if (forceSessionExtend === false && isUserSessionValid(sessionFromStorage)) {
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
+
+      const storedSessionId = sessionFromStorage?.sessionId;
+      const inMemorySessionId = sessionFromStorage?.sessionMeta?.id;
+
+      if (sessionFromStorage && storedSessionId !== inMemorySessionId) {
+        sessionFromStorage!.sessionMeta!.id = sessionFromStorage?.sessionId;
+        faro.api?.setSession(sessionFromStorage?.sessionMeta);
+      }
     } else {
       let newSession = addSessionMetadataToNextSession(
         createUserSessionObject({ isSampled: isSampled() }),


### PR DESCRIPTION
## Summary

When a user session is still valid and gets its `lastActivity` refreshed, the in-memory session metadata id (`sessionMeta.id`) could drift out of sync with the persisted `sessionId`. This change detects that mismatch and re-aligns the in-memory session metadata, pushing the corrected session through `faro.api.setSession`.

## Changes

- In `getUserSessionUpdater`, after extending a valid session, compare the stored `sessionId` against the in-memory `sessionMeta.id`. If they differ, update `sessionMeta.id` and call `faro.api.setSession` with the corrected metadata.

## Notes

Opened as a draft for review. Tests/validation have not yet been run.