### PR TITLE
chore: drop unsupported ${version} token from release-please PR header

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "prerelease": false,
-  "pull-request-header": "Faro Web SDK Release - ${version}",
+  "pull-request-header": "Faro Web SDK Release",
   "group-pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- [release-please-config.json](release-please-config.json) — drop `${version}` from `pull-request-header`. release-please only substitutes `${version}` in the `*-title-pattern` fields, not in `pull-request-header`, so it rendered verbatim in the release PR body (e.g. "Faro Web SDK Release - ${version}"). The version already shows in the PR title and changelog.

_PR description authored by Claude on Domas's behalf._

<img width="1339" height="604" alt="image" src="https://github.com/user-attachments/assets/11060882-7410-461e-846c-6cbcb20330fe" />
