### PR TITLE
fix(web-tracing): enforce a single tracing owner across Faro instances

### DIFF
--- a/docs/sources/developer/architecture/initialization.md
+++ b/docs/sources/developer/architecture/initialization.md
@@ -85,6 +85,22 @@ then the transports and finally the instrumentations.
 
 ## Tracing
 
+The `TracingInstrumentation` from `@grafana/faro-web-tracing` builds on OpenTelemetry, which allows
+only a single global tracer provider, propagator and context manager per browsing context. The
+fetch/XHR instrumentations also patch the global `fetch`/`XMLHttpRequest` only once.
+
+Because of these constraints, tracing has a single owner per page. The first Faro instance to
+initialize a `TracingInstrumentation` claims ownership (tracked on the global object so the claim is
+shared even across independently bundled micro-frontends). That owner registers the tracer provider
+and instruments fetch/XHR. Any later instance that adds a `TracingInstrumentation` detects the
+existing owner, logs a warning, and skips registration instead of registering a second provider
+(which OpenTelemetry would reject as a duplicate) or re-patching fetch/XHR with a different
+configuration.
+
+Consequently, all automatic spans are emitted by — and governed by the configuration of — the owning
+instance. This is independent of the `isolate` config option, because tracer-provider registration
+and fetch/XHR patching are inherently global.
+
 [initial-values]: #initial-values
 [components-api]: ./components/api.md
 [components-instrumentations]: ./components/instrumentations.md

--- a/packages/web-tracing/README.md
+++ b/packages/web-tracing/README.md
@@ -5,6 +5,21 @@ This package provides tools for integrating [OpenTelemetry][opentelemetry-js] ba
 
 See [quick start document][quick-start] for instructions how to set up and use.
 
+## Multiple Faro instances on one page (micro-frontends)
+
+OpenTelemetry allows only a single global tracer provider, propagator and context manager per
+browsing context, and the fetch/XHR instrumentations patch the global `fetch`/`XMLHttpRequest` only
+once. Because of this, when several Faro instances run on the same page (for example in a
+micro-frontend architecture), **only the first instance to initialize tracing owns it**: it registers
+the tracer provider and instruments fetch/XHR. Any Faro instance that adds a `TracingInstrumentation`
+afterwards detects the existing owner, logs a warning, and does not register a second provider or
+re-patch fetch/XHR (this also avoids OpenTelemetry "duplicate registration" errors).
+
+As a result, all spans are emitted by, and shaped by the configuration of, the owning instance. Later
+instances can still create manual spans against the shared provider via `faro.api.getOTEL()`, but do
+not emit their own automatic HTTP spans. This applies regardless of the `isolate` config option, since
+tracer-provider registration and fetch/XHR patching are inherently global.
+
 [faro-web-sdk-package]: https://github.com/grafana/faro-web-sdk/tree/main/packages/web-sdk
 [opentelemetry-js]: https://opentelemetry.io/docs/instrumentation/js/
 [quick-start]: https://github.com/grafana/faro-web-sdk/blob/main/docs/sources/tutorials/quick-start-browser.md

--- a/packages/web-tracing/src/instrumentation.test.ts
+++ b/packages/web-tracing/src/instrumentation.test.ts
@@ -1,0 +1,90 @@
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+
+import type { API, Config, InternalLogger, Metas, Transports } from '@grafana/faro-web-sdk';
+
+import { TracingInstrumentation } from './instrumentation';
+import { resetTracingOwnerForTests } from './tracingOwner';
+
+jest.mock('@opentelemetry/instrumentation', () => ({
+  ...jest.requireActual('@opentelemetry/instrumentation'),
+  registerInstrumentations: jest.fn(),
+}));
+
+function setupInstrumentation(appName: string) {
+  const api = {
+    initOTEL: jest.fn(),
+    getSession: jest.fn(() => ({})),
+    pushTraces: jest.fn(),
+    getActiveUserAction: jest.fn(),
+  } as unknown as API;
+
+  const internalLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as InternalLogger;
+
+  const instrumentation = new TracingInstrumentation();
+  Object.assign(instrumentation, {
+    api,
+    internalLogger,
+    config: { app: { name: appName } } as Config,
+    metas: { value: { browser: {} } } as unknown as Metas,
+    transports: { transports: [] } as unknown as Transports,
+  });
+
+  return { instrumentation, api, internalLogger };
+}
+
+describe('TracingInstrumentation single-owner behavior', () => {
+  let registerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    registerSpy = jest.spyOn(WebTracerProvider.prototype, 'register').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    resetTracingOwnerForTests();
+    jest.clearAllMocks();
+    registerSpy.mockRestore();
+  });
+
+  it('registers the provider and instrumentations for the first (owning) instance', () => {
+    const { instrumentation, api } = setupInstrumentation('app-a');
+
+    instrumentation.initialize();
+
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(registerInstrumentations).toHaveBeenCalledTimes(1);
+    expect(api.initOTEL).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-register for a second instance and warns instead', () => {
+    const first = setupInstrumentation('app-a');
+    first.instrumentation.initialize();
+
+    jest.clearAllMocks();
+
+    const second = setupInstrumentation('app-b');
+    second.instrumentation.initialize();
+
+    expect(registerSpy).not.toHaveBeenCalled();
+    expect(registerInstrumentations).not.toHaveBeenCalled();
+    // manual tracing must still work against the shared provider
+    expect(second.api.initOTEL).toHaveBeenCalledTimes(1);
+    expect(second.internalLogger.warn).toHaveBeenCalledTimes(1);
+    expect((second.internalLogger.warn as jest.Mock).mock.calls[0].join(' ')).toContain('app-a');
+  });
+
+  it('behaves identically for a lone instance (regression)', () => {
+    const { instrumentation, api } = setupInstrumentation('only-app');
+
+    instrumentation.initialize();
+
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(registerInstrumentations).toHaveBeenCalledTimes(1);
+    expect(api.initOTEL).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -30,6 +30,7 @@ import {
   ATTR_TELEMETRY_DISTRO_NAME,
   ATTR_TELEMETRY_DISTRO_VERSION,
 } from './semconv';
+import { claimTracingOwner, getTracingOwner } from './tracingOwner';
 import type { TracingInstrumentationOptions } from './types';
 
 // the providing of app name here is not great
@@ -47,6 +48,27 @@ export class TracingInstrumentation extends BaseInstrumentation {
   }
 
   initialize(): void {
+    // OpenTelemetry allows only a single global tracer provider and patches global fetch/XHR once
+    // per browsing context. When multiple Faro instances run on the same page (micro-frontends),
+    // only the first to initialize owns tracing; later instances would otherwise re-register the
+    // provider (throwing "duplicate registration" errors) and re-patch fetch/XHR with their own
+    // config, leaving spans attributed to the first app but shaped by the last app's config.
+    if (!claimTracingOwner(this.config.app.name)) {
+      const owner = getTracingOwner();
+      this.logWarn(
+        `Tracing is already owned by another Faro instance${
+          owner?.appName ? ` ("${owner.appName}")` : ''
+        }. This instance will not register a tracer provider or instrument fetch/XHR. ` +
+          'Only one Faro instance can own tracing per page.'
+      );
+
+      // Still expose the global OTEL trace/context so manual tracing keeps working against the
+      // shared provider owned by the first instance.
+      this.api.initOTEL(trace, context);
+
+      return;
+    }
+
     const options = this.options;
     const attributes: Attributes = {};
 

--- a/packages/web-tracing/src/tracingOwner.test.ts
+++ b/packages/web-tracing/src/tracingOwner.test.ts
@@ -1,0 +1,29 @@
+import { claimTracingOwner, getTracingOwner, isTracingOwned, resetTracingOwnerForTests } from './tracingOwner';
+
+describe('tracingOwner', () => {
+  afterEach(() => {
+    resetTracingOwnerForTests();
+  });
+
+  it('is unowned initially', () => {
+    expect(isTracingOwned()).toBe(false);
+    expect(getTracingOwner()).toBeUndefined();
+  });
+
+  it('lets the first caller claim ownership', () => {
+    expect(claimTracingOwner('app-a')).toBe(true);
+    expect(isTracingOwned()).toBe(true);
+    expect(getTracingOwner()).toEqual({ appName: 'app-a' });
+  });
+
+  it('rejects subsequent claims and keeps the first owner', () => {
+    expect(claimTracingOwner('app-a')).toBe(true);
+    expect(claimTracingOwner('app-b')).toBe(false);
+    expect(getTracingOwner()).toEqual({ appName: 'app-a' });
+  });
+
+  it('can claim without an app name', () => {
+    expect(claimTracingOwner()).toBe(true);
+    expect(getTracingOwner()).toEqual({ appName: undefined });
+  });
+});

--- a/packages/web-tracing/src/tracingOwner.ts
+++ b/packages/web-tracing/src/tracingOwner.ts
@@ -1,0 +1,59 @@
+import { globalObject } from '@grafana/faro-web-sdk';
+
+/**
+ * OpenTelemetry allows only a single global tracer provider, propagator and context manager per
+ * browsing context, and the fetch/XHR instrumentations patch the global `fetch`/`XMLHttpRequest`
+ * only once. When multiple Faro instances run on the same page (micro-frontends), they must
+ * therefore agree on a single instance that owns tracing.
+ *
+ * The owner is tracked on the global object rather than in module scope because independently
+ * bundled micro-frontends each ship their own copy of this package, so a module-level singleton
+ * would not be shared between them. They do share a single `window`.
+ */
+export const tracingOwnerKey = '_faroTracingOwner';
+
+export interface TracingOwner {
+  appName?: string;
+}
+
+type GlobalWithTracingOwner = { [tracingOwnerKey]?: TracingOwner };
+
+function getGlobal(): GlobalWithTracingOwner {
+  return globalObject as unknown as GlobalWithTracingOwner;
+}
+
+/**
+ * Attempts to claim ownership of tracing for the current browsing context. Returns `true` if the
+ * caller became the owner (no other instance had claimed it yet), or `false` if tracing is already
+ * owned by another instance.
+ */
+export function claimTracingOwner(appName?: string): boolean {
+  if (isTracingOwned()) {
+    return false;
+  }
+
+  Object.defineProperty(getGlobal(), tracingOwnerKey, {
+    // configurable so tests can reset the claim; writable:false still prevents accidental reassignment
+    configurable: true,
+    enumerable: false,
+    writable: false,
+    value: { appName },
+  });
+
+  return true;
+}
+
+export function getTracingOwner(): TracingOwner | undefined {
+  return getGlobal()[tracingOwnerKey];
+}
+
+export function isTracingOwned(): boolean {
+  return tracingOwnerKey in getGlobal();
+}
+
+/**
+ * Test-only utility to clear the claimed owner between tests.
+ */
+export function resetTracingOwnerForTests(): void {
+  delete getGlobal()[tracingOwnerKey];
+}


### PR DESCRIPTION
## Why

When multiple Faro instances run on the same page (micro-frontends), `TracingInstrumentation` behaves incorrectly for every app on the page: each request produces duplicate spans in the trace, and the resulting spans carry a mix of every instance's configuration.

OpenTelemetry allows only one global tracer provider per browsing context, and the fetch/XHR instrumentations patch the global `fetch`/`XMLHttpRequest`. Today every Faro instance runs both `provider.register()` and `registerInstrumentations()` on init, but the two have opposite outcomes:

- `provider.register()` is deduplicated by OTel — the **first** instance wins, so all spans are exported through the first app (and secondary apps never receive their own spans).
- `registerInstrumentations()` is not deduplicated — the re-patch guard (`_isFetchPatched`) is per-instance, so each instance stacks another wrapper on the global `fetch`/`XHR`. Every wrapper executes, so each request produces one CLIENT span per instance (nested), each shaped by that instance's config. The second `provider.register()` also logs OTel "duplicate registration" errors.

The result is duplicate spans in the trace, config from every instance mixed together, and secondary apps blind to their own network calls. See #1845 (and the duplicate-registration crash in #1818).

## What

Make tracing single-owner: the first Faro instance to initialize a `TracingInstrumentation` claims ownership and registers the provider + instruments fetch/XHR as before. Any later instance detects the existing owner, logs a warning, and skips registration — so there is exactly one provider, one wrapper, and one span per request, with consistent config.

- New `tracingOwner.ts` — first-to-claim owner slot stored on the global object (shared across independently bundled micro-frontends; a module-level flag would not be). Independent of the `isolate` option, since provider registration and fetch/XHR patching are inherently global.
- `instrumentation.ts` — guard at the top of `initialize()`. Non-owners still call `api.initOTEL(trace, context)` so manual spans keep working against the shared provider, then return.
- Tests for the owner helper and the single-owner behavior.
- Docs: Tracing section in the architecture doc + an MFE note in the web-tracing README.

This is the first step (single tracing owner) toward the broader cross-instance MFE tracing work; per-instance HTTP event visibility is a follow-up.

## Links

Closes #1845
Related: #1818, #568

## Checklist

- [x] Tests added
- [x] Changelog updated <!-- via conventional commit -->
- [x] Documentation updated
