### PR TITLE
fix(session): stop a background tab from emitting an expired session id

### DIFF
--- a/e2e/smoke/src/main.tsx
+++ b/e2e/smoke/src/main.tsx
@@ -10,6 +10,17 @@ import {
 } from '@grafana/faro-react';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
+// Opt-in via ?session=persistent so the session specs don't affect other smoke specs.
+const params = new URLSearchParams(window.location.search);
+const persistentSession = params.get('session') === 'persistent';
+const sessionTracking = persistentSession ? { enabled: true, persistent: true } : undefined;
+
+// Session signals only for the persistent scenario: web vitals/tracing/React
+// would emit on their own and rotate the session mid-test (non-deterministic).
+const instrumentations = persistentSession
+  ? [...getWebInstrumentations()]
+  : [...getWebInstrumentations(), new ReactIntegration(), new TracingInstrumentation()];
+
 const faro = initializeFaro({
   url: '/collect',
   app: {
@@ -17,7 +28,8 @@ const faro = initializeFaro({
     version: '0.0.0',
     environment: 'test',
   },
-  instrumentations: [...getWebInstrumentations(), new ReactIntegration(), new TracingInstrumentation()],
+  instrumentations,
+  ...(sessionTracking ? { sessionTracking } : {}),
 });
 
 function Thrower() {

--- a/e2e/smoke/tests/session-divergence.spec.ts
+++ b/e2e/smoke/tests/session-divergence.spec.ts
@@ -101,9 +101,12 @@ test('a background tab converges to the rotated session instead of emitting the 
     expect(a1, 'Tab A rotates to a new session when the stored one is expired').not.toBe(s0);
     expect(await storageSessionId(tabB), 'shared storage now holds A1 for both tabs').toBe(a1);
 
-    // Tab B's first post-rotation send triggers adoption; its body is still
-    // stamped with the old id (see header), so assert on the next send instead.
-    await clickAndCapture(tabB, bIds, LOG_BTN);
+    // Tab B's first post-rotation send is stamped before beforeSend adopts, so it
+    // must still carry the stale S0 — proving B was genuinely stale and did NOT
+    // self-rotate (the race that previously made this test vacuous). It triggers
+    // adoption; convergence is asserted on the next send.
+    const bFirst = await clickAndCapture(tabB, bIds, LOG_BTN);
+    expect(bFirst, 'Tab B is still on the stale session (did not self-rotate)').toBe(s0);
 
     const bConverged = await clickAndCapture(tabB, bIds, MEASUREMENT_BTN);
     expect(bConverged, 'background tab converges to the shared session, not the expired one').toBe(a1);

--- a/e2e/smoke/tests/session-divergence.spec.ts
+++ b/e2e/smoke/tests/session-divergence.spec.ts
@@ -21,7 +21,7 @@ import { expect, test } from './fixtures';
 //    post-rotation emit still carries the old id; convergence is asserted on the SECOND.
 
 const URL = '/?session=persistent';
-const THROTTLE_LAPSE_MS = 1_200; // > the 1s updateSession throttle window
+const THROTTLE_LAPSE_MS = 2_500; // > the 1s updateSession throttle window
 
 const EVENT_BTN = '[data-cy="btn-push-event"]';
 const LOG_BTN = '[data-cy="btn-push-log"]';

--- a/e2e/smoke/tests/session-divergence.spec.ts
+++ b/e2e/smoke/tests/session-divergence.spec.ts
@@ -1,0 +1,113 @@
+import { type Page } from '@playwright/test';
+
+import type { TransportBody } from '@grafana/faro-core';
+
+import { expect, test } from './fixtures';
+
+// Cross-tab session convergence (regression guard).
+//
+// Persistent sessions are shared via localStorage. When one tab rotates the
+// session, a background tab must adopt the new id rather than keep emitting the
+// expired one. Asserts: after Tab A rotates, Tab B's next emit carries the rotated id.
+//
+// Non-obvious mechanics (don't "simplify" away):
+//  - ?session=persistent runs session signals only, so nothing rotates on its own.
+//  - We force expiry by ageing the stored session (not by waiting out the real
+//    lifetime cap), then let the 1s updateSession throttle lapse so the next send
+//    rotates synchronously.
+//  - Each send uses a different signal type: faro won't re-send a duplicate, and
+//    rotation/adoption only happens on an actual send (updateSession in beforeSend).
+//  - Adoption runs in beforeSend after the item is stamped, so Tab B's FIRST
+//    post-rotation emit still carries the old id; convergence is asserted on the SECOND.
+
+const URL = '/?session=persistent';
+const THROTTLE_LAPSE_MS = 1_200; // > the 1s updateSession throttle window
+
+const EVENT_BTN = '[data-cy="btn-push-event"]';
+const LOG_BTN = '[data-cy="btn-push-log"]';
+const MEASUREMENT_BTN = '[data-cy="btn-push-measurement"]';
+const STORAGE_KEY = 'com.grafana.faro.session';
+
+// Capture the session id carried by every /collect payload this page sends.
+async function collectSessionIds(page: Page): Promise<string[]> {
+  const ids: string[] = [];
+  await page.route('**/collect', async (route) => {
+    const body = route.request().postDataJSON() as TransportBody;
+    const id = body?.meta?.session?.id;
+    if (id) {
+      ids.push(id);
+    }
+    await route.fulfill({ status: 201, body: '{}' });
+  });
+  return ids;
+}
+
+// The session id persisted in shared localStorage (where a rotation lands).
+function storageSessionId(page: Page): Promise<string | null> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw).sessionId as string) : null;
+  }, STORAGE_KEY);
+}
+
+// Make the shared stored session look expired (started at epoch) so the next tab
+// to send rotates it — without waiting out the real lifetime cap.
+async function expireStoredSession(page: Page): Promise<void> {
+  await page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    if (raw) {
+      window.localStorage.setItem(key, JSON.stringify({ ...JSON.parse(raw), started: 0 }));
+    }
+  }, STORAGE_KEY);
+}
+
+// Bring the tab to the front, click a signal button, and wait until the
+// resulting /collect payload is captured (so beforeSend/updateSession has run).
+// Returns the session id that payload carried — i.e. the tab's in-memory id.
+async function clickAndCapture(page: Page, sink: string[], button: string): Promise<string> {
+  const before = sink.length;
+  await page.bringToFront();
+  await page.locator(button).click();
+  await expect.poll(() => sink.length, { timeout: 5_000 }).toBeGreaterThan(before);
+  return sink[sink.length - 1]!;
+}
+
+test('a background tab converges to the rotated session instead of emitting the expired id', async ({ browser }) => {
+  const context = await browser.newContext(); // one context => shared localStorage
+  try {
+    // --- Tab A establishes session S0 ---
+    const tabA = await context.newPage();
+    const aIds = await collectSessionIds(tabA);
+    await tabA.goto(URL);
+    await tabA.locator(EVENT_BTN).waitFor();
+    const s0 = await clickAndCapture(tabA, aIds, EVENT_BTN);
+    expect(s0, 'Tab A establishes an initial session').toBeTruthy();
+
+    // --- Tab B resumes S0 from shared storage ---
+    const tabB = await context.newPage();
+    const bIds = await collectSessionIds(tabB);
+    await tabB.goto(URL);
+    await tabB.locator(EVENT_BTN).waitFor();
+    expect(await clickAndCapture(tabB, bIds, EVENT_BTN), 'Tab B resumes S0 from shared localStorage').toBe(s0);
+
+    // --- expire the shared session, then let the updateSession throttle lapse so
+    //     the next send rotates synchronously (neither tab emits in between) ---
+    await tabA.waitForTimeout(THROTTLE_LAPSE_MS);
+    await expireStoredSession(tabA);
+
+    // --- Tab A emits first (log = a fresh signal) -> rotates to A1 in storage ---
+    await clickAndCapture(tabA, aIds, LOG_BTN);
+    const a1 = await storageSessionId(tabA);
+    expect(a1, 'Tab A rotates to a new session when the stored one is expired').not.toBe(s0);
+    expect(await storageSessionId(tabB), 'shared storage now holds A1 for both tabs').toBe(a1);
+
+    // Tab B's first post-rotation send triggers adoption; its body is still
+    // stamped with the old id (see header), so assert on the next send instead.
+    await clickAndCapture(tabB, bIds, LOG_BTN);
+
+    const bConverged = await clickAndCapture(tabB, bIds, MEASUREMENT_BTN);
+    expect(bConverged, 'background tab converges to the shared session, not the expired one').toBe(a1);
+  } finally {
+    await context.close();
+  }
+});

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.test.ts
@@ -19,6 +19,7 @@ import {
   SESSION_EXPIRATION_TIME,
   SESSION_INACTIVITY_TIME,
   STORAGE_KEY,
+  STORAGE_UPDATE_DELAY,
 } from './sessionManager';
 import * as samplingModuleMock from './sessionManager/sampling';
 import { createUserSessionObject } from './sessionManager/sessionManagerUtils';
@@ -176,6 +177,49 @@ describe('SessionInstrumentation', () => {
     expect(transport.items).toHaveLength(4);
     event = transport.items[3]! as TransportItem<EventEvent>;
     expect(event.payload.name).toEqual(EVENT_SESSION_EXTEND);
+  });
+
+  it('silently adopts a session rotated by another tab without emitting a lifecycle event.', () => {
+    const transport = new MockTransport();
+
+    // this tab starts on S0 (resumed from shared storage)
+    mockStorage[STORAGE_KEY] = JSON.stringify(createUserSessionObject({ sessionId: 'S0' }));
+
+    const { api, metas } = initializeFaro(
+      mockConfig({
+        transports: [transport],
+        instrumentations: [new SessionInstrumentation()],
+        sessionTracking: {
+          enabled: true,
+          persistent: true,
+          samplingRate: 1,
+        },
+      })
+    );
+
+    expect(transport.items).toHaveLength(1);
+    expect((transport.items[0]! as TransportItem<EventEvent>).payload.name).toEqual(EVENT_SESSION_RESUME);
+    expect(metas.value.session?.id).toEqual('S0');
+
+    // clear the updateSession throttle, then another tab rotates the shared
+    // session: a different, still-valid session lands in storage
+    jest.advanceTimersByTime(STORAGE_UPDATE_DELAY + 1);
+    mockStorage[STORAGE_KEY] = JSON.stringify({
+      ...createUserSessionObject({ sessionId: 'A1' }),
+      sessionMeta: { id: 'A1', attributes: { isSampled: 'true', previousSession: 'S0' } },
+    });
+
+    // a send triggers updateSession, which adopts A1
+    api.pushLog(['trigger']);
+
+    // this tab converged to A1...
+    expect(metas.value.session?.id).toEqual('A1');
+    // ...silently: no session_start / session_extend event was emitted
+    const lifecycleEvents = transport.items.filter((item) => {
+      const name = (item as TransportItem<EventEvent>).payload.name;
+      return name === EVENT_SESSION_START || name === EVENT_SESSION_EXTEND;
+    });
+    expect(lifecycleEvents).toHaveLength(0);
   });
 
   it('Initialize session meta with user defined id and attributes provided via the initial session property.', () => {

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -26,10 +26,19 @@ export class SessionInstrumentation extends BaseInstrumentation {
   // event twice for the same session
   private notifiedSession: MetaSession | undefined;
 
+  // Reads the session manager's adoption flag (set once the manager exists).
+  private isAdoptingSession: () => boolean = () => false;
+
   private sendSessionStartEvent(meta: Meta): void {
     const session = meta.session;
 
     if (session && session.id !== this.notifiedSession?.id) {
+      // Adopting another tab's session: track it but emit nothing (the creating tab already did).
+      if (this.isAdoptingSession()) {
+        this.notifiedSession = session;
+        return;
+      }
+
       if (this.notifiedSession && this.notifiedSession.id === session.attributes?.['previousSession']) {
         this.api.pushEvent(EVENT_SESSION_EXTEND, {}, undefined, { skipDedupe: true });
         this.notifiedSession = session;
@@ -121,7 +130,9 @@ export class SessionInstrumentation extends BaseInstrumentation {
   }
 
   private registerBeforeSendHook(SessionManager: SessionManager) {
-    const { updateSession } = new SessionManager();
+    const sessionManager = new SessionManager();
+    this.isAdoptingSession = sessionManager.isAdopting;
+    const { updateSession } = sessionManager;
 
     this.transports?.addBeforeSendHooks((item) => {
       updateSession();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -1,4 +1,5 @@
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
+import type { MetaSession } from '@grafana/faro-core';
 
 import { throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
@@ -11,10 +12,26 @@ export class PersistentSessionsManager {
   private static storageTypeLocal = webStorageType.local;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
 
+  // Set only for the synchronous span of an adopting setSession(); the session
+  // instrumentation reads isAdopting() to suppress its lifecycle event.
+  private adopting = false;
+
+  isAdopting = (): boolean => this.adopting;
+
+  private adoptSession = (sessionMeta: MetaSession): void => {
+    this.adopting = true;
+    try {
+      faro.api?.setSession(sessionMeta);
+    } finally {
+      this.adopting = false;
+    }
+  };
+
   constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: PersistentSessionsManager.fetchUserSession,
       storeUserSession: PersistentSessionsManager.storeUserSession,
+      adoptSession: this.adoptSession,
     });
 
     this.init();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -1,4 +1,5 @@
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
+import type { MetaSession } from '@grafana/faro-core';
 
 import { throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
@@ -11,10 +12,26 @@ export class VolatileSessionsManager {
   private static storageTypeSession = webStorageType.session;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
 
+  // Adoption flag — see PersistentSessionsManager. No-op in practice
+  // (sessionStorage isn't shared across tabs); kept for parity.
+  private adopting = false;
+
+  isAdopting = (): boolean => this.adopting;
+
+  private adoptSession = (sessionMeta: MetaSession): void => {
+    this.adopting = true;
+    try {
+      faro.api?.setSession(sessionMeta);
+    } finally {
+      this.adopting = false;
+    }
+  };
+
   constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: VolatileSessionsManager.fetchUserSession,
       storeUserSession: VolatileSessionsManager.storeUserSession,
+      adoptSession: this.adoptSession,
     });
 
     this.init();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -1,5 +1,4 @@
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
-import type { MetaSession } from '@grafana/faro-core';
 
 import { throttle } from '../../../utils';
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
@@ -12,26 +11,14 @@ export class VolatileSessionsManager {
   private static storageTypeSession = webStorageType.session;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
 
-  // Adoption flag — see PersistentSessionsManager. No-op in practice
-  // (sessionStorage isn't shared across tabs); kept for parity.
-  private adopting = false;
-
-  isAdopting = (): boolean => this.adopting;
-
-  private adoptSession = (sessionMeta: MetaSession): void => {
-    this.adopting = true;
-    try {
-      faro.api?.setSession(sessionMeta);
-    } finally {
-      this.adopting = false;
-    }
-  };
+  // sessionStorage is tab-local, so this manager never adopts another tab's
+  // session. Stubbed so the instrumentation can treat both managers uniformly.
+  isAdopting = (): boolean => false;
 
   constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: VolatileSessionsManager.fetchUserSession,
       storeUserSession: VolatileSessionsManager.storeUserSession,
-      adoptSession: this.adoptSession,
     });
 
     this.init();

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -398,6 +398,52 @@ describe('sessionManagerUtils', () => {
     expect(mockOnSessionChange).toHaveBeenCalledTimes(1);
   });
 
+  it('adopts a divergent valid session from storage into in-memory metas', () => {
+    const faro = initializeFaro(mockConfig({ sessionTracking: { enabled: true, persistent: true } }));
+
+    // in-memory session is S0
+    faro.api.setSession({ id: 'S0', attributes: { isSampled: 'true' } });
+
+    const adoptedMeta = { id: 'A1', attributes: { isSampled: 'true', previousSession: 'S0' } };
+    const mockAdoptSession = jest.fn();
+
+    const updateSession = getUserSessionUpdater({
+      // storage holds a different, valid session (another tab rotated it)
+      fetchUserSession: jest.fn().mockReturnValue({
+        ...createUserSessionObject({ sessionId: 'A1' }),
+        sessionMeta: adoptedMeta,
+      }),
+      storeUserSession: jest.fn(),
+      adoptSession: mockAdoptSession,
+    });
+
+    updateSession();
+
+    expect(mockAdoptSession).toHaveBeenCalledTimes(1);
+    expect(mockAdoptSession).toHaveBeenCalledWith(adoptedMeta);
+  });
+
+  it('does not adopt when the stored valid session matches the in-memory id', () => {
+    const faro = initializeFaro(mockConfig({ sessionTracking: { enabled: true, persistent: true } }));
+
+    faro.api.setSession({ id: 'A1', attributes: { isSampled: 'true' } });
+
+    const mockAdoptSession = jest.fn();
+
+    const updateSession = getUserSessionUpdater({
+      fetchUserSession: jest.fn().mockReturnValue({
+        ...createUserSessionObject({ sessionId: 'A1' }),
+        sessionMeta: { id: 'A1', attributes: { isSampled: 'true' } },
+      }),
+      storeUserSession: jest.fn(),
+      adoptSession: mockAdoptSession,
+    });
+
+    updateSession();
+
+    expect(mockAdoptSession).not.toHaveBeenCalled();
+  });
+
   it('Returns the configured session manager', () => {
     let SessionManager = getSessionManagerByConfig({ persistent: false /* default */ });
     expect(new SessionManager()).toBeInstanceOf(VolatileSessionsManager);

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -55,6 +55,9 @@ export function isUserSessionValid(session: FaroUserSession | null): boolean {
 type GetUserSessionUpdaterParams = {
   storeUserSession: (session: FaroUserSession) => void;
   fetchUserSession: () => FaroUserSession | null;
+  // Silently adopt another tab's session into in-memory metas (cross-tab sync).
+  // Optional: only the valid (non-force-extend) branch uses it.
+  adoptSession?: (sessionMeta: NonNullable<FaroUserSession['sessionMeta']>) => void;
 };
 
 type UpdateSessionParams = { forceSessionExtend: boolean };
@@ -62,6 +65,7 @@ type UpdateSessionParams = { forceSessionExtend: boolean };
 export function getUserSessionUpdater({
   fetchUserSession,
   storeUserSession,
+  adoptSession,
 }: GetUserSessionUpdaterParams): (options?: UpdateSessionParams) => void {
   return function updateSession({ forceSessionExtend } = { forceSessionExtend: false }): void {
     if (!fetchUserSession || !storeUserSession) {
@@ -79,6 +83,16 @@ export function getUserSessionUpdater({
 
     if (forceSessionExtend === false && isUserSessionValid(sessionFromStorage)) {
       storeUserSession({ ...sessionFromStorage!, lastActivity: dateNow() });
+
+      // Another tab rotated the shared session; adopt it so we stop emitting the stale id.
+      const inMemorySessionId = faro.metas.value.session?.id;
+      if (
+        adoptSession != null &&
+        sessionFromStorage!.sessionMeta != null &&
+        sessionFromStorage!.sessionId !== inMemorySessionId
+      ) {
+        adoptSession(sessionFromStorage!.sessionMeta);
+      }
     } else {
       let newSession = addSessionMetadataToNextSession(
         createUserSessionObject({ isSampled: isSampled() }),


### PR DESCRIPTION
## Problem

With persistent sessions (shared across tabs via `localStorage`), when one tab
rotates its session — e.g. when the lifetime cap is reached — other tabs that
still hold the previous session id in memory never pick up the change. They keep
emitting the **expired** id on every signal, so a background tab can stay pinned
to a dead session indefinitely.

## Fix

When a tab finds a newer valid session in shared storage, it now adopts that
session into its in-memory metas instead of only refreshing `lastActivity`, so it
stops emitting the stale id. Adoption is silent — no duplicate
`session_start`/`session_extend`, since the rotating tab already emitted it — and
is gated by an instance-scoped flag so concurrent faro instances don't share it.

## Test

Adds a Playwright smoke spec covering the cross-tab case: after one tab rotates a
shared session, a background tab converges to the rotated id rather than
continuing to emit the expired one.

_PR description authored by Claude on Domas's behalf._

🤖 Generated with [Claude Code](https://claude.com/claude-code)