### PR TITLE
fix: emit navigation changes after commit

### DIFF
--- a/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
@@ -70,14 +70,13 @@ describe('monitorUrlChanges', () => {
 
   describe('with Navigation API', () => {
     let originalNavigation: any;
-    let originalNavigateEvent: any;
 
     beforeEach(() => {
       originalNavigation = (window as any).navigation;
-      originalNavigateEvent = (window as any).NavigateEvent;
 
-      const listeners: Record<string, Function[]> = { navigate: [] };
+      const listeners: Record<string, Function[]> = { currententrychange: [], navigate: [] };
       (window as any).navigation = {
+        currentEntry: { url: window.location.href },
         addEventListener: (type: string, cb: Function) => listeners[type]?.push(cb),
         removeEventListener: (type: string, cb: Function) => {
           const arr = listeners[type];
@@ -91,41 +90,27 @@ describe('monitorUrlChanges', () => {
         },
         _dispatch: (type: string, ev: any) => listeners[type]?.forEach((cb) => cb(ev)),
       };
-
-      function FakeNavigateEvent(this: any, _type: string, init: any) {
-        this.destination = init?.destination;
-      }
-      (FakeNavigateEvent as any).prototype = {
-        intercept: jest.fn(),
-      };
-
-      (window as any).NavigateEvent = FakeNavigateEvent as any;
     });
 
     afterEach(() => {
       (window as any).navigation = originalNavigation;
-      (window as any).NavigateEvent = originalNavigateEvent;
     });
 
-    it('emits on same-document navigate events and does not patch history', () => {
+    it('emits on currententrychange events and does not patch history', () => {
       const initialHref = window.location.href;
       const observable = monitorUrlChanges();
       const subscriber = jest.fn();
       observable.subscribe(subscriber);
 
-      (window as any).navigation._dispatch(
-        'navigate',
-        new (window as any).NavigateEvent('navigate', {
-          destination: { url: initialHref + '#nav', sameDocument: true },
-        })
-      );
+      (window as any).navigation.currentEntry = { url: initialHref + '#nav' };
+      (window as any).navigation._dispatch('currententrychange', {});
 
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({
         type: MESSAGE_TYPE_URL_CHANGE,
         from: initialHref,
         to: initialHref + '#nav',
-        trigger: 'navigate',
+        trigger: 'currententrychange',
       });
 
       // ensure history methods were not wrapped in this mode
@@ -135,26 +120,34 @@ describe('monitorUrlChanges', () => {
       expect(replaceDesc?.value).toBeDefined();
     });
 
-    it('emits on intercept for cross-document navigations (soft navigation)', () => {
+    it('does not emit on navigate events before navigation commits', () => {
       const initialHref = window.location.href;
       const observable = monitorUrlChanges();
       const subscriber = jest.fn();
       observable.subscribe(subscriber);
 
-      const ev = new (window as any).NavigateEvent('navigate', {
-        destination: { url: initialHref + '/soft', sameDocument: false },
+      (window as any).navigation._dispatch('navigate', {
+        destination: { url: initialHref + '/pending', sameDocument: true },
       });
-      // make intercept permitted
-      (ev as any).canIntercept = true;
-      // call the wrapped intercept
-      (window as any).NavigateEvent.prototype.intercept.call(ev, {});
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('emits on committed soft navigations', () => {
+      const initialHref = window.location.href;
+      const observable = monitorUrlChanges();
+      const subscriber = jest.fn();
+      observable.subscribe(subscriber);
+
+      (window as any).navigation.currentEntry = { url: initialHref + '/soft' };
+      (window as any).navigation._dispatch('currententrychange', {});
 
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({
         type: MESSAGE_TYPE_URL_CHANGE,
         from: initialHref,
         to: initialHref + '/soft',
-        trigger: 'navigate-intercept',
+        trigger: 'currententrychange',
       });
     });
   });

--- a/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
@@ -70,14 +70,13 @@ describe('monitorUrlChanges', () => {
 
   describe('with Navigation API', () => {
     let originalNavigation: any;
-    let originalNavigateEvent: any;
 
     beforeEach(() => {
       originalNavigation = (window as any).navigation;
-      originalNavigateEvent = (window as any).NavigateEvent;
 
-      const listeners: Record<string, Function[]> = { navigate: [] };
+      const listeners: Record<string, Function[]> = { currententrychange: [], navigate: [] };
       (window as any).navigation = {
+        currentEntry: { url: window.location.href },
         addEventListener: (type: string, cb: Function) => listeners[type]?.push(cb),
         removeEventListener: (type: string, cb: Function) => {
           const arr = listeners[type];
@@ -91,41 +90,30 @@ describe('monitorUrlChanges', () => {
         },
         _dispatch: (type: string, ev: any) => listeners[type]?.forEach((cb) => cb(ev)),
       };
-
-      function FakeNavigateEvent(this: any, _type: string, init: any) {
-        this.destination = init?.destination;
-      }
-      (FakeNavigateEvent as any).prototype = {
-        intercept: jest.fn(),
-      };
-
-      (window as any).NavigateEvent = FakeNavigateEvent as any;
     });
 
     afterEach(() => {
       (window as any).navigation = originalNavigation;
-      (window as any).NavigateEvent = originalNavigateEvent;
     });
 
-    it('emits on same-document navigate events and does not patch history', () => {
+    it('emits on currententrychange events and does not patch history', () => {
       const initialHref = window.location.href;
       const observable = monitorUrlChanges();
       const subscriber = jest.fn();
       observable.subscribe(subscriber);
 
-      (window as any).navigation._dispatch(
-        'navigate',
-        new (window as any).NavigateEvent('navigate', {
-          destination: { url: initialHref + '#nav', sameDocument: true },
-        })
-      );
+      (window as any).navigation.currentEntry = { url: initialHref + '#nav' };
+      (window as any).navigation._dispatch('currententrychange', {
+        from: { url: initialHref },
+        navigationType: 'push',
+      });
 
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({
         type: MESSAGE_TYPE_URL_CHANGE,
         from: initialHref,
         to: initialHref + '#nav',
-        trigger: 'navigate',
+        trigger: 'pushState',
       });
 
       // ensure history methods were not wrapped in this mode
@@ -135,26 +123,49 @@ describe('monitorUrlChanges', () => {
       expect(replaceDesc?.value).toBeDefined();
     });
 
-    it('emits on intercept for cross-document navigations (soft navigation)', () => {
+    it('does not let uncommitted navigate events corrupt the next committed from URL', () => {
       const initialHref = window.location.href;
       const observable = monitorUrlChanges();
       const subscriber = jest.fn();
       observable.subscribe(subscriber);
 
-      const ev = new (window as any).NavigateEvent('navigate', {
-        destination: { url: initialHref + '/soft', sameDocument: false },
+      (window as any).navigation._dispatch('navigate', {
+        destination: { url: initialHref + '/pending', sameDocument: true },
       });
-      // make intercept permitted
-      (ev as any).canIntercept = true;
-      // call the wrapped intercept
-      (window as any).NavigateEvent.prototype.intercept.call(ev, {});
+
+      (window as any).navigation.currentEntry = { url: initialHref + '/committed' };
+      (window as any).navigation._dispatch('currententrychange', {
+        from: { url: initialHref },
+        navigationType: 'push',
+      });
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledWith({
+        type: MESSAGE_TYPE_URL_CHANGE,
+        from: initialHref,
+        to: initialHref + '/committed',
+        trigger: 'pushState',
+      });
+    });
+
+    it('emits on committed soft navigations', () => {
+      const initialHref = window.location.href;
+      const observable = monitorUrlChanges();
+      const subscriber = jest.fn();
+      observable.subscribe(subscriber);
+
+      (window as any).navigation.currentEntry = { url: initialHref + '/soft' };
+      (window as any).navigation._dispatch('currententrychange', {
+        from: { url: initialHref },
+        navigationType: 'traverse',
+      });
 
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({
         type: MESSAGE_TYPE_URL_CHANGE,
         from: initialHref,
         to: initialHref + '/soft',
-        trigger: 'navigate-intercept',
+        trigger: 'popstate',
       });
     });
   });

--- a/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts
@@ -6,7 +6,7 @@ export type UrlChangeMessage = {
   type: typeof MESSAGE_TYPE_URL_CHANGE;
   from: string;
   to: string;
-  trigger: 'pushState' | 'replaceState' | 'popstate' | 'hashchange' | 'navigate' | 'navigate-intercept';
+  trigger: 'pushState' | 'replaceState' | 'popstate' | 'hashchange' | 'currententrychange';
 };
 
 let urlChangeObservable: Observable<UrlChangeMessage> | undefined;
@@ -16,8 +16,7 @@ let originalPushState: typeof window.history.pushState | undefined;
 let originalReplaceState: typeof window.history.replaceState | undefined;
 let onPopStateHandler: ((this: Window, ev: PopStateEvent) => any) | undefined;
 let onHashChangeHandler: ((this: Window, ev: HashChangeEvent) => any) | undefined;
-let onNavigateHandler: ((this: any, ev: any) => any) | undefined;
-let originalNavigateEventIntercept: (((this: any, options?: any) => any) & { _faroWrapped?: boolean }) | undefined;
+let onCurrentEntryChangeHandler: ((this: any, ev: any) => any) | undefined;
 
 export function monitorUrlChanges(): Observable<UrlChangeMessage> {
   if (!urlChangeObservable) {
@@ -34,51 +33,25 @@ export function monitorUrlChanges(): Observable<UrlChangeMessage> {
   }
 
   if (!isInstrumented) {
-    const hasNavigation = 'navigation' in window && 'NavigateEvent' in (window as any);
+    const navigation = (window as any).navigation;
+    const hasNavigation =
+      typeof navigation?.addEventListener === 'function' &&
+      typeof navigation?.removeEventListener === 'function' &&
+      'currentEntry' in navigation;
 
     if (hasNavigation) {
       // Prefer Navigation API when supported: do not patch history or add popstate/hashchange listeners
-      onNavigateHandler = (e: any) => {
+      onCurrentEntryChangeHandler = () => {
         try {
-          const destination = e?.destination as { url?: string; sameDocument?: boolean } | undefined;
-          if (destination?.sameDocument && typeof destination.url === 'string') {
-            emit('navigate', destination.url);
+          const currentUrl = navigation.currentEntry?.url;
+          if (typeof currentUrl === 'string') {
+            emit('currententrychange', currentUrl);
           }
         } catch (_err) {
           // Swallow to avoid impacting host app
         }
       };
-      (window as any).navigation.addEventListener('navigate', onNavigateHandler as any);
-
-      const NavigateEventConstructor = (window as any).NavigateEvent;
-      if (
-        NavigateEventConstructor &&
-        NavigateEventConstructor.prototype &&
-        typeof NavigateEventConstructor.prototype.intercept === 'function'
-      ) {
-        if (!originalNavigateEventIntercept) {
-          originalNavigateEventIntercept = NavigateEventConstructor.prototype.intercept;
-        }
-
-        // Wrap intercept to detect soft navigations (cross-document turned same-document)
-        NavigateEventConstructor.prototype.intercept = function (this: any, options?: any) {
-          try {
-            const canIntercept = !!this?.canIntercept;
-            const destination = this?.destination as { url?: string; sameDocument?: boolean } | undefined;
-            if (
-              canIntercept &&
-              destination &&
-              destination.sameDocument === false &&
-              typeof destination.url === 'string'
-            ) {
-              emit('navigate-intercept', destination.url);
-            }
-          } catch (_err) {
-            // ignore
-          }
-          return originalNavigateEventIntercept!.call(this, options);
-        } as typeof originalNavigateEventIntercept;
-      }
+      navigation.addEventListener('currententrychange', onCurrentEntryChangeHandler as any);
 
       isInstrumented = true;
     } else {
@@ -121,8 +94,8 @@ export function __resetUrlChangeMonitorForTests() {
   if (onHashChangeHandler) {
     window.removeEventListener('hashchange', onHashChangeHandler);
   }
-  if (onNavigateHandler && (window as any).navigation?.removeEventListener) {
-    (window as any).navigation.removeEventListener('navigate', onNavigateHandler as any);
+  if (onCurrentEntryChangeHandler && (window as any).navigation?.removeEventListener) {
+    (window as any).navigation.removeEventListener('currententrychange', onCurrentEntryChangeHandler as any);
   }
   if (originalPushState) {
     window.history.pushState = originalPushState;
@@ -130,16 +103,12 @@ export function __resetUrlChangeMonitorForTests() {
   if (originalReplaceState) {
     window.history.replaceState = originalReplaceState;
   }
-  if (originalNavigateEventIntercept && (window as any).NavigateEvent?.prototype) {
-    (window as any).NavigateEvent.prototype.intercept = originalNavigateEventIntercept;
-  }
   urlChangeObservable = undefined;
   isInstrumented = false;
   lastHref = undefined;
   onPopStateHandler = undefined;
   onHashChangeHandler = undefined;
-  onNavigateHandler = undefined;
+  onCurrentEntryChangeHandler = undefined;
   originalPushState = undefined;
   originalReplaceState = undefined;
-  originalNavigateEventIntercept = undefined;
 }

--- a/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts
+++ b/packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts
@@ -6,7 +6,7 @@ export type UrlChangeMessage = {
   type: typeof MESSAGE_TYPE_URL_CHANGE;
   from: string;
   to: string;
-  trigger: 'pushState' | 'replaceState' | 'popstate' | 'hashchange' | 'navigate' | 'navigate-intercept';
+  trigger: 'pushState' | 'replaceState' | 'popstate' | 'hashchange' | 'reload';
 };
 
 let urlChangeObservable: Observable<UrlChangeMessage> | undefined;
@@ -16,8 +16,21 @@ let originalPushState: typeof window.history.pushState | undefined;
 let originalReplaceState: typeof window.history.replaceState | undefined;
 let onPopStateHandler: ((this: Window, ev: PopStateEvent) => any) | undefined;
 let onHashChangeHandler: ((this: Window, ev: HashChangeEvent) => any) | undefined;
-let onNavigateHandler: ((this: any, ev: any) => any) | undefined;
-let originalNavigateEventIntercept: (((this: any, options?: any) => any) & { _faroWrapped?: boolean }) | undefined;
+let onCurrentEntryChangeHandler: ((this: any, ev: any) => any) | undefined;
+
+function getNavigationTrigger(navigationType: string | undefined): UrlChangeMessage['trigger'] {
+  switch (navigationType) {
+    case 'push':
+      return 'pushState';
+    case 'replace':
+      return 'replaceState';
+    case 'reload':
+      return 'reload';
+    case 'traverse':
+    default:
+      return 'popstate';
+  }
+}
 
 export function monitorUrlChanges(): Observable<UrlChangeMessage> {
   if (!urlChangeObservable) {
@@ -25,60 +38,37 @@ export function monitorUrlChanges(): Observable<UrlChangeMessage> {
     lastHref = location.href;
   }
 
-  function emit(trigger: UrlChangeMessage['trigger'], toOverride?: string) {
+  function emit(trigger: UrlChangeMessage['trigger'], toOverride?: string, fromOverride?: string) {
     const next = toOverride ?? location.href;
-    if (next !== lastHref) {
-      urlChangeObservable!.notify({ type: MESSAGE_TYPE_URL_CHANGE, from: lastHref!, to: next, trigger });
+    const previous = fromOverride ?? lastHref;
+    if (previous && next !== previous) {
+      urlChangeObservable!.notify({ type: MESSAGE_TYPE_URL_CHANGE, from: previous, to: next, trigger });
       lastHref = next;
     }
   }
 
   if (!isInstrumented) {
-    const hasNavigation = 'navigation' in window && 'NavigateEvent' in (window as any);
+    const navigationApi = (window as any).navigation;
+    const hasNavigation =
+      typeof navigationApi?.addEventListener === 'function' &&
+      typeof navigationApi?.removeEventListener === 'function' &&
+      'currentEntry' in navigationApi;
 
     if (hasNavigation) {
       // Prefer Navigation API when supported: do not patch history or add popstate/hashchange listeners
-      onNavigateHandler = (e: any) => {
+      onCurrentEntryChangeHandler = (event: any) => {
         try {
-          const destination = e?.destination as { url?: string; sameDocument?: boolean } | undefined;
-          if (destination?.sameDocument && typeof destination.url === 'string') {
-            emit('navigate', destination.url);
+          const currentUrl = navigationApi.currentEntry?.url;
+          if (typeof currentUrl === 'string') {
+            const fromUrl = event?.from?.url;
+            const trigger = getNavigationTrigger(event?.navigationType);
+            emit(trigger, currentUrl, typeof fromUrl === 'string' ? fromUrl : undefined);
           }
         } catch (_err) {
           // Swallow to avoid impacting host app
         }
       };
-      (window as any).navigation.addEventListener('navigate', onNavigateHandler as any);
-
-      const NavigateEventConstructor = (window as any).NavigateEvent;
-      if (
-        NavigateEventConstructor &&
-        NavigateEventConstructor.prototype &&
-        typeof NavigateEventConstructor.prototype.intercept === 'function'
-      ) {
-        if (!originalNavigateEventIntercept) {
-          originalNavigateEventIntercept = NavigateEventConstructor.prototype.intercept;
-        }
-
-        // Wrap intercept to detect soft navigations (cross-document turned same-document)
-        NavigateEventConstructor.prototype.intercept = function (this: any, options?: any) {
-          try {
-            const canIntercept = !!this?.canIntercept;
-            const destination = this?.destination as { url?: string; sameDocument?: boolean } | undefined;
-            if (
-              canIntercept &&
-              destination &&
-              destination.sameDocument === false &&
-              typeof destination.url === 'string'
-            ) {
-              emit('navigate-intercept', destination.url);
-            }
-          } catch (_err) {
-            // ignore
-          }
-          return originalNavigateEventIntercept!.call(this, options);
-        } as typeof originalNavigateEventIntercept;
-      }
+      navigationApi.addEventListener('currententrychange', onCurrentEntryChangeHandler as any);
 
       isInstrumented = true;
     } else {
@@ -121,8 +111,8 @@ export function __resetUrlChangeMonitorForTests() {
   if (onHashChangeHandler) {
     window.removeEventListener('hashchange', onHashChangeHandler);
   }
-  if (onNavigateHandler && (window as any).navigation?.removeEventListener) {
-    (window as any).navigation.removeEventListener('navigate', onNavigateHandler as any);
+  if (onCurrentEntryChangeHandler && (window as any).navigation?.removeEventListener) {
+    (window as any).navigation.removeEventListener('currententrychange', onCurrentEntryChangeHandler as any);
   }
   if (originalPushState) {
     window.history.pushState = originalPushState;
@@ -130,16 +120,12 @@ export function __resetUrlChangeMonitorForTests() {
   if (originalReplaceState) {
     window.history.replaceState = originalReplaceState;
   }
-  if (originalNavigateEventIntercept && (window as any).NavigateEvent?.prototype) {
-    (window as any).NavigateEvent.prototype.intercept = originalNavigateEventIntercept;
-  }
   urlChangeObservable = undefined;
   isInstrumented = false;
   lastHref = undefined;
   onPopStateHandler = undefined;
   onHashChangeHandler = undefined;
-  onNavigateHandler = undefined;
+  onCurrentEntryChangeHandler = undefined;
   originalPushState = undefined;
   originalReplaceState = undefined;
-  originalNavigateEventIntercept = undefined;
 }


### PR DESCRIPTION
Summary

- Listen for Navigation API currententrychange events instead of navigate events.
- Emit URL changes from navigation.currentEntry.url after navigation commits.
- Remove the navigate intercept wrapper and update URL monitor tests.

Testing

- git diff --check
- yarn eslint packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
- yarn prettier --check packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.ts packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts
- Focused Jest run for packages/web-sdk/src/instrumentations/_internal/monitors/urlChangeMonitor.test.ts

Closes #1794