### PR TITLE
chore(deps): bump undici to 6.27.0 to remediate CVE-2026-12151

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13290,9 +13290,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Bumps `undici` from 6.26.0 to 6.27.0 in the lockfile to remediate CVE-2026-12151 (HIGH, CVSS 7.5) — a WebSocket client DoS where a malicious server streams unbounded continuation frames, exhausting client memory. All 6.x releases from 6.17.0 are affected; 6.27.0 is the fixed 6.x release.

`undici` is a build-time transitive dependency (via `node-gyp`, range `^6.25.0`), so 6.27.0 stays in range. Only `yarn.lock` changed; `yarn build` passes.

Dependabot alert: https://github.com/grafana/faro-web-sdk/security/dependabot