### PR TITLE
fix: serialize all OTLP measurement values

### DIFF
--- a/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
@@ -175,6 +175,10 @@ const matchMeasurementLogRecord = {
       key: 'measurement.value',
       value: { doubleValue: 213.7000000011176 },
     },
+    {
+      key: 'measurement.values.fcp',
+      value: { doubleValue: 213.7000000011176 },
+    },
   ],
 
   traceId: 'trace-id',
@@ -185,6 +189,55 @@ describe('toMeasurementLogRecord', () => {
   it('Builds resource payload object for given transport item.', () => {
     const measurementLogRecord = getLogTransforms(mockInternalLogger).toScopeLog(item).logRecords[0];
     expect(measurementLogRecord).toStrictEqual(matchMeasurementLogRecord);
+  });
+
+  it('serializes all measurement values as attributes.', () => {
+    const measurementLogRecord = getLogTransforms(mockInternalLogger).toScopeLog({
+      ...item,
+      payload: {
+        ...item.payload,
+        values: {
+          inp: 24,
+          delta: 24,
+          input_delay: 5.3,
+          processing_duration: 0.3,
+          presentation_delay: 18.4,
+        },
+      },
+    }).logRecords[0]!;
+
+    expect(measurementLogRecord.attributes).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'measurement.name',
+          value: { stringValue: 'inp' },
+        },
+        {
+          key: 'measurement.value',
+          value: { intValue: 24 },
+        },
+        {
+          key: 'measurement.values.inp',
+          value: { intValue: 24 },
+        },
+        {
+          key: 'measurement.values.delta',
+          value: { intValue: 24 },
+        },
+        {
+          key: 'measurement.values.input_delay',
+          value: { doubleValue: 5.3 },
+        },
+        {
+          key: 'measurement.values.processing_duration',
+          value: { doubleValue: 0.3 },
+        },
+        {
+          key: 'measurement.values.presentation_delay',
+          value: { doubleValue: 18.4 },
+        },
+      ])
+    );
   });
 
   it('Builds resource payload object for given transport item with custom body attached.', () => {

--- a/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
@@ -187,6 +187,58 @@ describe('toMeasurementLogRecord', () => {
     expect(measurementLogRecord).toStrictEqual(matchMeasurementLogRecord);
   });
 
+  it('serializes all measurement values as attributes.', () => {
+    const measurementLogRecord = getLogTransforms(mockInternalLogger).toScopeLog({
+      ...item,
+      payload: {
+        ...item.payload,
+        values: {
+          inp: 24,
+          delta: 24,
+          input_delay: 5.3,
+          processing_duration: 0.3,
+          presentation_delay: 18.4,
+        },
+      },
+    }).logRecords[0]!;
+
+    const attributeKeys = measurementLogRecord.attributes.map(({ key }) => key);
+    expect(attributeKeys).toHaveLength(new Set(attributeKeys).size);
+
+    expect(
+      measurementLogRecord.attributes.filter(({ key }) => key.startsWith('measurement.'))
+    ).toStrictEqual([
+      {
+        key: 'measurement.type',
+        value: { stringValue: 'web-vitals' },
+      },
+      {
+        key: 'measurement.name',
+        value: { stringValue: 'inp' },
+      },
+      {
+        key: 'measurement.value',
+        value: { intValue: 24 },
+      },
+      {
+        key: 'measurement.values.delta',
+        value: { intValue: 24 },
+      },
+      {
+        key: 'measurement.values.input_delay',
+        value: { doubleValue: 5.3 },
+      },
+      {
+        key: 'measurement.values.processing_duration',
+        value: { doubleValue: 0.3 },
+      },
+      {
+        key: 'measurement.values.presentation_delay',
+        value: { doubleValue: 18.4 },
+      },
+    ]);
+  });
+
   it('Builds resource payload object for given transport item with custom body attached.', () => {
     const customOtlpTransform: OtlpHttpTransportOptions['otlpTransform'] = {
       createMeasurementLogBody(item) {

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -174,7 +174,10 @@ export function getLogTransforms(
   function toMeasurementLogRecord(transportItem: TransportItem<MeasurementEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
-    const [measurementName, measurementValue] = Object.entries(payload.values).flat();
+    const [[measurementName, measurementValue] = []] = Object.entries(payload.values);
+    const measurementValueAttributes = Object.entries(payload.values)
+      .map(([name, value]) => toAttribute(`measurement.values.${name}`, value))
+      .filter(isAttribute);
 
     const body = getCustomLogBody(transportItem, customOtlpTransform?.createMeasurementLogBody);
 
@@ -186,6 +189,7 @@ export function getLogTransforms(
         toAttribute('measurement.type', payload.type),
         toAttribute('measurement.name', measurementName),
         toAttribute('measurement.value', measurementValue),
+        ...measurementValueAttributes,
         toAttribute('faro.measurement.context', payload.context),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,

--- a/experimental/transport-otlp-http/src/payload/transform/transform.ts
+++ b/experimental/transport-otlp-http/src/payload/transform/transform.ts
@@ -174,7 +174,11 @@ export function getLogTransforms(
   function toMeasurementLogRecord(transportItem: TransportItem<MeasurementEvent>): LogRecord {
     const { meta, payload } = transportItem;
     const timeUnixNano = toTimeUnixNano(payload.timestamp);
-    const [measurementName, measurementValue] = Object.entries(payload.values).flat();
+    const [[measurementName, measurementValue] = [], ...additionalMeasurementValues] =
+      Object.entries(payload.values);
+    const measurementValueAttributes = additionalMeasurementValues
+      .map(([name, value]) => toAttribute(`measurement.values.${name}`, value))
+      .filter(isAttribute);
 
     const body = getCustomLogBody(transportItem, customOtlpTransform?.createMeasurementLogBody);
 
@@ -186,6 +190,7 @@ export function getLogTransforms(
         toAttribute('measurement.type', payload.type),
         toAttribute('measurement.name', measurementName),
         toAttribute('measurement.value', measurementValue),
+        ...measurementValueAttributes,
         toAttribute('faro.measurement.context', payload.context),
       ].filter(isAttribute),
       traceId: payload.trace?.trace_id,


### PR DESCRIPTION
Summary

- Add one OTLP log attribute for every measurement payload value.
- Keep the existing measurement.name and measurement.value attributes for the first value.
- Add regression coverage for multi-value measurements.

Testing

- git diff --check
- yarn eslint experimental/transport-otlp-http/src/payload/transform/transform.ts experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
- yarn prettier --check experimental/transport-otlp-http/src/payload/transform/transform.ts experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts
- Focused Jest run for experimental/transport-otlp-http/src/payload/transform/toMeasurementLogRecord.test.ts

Closes #2105