### PR TITLE
feat(user-actions): add configurable initial activity timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,25 @@
 
 ## Next
 
+### Features
+
+- **user-actions:** add configurable initial activity timeouts globally, through `startUserAction`, and with
+  `data-faro-user-action-timeout` element overrides
+
+### Bug Fixes
+
+- **user-actions:** prevent declarative user actions from attaching duplicate controllers
+
 ## [2.8.2](https://github.com/grafana/faro-web-sdk/compare/v2.8.1...v2.8.2) (2026-07-01)
 
 ### Bug Fixes
 
-- **session:** attribute the rotation-triggering signal to the new session ([#2168](https://github.com/grafana/faro-web-sdk/issues/2168)) ([923d3b8](https://github.com/grafana/faro-web-sdk/commit/923d3b80cea70ebac284e805df7fdfd68975783b))
-- **session:** stop a background tab from emitting an expired session id ([#2167](https://github.com/grafana/faro-web-sdk/issues/2167)) ([eba5c2f](https://github.com/grafana/faro-web-sdk/commit/eba5c2fbc7d5341912b537ad518092489d82c68b))
+- **session:** attribute the rotation-triggering signal to the new session
+  ([#2168](https://github.com/grafana/faro-web-sdk/issues/2168))
+  ([923d3b8](https://github.com/grafana/faro-web-sdk/commit/923d3b80cea70ebac284e805df7fdfd68975783b))
+- **session:** stop a background tab from emitting an expired session id
+  ([#2167](https://github.com/grafana/faro-web-sdk/issues/2167))
+  ([eba5c2f](https://github.com/grafana/faro-web-sdk/commit/eba5c2fbc7d5341912b537ad518092489d82c68b))
 
 ## [2.8.1](https://github.com/grafana/faro-web-sdk/compare/v2.8.0...v2.8.1) (2026-06-26)
 
@@ -19,28 +32,50 @@
 
 ### Features
 
-- **web-sdk:** add gzip request compression to FetchTransport ([#2028](https://github.com/grafana/faro-web-sdk/issues/2028)) ([acf7e29](https://github.com/grafana/faro-web-sdk/commit/acf7e29121cf6f04d0719ad7eebd610909457c1a))
+- **web-sdk:** add gzip request compression to FetchTransport
+  ([#2028](https://github.com/grafana/faro-web-sdk/issues/2028))
+  ([acf7e29](https://github.com/grafana/faro-web-sdk/commit/acf7e29121cf6f04d0719ad7eebd610909457c1a))
 
 ### Bug Fixes
 
-- **ci:** align Renovate npm cooldown with yarn 7-day age gate ([#2133](https://github.com/grafana/faro-web-sdk/issues/2133)) ([62be84c](https://github.com/grafana/faro-web-sdk/commit/62be84cb0acad9ac7e2b46741d4a3df4176c5b80))
-- **ci:** sign release-please lockfile-refresh commit via GitHub API ([#2150](https://github.com/grafana/faro-web-sdk/issues/2150)) ([d662d78](https://github.com/grafana/faro-web-sdk/commit/d662d78fdc815ddd246fffe2000579408ad123b2))
+- **ci:** align Renovate npm cooldown with yarn 7-day age gate
+  ([#2133](https://github.com/grafana/faro-web-sdk/issues/2133))
+  ([62be84c](https://github.com/grafana/faro-web-sdk/commit/62be84cb0acad9ac7e2b46741d4a3df4176c5b80))
+- **ci:** sign release-please lockfile-refresh commit via GitHub API
+  ([#2150](https://github.com/grafana/faro-web-sdk/issues/2150))
+  ([d662d78](https://github.com/grafana/faro-web-sdk/commit/d662d78fdc815ddd246fffe2000579408ad123b2))
 - **core:** allow BatchExecutor to run in worker scopes ([#2122](https://github.com/grafana/faro-web-sdk/issues/2122)) ([07d5282](https://github.com/grafana/faro-web-sdk/commit/07d5282962df56f1a194be120891720591704e1d))
 - **deps:** update npm-dependencies past 7-day cooldown ([#2138](https://github.com/grafana/faro-web-sdk/issues/2138)) ([f8ef28e](https://github.com/grafana/faro-web-sdk/commit/f8ef28e8e130b0c1a663ea5f49a0345ae4453999))
-- **security/high/e2e/smoke:** update security e2e/smoke vite to v8.0.16 [security] ([#2129](https://github.com/grafana/faro-web-sdk/issues/2129)) ([f52baee](https://github.com/grafana/faro-web-sdk/commit/f52baeeb407126b4cc3f732e863c7da04ec86c8d))
-- **security/medium/:** update security tar to v7.5.16 [security] ([#2130](https://github.com/grafana/faro-web-sdk/issues/2130)) ([cec1026](https://github.com/grafana/faro-web-sdk/commit/cec1026a1e64151f13a7814c214a2cb51f455e19))
-- **web-sdk:** report service worker time as 0 when no service worker is used ([#2149](https://github.com/grafana/faro-web-sdk/issues/2149)) ([13ab0a4](https://github.com/grafana/faro-web-sdk/commit/13ab0a4cf95f4d325c3c352bd7bddb3c3fc4324d))
-- **web-tracing:** update @opentelemetry/core to v2.8.0 [security] ([#2136](https://github.com/grafana/faro-web-sdk/issues/2136)) ([a73fb1f](https://github.com/grafana/faro-web-sdk/commit/a73fb1f50ac906110f6e059438c46a4c823e8b8c))
+- **security/high/e2e/smoke:** update security e2e/smoke vite to v8.0.16 [security]
+  ([#2129](https://github.com/grafana/faro-web-sdk/issues/2129))
+  ([f52baee](https://github.com/grafana/faro-web-sdk/commit/f52baeeb407126b4cc3f732e863c7da04ec86c8d))
+- **security/medium/:** update security tar to v7.5.16 [security]
+  ([#2130](https://github.com/grafana/faro-web-sdk/issues/2130))
+  ([cec1026](https://github.com/grafana/faro-web-sdk/commit/cec1026a1e64151f13a7814c214a2cb51f455e19))
+- **web-sdk:** report service worker time as 0 when no service worker is used
+  ([#2149](https://github.com/grafana/faro-web-sdk/issues/2149))
+  ([13ab0a4](https://github.com/grafana/faro-web-sdk/commit/13ab0a4cf95f4d325c3c352bd7bddb3c3fc4324d))
+- **web-tracing:** update @opentelemetry/core to v2.8.0 [security]
+  ([#2136](https://github.com/grafana/faro-web-sdk/issues/2136))
+  ([a73fb1f](https://github.com/grafana/faro-web-sdk/commit/a73fb1f50ac906110f6e059438c46a4c823e8b8c))
 
 ## [2.7.1](https://github.com/grafana/faro-web-sdk/compare/v2.7.0...v2.7.1) (2026-06-03)
 
 ### Bug Fixes
 
 - **core:** use crypto.getRandomValues in genShortID ([#2108](https://github.com/grafana/faro-web-sdk/issues/2108)) ([7f54972](https://github.com/grafana/faro-web-sdk/commit/7f549728a023b0ac22bcd5e141fad22dea0347d9))
-- **deps:** regenerate yarn.lock to drop stale semver descriptor ([#2107](https://github.com/grafana/faro-web-sdk/issues/2107)) ([9ada1a0](https://github.com/grafana/faro-web-sdk/commit/9ada1a06630b8b4aae0769f96d868453e1c57b5e))
-- **instrumentation:** incomplete regular expression for hostnames ([#2096](https://github.com/grafana/faro-web-sdk/issues/2096)) ([fc43fb5](https://github.com/grafana/faro-web-sdk/commit/fc43fb581820949d4a3eb8ce46e426d6c6582932))
-- **react:** import unknownString from declared @grafana/faro-web-sdk ([#2116](https://github.com/grafana/faro-web-sdk/issues/2116)) ([28e1efd](https://github.com/grafana/faro-web-sdk/commit/28e1efd1e3a07ec0f75e3ad28eec6f742191a000))
-- **web-sdk:** cap stack-frame line length to bound regex backtracking ([#2109](https://github.com/grafana/faro-web-sdk/issues/2109)) ([b484c31](https://github.com/grafana/faro-web-sdk/commit/b484c31ac1b6614eaea43802ef332322f9ab3716))
+- **deps:** regenerate yarn.lock to drop stale semver descriptor
+  ([#2107](https://github.com/grafana/faro-web-sdk/issues/2107))
+  ([9ada1a0](https://github.com/grafana/faro-web-sdk/commit/9ada1a06630b8b4aae0769f96d868453e1c57b5e))
+- **instrumentation:** incomplete regular expression for hostnames
+  ([#2096](https://github.com/grafana/faro-web-sdk/issues/2096))
+  ([fc43fb5](https://github.com/grafana/faro-web-sdk/commit/fc43fb581820949d4a3eb8ce46e426d6c6582932))
+- **react:** import unknownString from declared @grafana/faro-web-sdk
+  ([#2116](https://github.com/grafana/faro-web-sdk/issues/2116))
+  ([28e1efd](https://github.com/grafana/faro-web-sdk/commit/28e1efd1e3a07ec0f75e3ad28eec6f742191a000))
+- **web-sdk:** cap stack-frame line length to bound regex backtracking
+  ([#2109](https://github.com/grafana/faro-web-sdk/issues/2109))
+  ([b484c31](https://github.com/grafana/faro-web-sdk/commit/b484c31ac1b6614eaea43802ef332322f9ab3716))
 
 ## [2.7.0](https://github.com/grafana/faro-web-sdk/compare/v2.6.3...v2.7.0) (2026-05-20)
 
@@ -50,9 +85,15 @@
 
 ### Bug Fixes
 
-- **core:** fall back to window when resolving Metro bundle id ([#2079](https://github.com/grafana/faro-web-sdk/issues/2079)) ([3cfd620](https://github.com/grafana/faro-web-sdk/commit/3cfd6204b7bc83e5c440c523b6287993ccfbd728))
-- **demo:** bind Tempo OTLP receiver to 0.0.0.0 so Alloy can reach it ([#2038](https://github.com/grafana/faro-web-sdk/issues/2038)) ([7a0af53](https://github.com/grafana/faro-web-sdk/commit/7a0af536a4a7254bf62473b20d04cf937ecd246a))
-- **demo:** use `grafana server` subcommand for Grafana 13 image ([#2035](https://github.com/grafana/faro-web-sdk/issues/2035)) ([5d92107](https://github.com/grafana/faro-web-sdk/commit/5d9210769e5e0752f41a3f543089397d9fe8149a))
+- **core:** fall back to window when resolving Metro bundle id
+  ([#2079](https://github.com/grafana/faro-web-sdk/issues/2079))
+  ([3cfd620](https://github.com/grafana/faro-web-sdk/commit/3cfd6204b7bc83e5c440c523b6287993ccfbd728))
+- **demo:** bind Tempo OTLP receiver to 0.0.0.0 so Alloy can reach it
+  ([#2038](https://github.com/grafana/faro-web-sdk/issues/2038))
+  ([7a0af53](https://github.com/grafana/faro-web-sdk/commit/7a0af536a4a7254bf62473b20d04cf937ecd246a))
+- **demo:** use `grafana server` subcommand for Grafana 13 image
+  ([#2035](https://github.com/grafana/faro-web-sdk/issues/2035))
+  ([5d92107](https://github.com/grafana/faro-web-sdk/commit/5d9210769e5e0752f41a3f543089397d9fe8149a))
 - **deps:** update npm-dependencies ([#2077](https://github.com/grafana/faro-web-sdk/issues/2077)) ([8574f55](https://github.com/grafana/faro-web-sdk/commit/8574f5579b8c84a829269aa7e19e76238daa6b6e))
 - pin package manager and disable yarn/npm scripts ([#2075](https://github.com/grafana/faro-web-sdk/issues/2075)) ([ef2d248](https://github.com/grafana/faro-web-sdk/commit/ef2d248259f99e3e712bceff0f6fc99f6b0d81e1))
 
@@ -66,30 +107,48 @@
 
 ### Bug Fixes
 
-- **ci:** include ${component} in release-please PR title ([#2066](https://github.com/grafana/faro-web-sdk/issues/2066)) ([367aacc](https://github.com/grafana/faro-web-sdk/commit/367aacc76fbb4777a61da40652bbe891826e0039))
+- **ci:** include ${component} in release-please PR title
+  ([#2066](https://github.com/grafana/faro-web-sdk/issues/2066))
+  ([367aacc](https://github.com/grafana/faro-web-sdk/commit/367aacc76fbb4777a61da40652bbe891826e0039))
 
 ## [2.6.1](https://github.com/grafana/faro-web-sdk/compare/v2.6.0...v2.6.1) (2026-05-11)
 
 ### Bug Fixes
 
-- **ci:** set release-please PR title pattern with version ([#2063](https://github.com/grafana/faro-web-sdk/issues/2063)) ([4310b16](https://github.com/grafana/faro-web-sdk/commit/4310b1685b4963de539919a15edd797aa21d032b))
+- **ci:** set release-please PR title pattern with version
+  ([#2063](https://github.com/grafana/faro-web-sdk/issues/2063))
+  ([4310b16](https://github.com/grafana/faro-web-sdk/commit/4310b1685b4963de539919a15edd797aa21d032b))
 
 ## [2.6.0](https://github.com/grafana/faro-web-sdk/compare/v2.5.0...v2.6.0) (2026-05-11)
 
 ### Features
 
 - **replay:** pause recording after user inactivity ([#2015](https://github.com/grafana/faro-web-sdk/issues/2015)) ([fedbe7f](https://github.com/grafana/faro-web-sdk/commit/fedbe7ff41c592a7782737ea2200680cf8796800))
-- **web-sdk:** add `httpHost` to `faro.performance.resource` events ([#2014](https://github.com/grafana/faro-web-sdk/issues/2014)) ([517d26f](https://github.com/grafana/faro-web-sdk/commit/517d26f17f96d21990e52c5804a0b77676f685df))
+- **web-sdk:** add `httpHost` to `faro.performance.resource` events
+  ([#2014](https://github.com/grafana/faro-web-sdk/issues/2014))
+  ([517d26f](https://github.com/grafana/faro-web-sdk/commit/517d26f17f96d21990e52c5804a0b77676f685df))
 
 ### Bug Fixes
 
-- **ci:** anchor release-please at v2.5.0 commit on main ([#2061](https://github.com/grafana/faro-web-sdk/issues/2061)) ([9a99abf](https://github.com/grafana/faro-web-sdk/commit/9a99abf6c119c17652335880d0116321d0036a1e))
-- **ci:** consolidate release-please into single changelog and unblock release PR ([#2048](https://github.com/grafana/faro-web-sdk/issues/2048)) ([1454048](https://github.com/grafana/faro-web-sdk/commit/14540489ca20ff2e1797700f14e440a7ea637709))
-- **ci:** correct jsonpath syntax in release-please extra-files ([#2049](https://github.com/grafana/faro-web-sdk/issues/2049)) ([0ca2dfe](https://github.com/grafana/faro-web-sdk/commit/0ca2dfe5d833c871ed115b9ed07854ea4e4fdbfb))
-- **ci:** correct release-please changelog-path to unblock release flow ([#2045](https://github.com/grafana/faro-web-sdk/issues/2045)) ([1682dd9](https://github.com/grafana/faro-web-sdk/commit/1682dd9b959f7ac336d61fd65b91838e9166e87c))
+- **ci:** anchor release-please at v2.5.0 commit on main
+  ([#2061](https://github.com/grafana/faro-web-sdk/issues/2061))
+  ([9a99abf](https://github.com/grafana/faro-web-sdk/commit/9a99abf6c119c17652335880d0116321d0036a1e))
+- **ci:** consolidate release-please into single changelog and unblock release PR
+  ([#2048](https://github.com/grafana/faro-web-sdk/issues/2048))
+  ([1454048](https://github.com/grafana/faro-web-sdk/commit/14540489ca20ff2e1797700f14e440a7ea637709))
+- **ci:** correct jsonpath syntax in release-please extra-files
+  ([#2049](https://github.com/grafana/faro-web-sdk/issues/2049))
+  ([0ca2dfe](https://github.com/grafana/faro-web-sdk/commit/0ca2dfe5d833c871ed115b9ed07854ea4e4fdbfb))
+- **ci:** correct release-please changelog-path to unblock release flow
+  ([#2045](https://github.com/grafana/faro-web-sdk/issues/2045))
+  ([1682dd9](https://github.com/grafana/faro-web-sdk/commit/1682dd9b959f7ac336d61fd65b91838e9166e87c))
 - **ci:** exclude CHANGELOG.md from markdownlint ([#2062](https://github.com/grafana/faro-web-sdk/issues/2062)) ([844256b](https://github.com/grafana/faro-web-sdk/commit/844256be8dfaf615c254f65bacb958c4a7eebfb4))
-- **ci:** pre-format release-please PR to satisfy prettier check ([#2051](https://github.com/grafana/faro-web-sdk/issues/2051)) ([848ad90](https://github.com/grafana/faro-web-sdk/commit/848ad907e7b1dc8b866b10335b3ecce3354e99a2))
-- **ci:** two-stage yarn install in release-please cleanup step ([#2053](https://github.com/grafana/faro-web-sdk/issues/2053)) ([b87bd7c](https://github.com/grafana/faro-web-sdk/commit/b87bd7c5e50eb76555a2477b0bdecda43c6ff473))
+- **ci:** pre-format release-please PR to satisfy prettier check
+  ([#2051](https://github.com/grafana/faro-web-sdk/issues/2051))
+  ([848ad90](https://github.com/grafana/faro-web-sdk/commit/848ad907e7b1dc8b866b10335b3ecce3354e99a2))
+- **ci:** two-stage yarn install in release-please cleanup step
+  ([#2053](https://github.com/grafana/faro-web-sdk/issues/2053))
+  ([b87bd7c](https://github.com/grafana/faro-web-sdk/commit/b87bd7c5e50eb76555a2477b0bdecda43c6ff473))
 - **deps:** update npm-dependencies ([#2058](https://github.com/grafana/faro-web-sdk/issues/2058)) ([7f4f4d5](https://github.com/grafana/faro-web-sdk/commit/7f4f4d5f679671f04cdab654c194bdbb9ed42332))
 
 ## 2.5.0

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -25,6 +25,7 @@ export type { MetaAPI } from './meta';
 
 export {
   UserActionImportance,
+  type StartUserActionOptions,
   type UserActionImportanceType,
   UserActionState,
   type UserActionInterface,

--- a/packages/core/src/api/userActions/index.ts
+++ b/packages/core/src/api/userActions/index.ts
@@ -1,6 +1,7 @@
 export { UserActionImportance } from './const';
 export { type UserActionImportance as UserActionImportanceType } from './const';
 export {
+  type StartUserActionOptions,
   type UserActionsAPI,
   UserActionState,
   type UserActionInterface,

--- a/packages/core/src/api/userActions/initialize.test.ts
+++ b/packages/core/src/api/userActions/initialize.test.ts
@@ -3,7 +3,7 @@ import { mockConfig, mockInternalLogger } from '../../testUtils';
 import { mockTransports } from '../apiTestHelpers';
 
 import { userActionEventName } from './const';
-import { initializeUserActionsAPI } from './initialize';
+import { initializeUserActionsAPI, userActionsMessageBus } from './initialize';
 import { UserActionInternalInterface, UserActionsAPI } from './types';
 import UserAction from './userAction';
 
@@ -62,6 +62,21 @@ describe('initializeUserActionsAPI', () => {
     );
   });
 
+  it('publishes the per-action initial activity timeout', () => {
+    const messageSpy = jest.fn();
+    const subscription = userActionsMessageBus.subscribe(messageSpy);
+
+    api.startUserAction('first', undefined, { initialActivityTimeout: 450 });
+
+    expect(messageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialActivityTimeout: 450,
+      })
+    );
+
+    subscription.unsubscribe();
+  });
+
   it('subsequent startUserAction calls will return undefined as long as there is an action running', () => {
     api.startUserAction('A');
     const a2 = api.startUserAction('B');
@@ -84,7 +99,7 @@ describe('initializeUserActionsAPI', () => {
     const action = api.startUserAction(
       'test-action',
       { foo: 'bar' },
-      { importance: UserActionImportance.Critical, triggerName: 'foo' }
+      { importance: UserActionImportance.Critical, triggerName: 'foo', initialActivityTimeout: 450 }
     );
     (action as unknown as UserActionInternalInterface)?.end();
 
@@ -102,5 +117,6 @@ describe('initializeUserActionsAPI', () => {
       undefined,
       expect.any(Object)
     );
+    expect(mockPushEvent.mock.calls[0]?.[1]).not.toHaveProperty('initialActivityTimeout');
   });
 });

--- a/packages/core/src/api/userActions/initialize.ts
+++ b/packages/core/src/api/userActions/initialize.ts
@@ -64,6 +64,7 @@ export function initializeUserActionsAPI({
       userActionsMessageBus.notify({
         type: userActionStart,
         userAction: userAction,
+        initialActivityTimeout: options?.initialActivityTimeout,
       });
       activeUserAction = userAction;
 

--- a/packages/core/src/api/userActions/types.ts
+++ b/packages/core/src/api/userActions/types.ts
@@ -51,6 +51,8 @@ export type EndUserActionProps = {
 export type StartUserActionOptions = {
   triggerName?: string;
   importance?: UserActionImportanceType;
+  /** Time in milliseconds to wait for the first qualifying signal. Overrides the global setting for this action. */
+  initialActivityTimeout?: number;
 };
 
 export interface UserActionsAPI {
@@ -65,6 +67,7 @@ export interface UserActionsAPI {
 export type UserActionStart = {
   type: 'user_action_start';
   userAction: UserActionInterface;
+  initialActivityTimeout?: number;
 };
 
 // Union type

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -239,6 +239,12 @@ export interface Config<P = APIEvent> {
     dataAttributeName?: string;
 
     /**
+     * Time in milliseconds to wait for the first qualifying signal after a user action starts.
+     * Values above 1000 ms are clamped. Default is 100 ms.
+     */
+    initialActivityTimeout?: number;
+
+    /**
      * Predicate function to exclude items from user actions.
      * If the function returns true, the item will be excluded from user actions.
      */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   PushMeasurementOptions,
   Stacktrace,
   StacktraceParser,
+  StartUserActionOptions,
   TraceContext,
   TraceEvent,
   TracesAPI,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -137,6 +137,7 @@ export {
   ViewInstrumentation,
   WebVitalsInstrumentation,
   userActionDataAttribute,
+  userActionTimeoutDataAttribute,
 } from '@grafana/faro-web-sdk';
 
 export type {

--- a/packages/web-sdk/src/config/makeCoreConfig.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.test.ts
@@ -1,4 +1,4 @@
-import { defaultLogArgsSerializer, isFunction } from '@grafana/faro-core';
+import { defaultLogArgsSerializer, InternalLoggerLevel, isFunction } from '@grafana/faro-core';
 import type { LogArgsSerializer } from '@grafana/faro-core';
 
 import { userActionDataAttribute } from '../instrumentations/userActions';
@@ -189,6 +189,7 @@ describe('config', () => {
 
     expect(config).toBeTruthy();
     expect(config?.userActionsInstrumentation?.dataAttributeName).toBe(userActionDataAttribute);
+    expect(config?.userActionsInstrumentation?.initialActivityTimeout).toBe(100);
   });
 
   it('trackUserActions setting are added to the config as provided by the user', () => {
@@ -203,6 +204,44 @@ describe('config', () => {
 
     expect(config).toBeTruthy();
     expect(config?.userActionsInstrumentation?.dataAttributeName).toBe('data-test-action-name');
+  });
+
+  it('normalizes a camelCase user action attribute name', () => {
+    const config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      userActionsInstrumentation: { dataAttributeName: 'testActionName' },
+    });
+
+    expect(config.userActionsInstrumentation?.dataAttributeName).toBe('data-test-action-name');
+  });
+
+  it('falls back and warns for an invalid global initial activity timeout', () => {
+    const warn = jest.fn();
+    const config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      internalLoggerLevel: InternalLoggerLevel.WARN,
+      unpatchedConsole: { warn } as unknown as Console,
+      userActionsInstrumentation: { initialActivityTimeout: Number.NaN },
+    });
+
+    expect(config.userActionsInstrumentation?.initialActivityTimeout).toBe(100);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('clamps and warns for a global initial activity timeout above 1000 ms', () => {
+    const warn = jest.fn();
+    const config = makeCoreConfig({
+      url: 'http://example.com/my-collector',
+      app: {},
+      internalLoggerLevel: InternalLoggerLevel.WARN,
+      unpatchedConsole: { warn } as unknown as Console,
+      userActionsInstrumentation: { initialActivityTimeout: 1001 },
+    });
+
+    expect(config.userActionsInstrumentation?.initialActivityTimeout).toBe(1000);
+    expect(warn).toHaveBeenCalled();
   });
 
   it('experimental settings defaults are applied', () => {

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -14,7 +14,8 @@ import type { Config, Instrumentation, MetaItem, MetaSession, Transport } from '
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
 import { defaultSessionTrackingConfig } from '../instrumentations/session';
-import { userActionDataAttribute } from '../instrumentations/userActions/const';
+import { defaultInitialActivityTimeout, userActionDataAttribute } from '../instrumentations/userActions/const';
+import { normalizeDataAttributeName, normalizeInitialActivityTimeout } from '../instrumentations/userActions/util';
 import { browserMeta, osMeta, sdkMeta } from '../metas';
 import { k6Meta } from '../metas/k6';
 import { createPageMeta } from '../metas/page';
@@ -70,8 +71,15 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
 
   // Extract user actions instrumentation with defaults
   const userActionsInstrumentation = {
-    dataAttributeName: browserConfig.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute,
+    dataAttributeName: normalizeDataAttributeName(
+      browserConfig.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute
+    ),
     excludeItem: browserConfig.userActionsInstrumentation?.excludeItem,
+    initialActivityTimeout: normalizeInitialActivityTimeout(
+      browserConfig.userActionsInstrumentation?.initialActivityTimeout,
+      defaultInitialActivityTimeout,
+      (message) => internalLogger.warn(message)
+    ),
   };
 
   return {

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -179,4 +179,4 @@ export {
 
 export { getIgnoreUrls, getUrlFromResource } from './utils/url';
 
-export { userActionDataAttribute } from './instrumentations/userActions';
+export { userActionDataAttribute, userActionTimeoutDataAttribute } from './instrumentations/userActions';

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -26,7 +26,7 @@ export {
 
 export { PerformanceInstrumentation } from './performance';
 
-export { UserActionInstrumentation, userActionDataAttribute } from './userActions';
+export { UserActionInstrumentation, userActionDataAttribute, userActionTimeoutDataAttribute } from './userActions';
 
 export { CSPInstrumentation } from './csp';
 

--- a/packages/web-sdk/src/instrumentations/userActions/const.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/const.ts
@@ -1,6 +1,6 @@
 export const userActionDataAttributeParsed = 'faroUserActionName';
 export const userActionDataAttribute = 'data-faro-user-action-name';
-export const userActionTimeoutDataAttribute = 'data-faro-user-action-timeout';
+export const userActionTimeoutDataAttribute = userActionDataAttribute.replace(/-name$/, '-timeout');
 export const defaultInitialActivityTimeout = 100;
 export const maxInitialActivityTimeout = 1000;
 

--- a/packages/web-sdk/src/instrumentations/userActions/const.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/const.ts
@@ -1,5 +1,8 @@
 export const userActionDataAttributeParsed = 'faroUserActionName';
 export const userActionDataAttribute = 'data-faro-user-action-name';
+export const userActionTimeoutDataAttribute = 'data-faro-user-action-timeout';
+export const defaultInitialActivityTimeout = 100;
+export const maxInitialActivityTimeout = 1000;
 
 export {
   MESSAGE_TYPE_DOM_MUTATION,

--- a/packages/web-sdk/src/instrumentations/userActions/index.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/index.ts
@@ -13,4 +13,4 @@ export {
   MESSAGE_TYPE_HTTP_REQUEST_START,
 } from '../_internal/monitors/const';
 
-export { userActionDataAttribute } from './const';
+export { userActionDataAttribute, userActionTimeoutDataAttribute } from './const';

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
@@ -98,6 +98,33 @@ describe('UserActionInstrumentation output', () => {
     addEventListenerSpy.mockRestore();
   });
 
+  it('removes browser triggers without AbortController support', () => {
+    const faro = initializeFaro(
+      mockConfig({ userActionsInstrumentation: { dataAttributeName: 'data-faro-user-action-name' } })
+    );
+    const startUserActionSpy = jest.spyOn(faro.api, 'startUserAction');
+    const abortControllerDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'AbortController')!;
+    Object.defineProperty(globalThis, 'AbortController', { ...abortControllerDescriptor, value: undefined });
+    const element = document.createElement('button');
+    element.setAttribute('data-faro-user-action-name', 'ua-declarative');
+    document.body.appendChild(element);
+
+    try {
+      inst = new UserActionInstrumentation();
+      inst.initialize();
+      element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+      expect(startUserActionSpy).toHaveBeenCalledTimes(1);
+
+      inst.destroy();
+      element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+      expect(startUserActionSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis, 'AbortController', abortControllerDescriptor);
+      startUserActionSpy.mockRestore();
+      element.remove();
+    }
+  });
+
   it('calls end() when activity is observed via DOM mutations', () => {
     const faro = initializeFaro(mockConfig());
 

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
@@ -1,4 +1,10 @@
-import { initializeFaro, Observable, UserActionInternalInterface } from '@grafana/faro-core';
+import {
+  initializeFaro,
+  InternalLoggerLevel,
+  Observable,
+  type UnpatchedConsole,
+  UserActionInternalInterface,
+} from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import { MESSAGE_TYPE_DOM_MUTATION, MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './const';
@@ -52,6 +58,30 @@ describe('UserActionInstrumentation output', () => {
     jest.advanceTimersByTime(200);
 
     expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  it('logs when no user action event is sent because no initial activity is observed', () => {
+    const debug = jest.fn();
+    const faro = initializeFaro(
+      mockConfig({
+        internalLoggerLevel: InternalLoggerLevel.VERBOSE,
+        unpatchedConsole: { debug } as unknown as UnpatchedConsole,
+      })
+    );
+
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    faro.api.startUserAction('ua-no-activity');
+    debug.mockClear();
+
+    jest.advanceTimersByTime(100);
+
+    expect(debug).toHaveBeenCalledWith(
+      'Faro\n',
+      'User action not sent; no DOM, resource, or HTTP activity:',
+      'ua-no-activity'
+    );
   });
 
   it('registers only the pointerdown and keydown browser triggers', () => {

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.test.ts
@@ -2,6 +2,9 @@ import { initializeFaro, Observable, UserActionInternalInterface } from '@grafan
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import { MESSAGE_TYPE_DOM_MUTATION, MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './const';
+import { UserActionInstrumentation } from './instrumentation';
+import { getUserEventHandler } from './processUserActionEventHandler';
+import { UserActionController } from './userActionController';
 
 let http$: Observable<any>;
 let dom$: Observable<any>;
@@ -22,6 +25,8 @@ jest.mock('../_internal/monitors/performanceEntriesMonitor', () => ({
 }));
 
 describe('UserActionInstrumentation output', () => {
+  let inst: UserActionInstrumentation;
+
   beforeEach(() => {
     http$ = new Observable();
     dom$ = new Observable();
@@ -30,6 +35,7 @@ describe('UserActionInstrumentation output', () => {
   });
 
   afterEach(() => {
+    inst?.destroy();
     jest.runOnlyPendingTimers();
     jest.clearAllTimers();
   });
@@ -37,8 +43,7 @@ describe('UserActionInstrumentation output', () => {
   it('calls cancel() when no activity is observed', () => {
     const faro = initializeFaro(mockConfig());
 
-    const { UserActionInstrumentation } = require('./instrumentation');
-    const inst = new UserActionInstrumentation();
+    inst = new UserActionInstrumentation();
     inst.initialize();
 
     const ua = faro.api.startUserAction('ua-dom');
@@ -49,11 +54,24 @@ describe('UserActionInstrumentation output', () => {
     expect(cancelSpy).toHaveBeenCalled();
   });
 
+  it('registers only the pointerdown and keydown browser triggers', () => {
+    initializeFaro(mockConfig());
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    const registeredEvents = addEventListenerSpy.mock.calls.map(([eventName]) => eventName);
+    expect(registeredEvents).toEqual(['pointerdown', 'keydown']);
+    expect(registeredEvents).not.toContain('click');
+    expect(registeredEvents).not.toContain('change');
+
+    addEventListenerSpy.mockRestore();
+  });
+
   it('calls end() when activity is observed via DOM mutations', () => {
     const faro = initializeFaro(mockConfig());
 
-    const { UserActionInstrumentation } = require('./instrumentation');
-    const inst = new UserActionInstrumentation();
+    inst = new UserActionInstrumentation();
     inst.initialize();
 
     const ua = faro.api.startUserAction('ua-dom');
@@ -69,8 +87,7 @@ describe('UserActionInstrumentation output', () => {
   it('calls end() when activity is observed via performance entries', () => {
     const faro = initializeFaro(mockConfig());
 
-    const { UserActionInstrumentation } = require('./instrumentation');
-    const inst = new UserActionInstrumentation();
+    inst = new UserActionInstrumentation();
     inst.initialize();
 
     const ua = faro.api.startUserAction('ua-perf');
@@ -86,8 +103,7 @@ describe('UserActionInstrumentation output', () => {
   it('calls end() when HTTP request is observed', () => {
     const faro = initializeFaro(mockConfig());
 
-    const { UserActionInstrumentation } = require('./instrumentation');
-    const inst = new UserActionInstrumentation();
+    inst = new UserActionInstrumentation();
     inst.initialize();
 
     const ua = faro.api.startUserAction('ua-http');
@@ -108,5 +124,122 @@ describe('UserActionInstrumentation output', () => {
     });
 
     expect(endSpy).toHaveBeenCalled();
+  });
+
+  it('uses an API timeout override in preference to the global timeout', () => {
+    const faro = initializeFaro(mockConfig({ userActionsInstrumentation: { initialActivityTimeout: 300 } }));
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    const ua = faro.api.startUserAction('ua-api', undefined, { initialActivityTimeout: 500 });
+    const cancelSpy = jest.spyOn(ua as unknown as UserActionInternalInterface, 'cancel');
+
+    jest.advanceTimersByTime(300);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses an element timeout override in preference to the global timeout', () => {
+    const faro = initializeFaro(
+      mockConfig({
+        userActionsInstrumentation: {
+          dataAttributeName: 'data-faro-user-action-name',
+          initialActivityTimeout: 300,
+        },
+      })
+    );
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+    const element = document.createElement('button');
+    element.setAttribute('data-faro-user-action-name', 'ua-element');
+    element.setAttribute('data-faro-user-action-timeout', '500');
+
+    getUserEventHandler(faro).processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+    const ua = faro.api.getActiveUserAction();
+    const cancelSpy = jest.spyOn(ua as unknown as UserActionInternalInterface, 'cancel');
+
+    jest.advanceTimersByTime(300);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the global timeout for a malformed element override', () => {
+    const faro = initializeFaro(
+      mockConfig({
+        userActionsInstrumentation: {
+          dataAttributeName: 'data-faro-user-action-name',
+          initialActivityTimeout: 300,
+        },
+      })
+    );
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+    const element = document.createElement('button');
+    element.setAttribute('data-faro-user-action-name', 'ua-element');
+    element.setAttribute('data-faro-user-action-timeout', 'invalid');
+
+    getUserEventHandler(faro).processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+    const ua = faro.api.getActiveUserAction();
+    const cancelSpy = jest.spyOn(ua as unknown as UserActionInternalInterface, 'cancel');
+
+    jest.advanceTimersByTime(299);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the global timeout for an invalid API override', () => {
+    const faro = initializeFaro(mockConfig({ userActionsInstrumentation: { initialActivityTimeout: 300 } }));
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    const ua = faro.api.startUserAction('ua-api', undefined, { initialActivityTimeout: Number.POSITIVE_INFINITY });
+    const cancelSpy = jest.spyOn(ua as unknown as UserActionInternalInterface, 'cancel');
+
+    jest.advanceTimersByTime(299);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps an API timeout override to 1000 ms', () => {
+    const faro = initializeFaro(mockConfig());
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    const ua = faro.api.startUserAction('ua-api', undefined, { initialActivityTimeout: 1500 });
+    const cancelSpy = jest.spyOn(ua as unknown as UserActionInternalInterface, 'cancel');
+
+    jest.advanceTimersByTime(999);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['manual', 'declarative'])('attaches exactly one controller for a %s start', (startType) => {
+    const faro = initializeFaro(
+      mockConfig({ userActionsInstrumentation: { dataAttributeName: 'data-faro-user-action-name' } })
+    );
+    const attachSpy = jest.spyOn(UserActionController.prototype, 'attach').mockImplementation(() => undefined);
+    inst = new UserActionInstrumentation();
+    inst.initialize();
+
+    if (startType === 'manual') {
+      faro.api.startUserAction('ua-manual');
+    } else {
+      const element = document.createElement('button');
+      element.setAttribute('data-faro-user-action-name', 'ua-declarative');
+      getUserEventHandler(faro).processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+    }
+
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+    attachSpy.mockRestore();
   });
 });

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
@@ -7,24 +7,21 @@ export class UserActionInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
 
   private _userActionSub?: Subscription;
-  private _abortController?: AbortController;
+  private _processUserEvent?: (event: PointerEvent | KeyboardEvent) => void;
+  private _processKeydown?: (event: KeyboardEvent) => void;
 
   initialize(): void {
     const { processUserEvent, processUserActionStarted } = getUserEventHandler(faro, (message) =>
       this.logWarn(message)
     );
-    this._abortController = new AbortController();
-    const { signal } = this._abortController;
-    window.addEventListener('pointerdown', processUserEvent, { signal });
-    window.addEventListener(
-      'keydown',
-      (ev: KeyboardEvent) => {
-        if ([' ', 'Enter'].includes(ev.key)) {
-          processUserEvent(ev);
-        }
-      },
-      { signal }
-    );
+    this._processUserEvent = processUserEvent;
+    this._processKeydown = (event: KeyboardEvent) => {
+      if ([' ', 'Enter'].includes(event.key)) {
+        processUserEvent(event);
+      }
+    };
+    window.addEventListener('pointerdown', this._processUserEvent);
+    window.addEventListener('keydown', this._processKeydown);
 
     this._userActionSub = userActionsMessageBus.subscribe(({ type, userAction, initialActivityTimeout }) => {
       if (type === 'user_action_start') {
@@ -34,7 +31,12 @@ export class UserActionInstrumentation extends BaseInstrumentation {
   }
 
   destroy() {
-    this._abortController?.abort();
+    if (this._processUserEvent) {
+      window.removeEventListener('pointerdown', this._processUserEvent);
+    }
+    if (this._processKeydown) {
+      window.removeEventListener('keydown', this._processKeydown);
+    }
     this._userActionSub?.unsubscribe();
   }
 }

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
@@ -7,24 +7,36 @@ export class UserActionInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
 
   private _userActionSub?: Subscription;
+  private _processUserEvent?: (event: PointerEvent | KeyboardEvent) => void;
+  private _processKeydown?: (event: KeyboardEvent) => void;
 
   initialize(): void {
-    const { processUserEvent, processUserActionStarted } = getUserEventHandler(faro);
-    window.addEventListener('pointerdown', processUserEvent);
-    window.addEventListener('keydown', (ev: KeyboardEvent) => {
+    const { processUserEvent, processUserActionStarted } = getUserEventHandler(faro, (message) =>
+      this.logWarn(message)
+    );
+    this._processUserEvent = processUserEvent;
+    this._processKeydown = (ev: KeyboardEvent) => {
       if ([' ', 'Enter'].includes(ev.key)) {
         processUserEvent(ev);
       }
-    });
+    };
+    window.addEventListener('pointerdown', this._processUserEvent);
+    window.addEventListener('keydown', this._processKeydown);
 
-    this._userActionSub = userActionsMessageBus.subscribe(({ type, userAction }) => {
+    this._userActionSub = userActionsMessageBus.subscribe(({ type, userAction, initialActivityTimeout }) => {
       if (type === 'user_action_start') {
-        processUserActionStarted(userAction);
+        processUserActionStarted(userAction, initialActivityTimeout);
       }
     });
   }
 
   destroy() {
+    if (this._processUserEvent) {
+      window.removeEventListener('pointerdown', this._processUserEvent);
+    }
+    if (this._processKeydown) {
+      window.removeEventListener('keydown', this._processKeydown);
+    }
     this._userActionSub?.unsubscribe();
   }
 }

--- a/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/instrumentation.ts
@@ -7,21 +7,24 @@ export class UserActionInstrumentation extends BaseInstrumentation {
   readonly version = VERSION;
 
   private _userActionSub?: Subscription;
-  private _processUserEvent?: (event: PointerEvent | KeyboardEvent) => void;
-  private _processKeydown?: (event: KeyboardEvent) => void;
+  private _abortController?: AbortController;
 
   initialize(): void {
     const { processUserEvent, processUserActionStarted } = getUserEventHandler(faro, (message) =>
       this.logWarn(message)
     );
-    this._processUserEvent = processUserEvent;
-    this._processKeydown = (ev: KeyboardEvent) => {
-      if ([' ', 'Enter'].includes(ev.key)) {
-        processUserEvent(ev);
-      }
-    };
-    window.addEventListener('pointerdown', this._processUserEvent);
-    window.addEventListener('keydown', this._processKeydown);
+    this._abortController = new AbortController();
+    const { signal } = this._abortController;
+    window.addEventListener('pointerdown', processUserEvent, { signal });
+    window.addEventListener(
+      'keydown',
+      (ev: KeyboardEvent) => {
+        if ([' ', 'Enter'].includes(ev.key)) {
+          processUserEvent(ev);
+        }
+      },
+      { signal }
+    );
 
     this._userActionSub = userActionsMessageBus.subscribe(({ type, userAction, initialActivityTimeout }) => {
       if (type === 'user_action_start') {
@@ -31,12 +34,7 @@ export class UserActionInstrumentation extends BaseInstrumentation {
   }
 
   destroy() {
-    if (this._processUserEvent) {
-      window.removeEventListener('pointerdown', this._processUserEvent);
-    }
-    if (this._processKeydown) {
-      window.removeEventListener('keydown', this._processKeydown);
-    }
+    this._abortController?.abort();
     this._userActionSub?.unsubscribe();
   }
 }

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
@@ -116,6 +116,40 @@ describe('getUserEventHandler', () => {
     expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'click' });
   });
 
+  it('passes the element initial activity timeout to the user action start message', () => {
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+    const element = document.createElement('div');
+    element.setAttribute('data-foo-bar', 'my-action');
+    element.setAttribute('data-foo-bar-timeout', '450');
+
+    processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+
+    expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'pointerdown', initialActivityTimeout: 450 });
+  });
+
+  it('derives the timeout attribute from a camelCase action attribute ending in Name', () => {
+    faro.config!.userActionsInstrumentation!.dataAttributeName = 'customActionName';
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+    const element = document.createElement('div');
+    element.setAttribute('data-custom-action-name', 'my-action');
+    element.setAttribute('data-custom-action-timeout', '350');
+
+    processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+
+    expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'pointerdown', initialActivityTimeout: 350 });
+  });
+
+  it('passes a malformed element timeout through for validation by the instrumentation', () => {
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+    const element = document.createElement('div');
+    element.setAttribute('data-foo-bar', 'my-action');
+    element.setAttribute('data-foo-bar-timeout', 'not-a-number');
+
+    processUserEvent({ type: 'pointerdown', target: element } as unknown as PointerEvent);
+
+    expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'pointerdown', initialActivityTimeout: NaN });
+  });
+
   it('does not start a new action if one already exists', () => {
     getCurrentSpy.mockReturnValue(fakeAction);
     const { processUserEvent } = getUserEventHandler(faro as Faro);

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -11,7 +11,7 @@ import {
 } from './util';
 
 export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning = noop) {
-  const { api, config } = faro;
+  const { api, config, internalLogger } = faro;
   const globalInitialActivityTimeout = normalizeInitialActivityTimeout(
     config.userActionsInstrumentation?.initialActivityTimeout,
     defaultInitialActivityTimeout,
@@ -39,7 +39,7 @@ export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning
       globalInitialActivityTimeout,
       onTimeoutWarning
     );
-    new UserActionController(internalUserAction, effectiveInitialActivityTimeout).attach();
+    new UserActionController(internalUserAction, internalLogger.debug, effectiveInitialActivityTimeout).attach();
   }
 
   return { processUserEvent, processUserActionStarted };

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -1,35 +1,59 @@
 import type { Faro, Subscription, UserActionInterface, UserActionInternalInterface } from '@grafana/faro-core';
 
-import { userActionDataAttributeParsed as userActionDataAttribute } from './const';
+import { defaultInitialActivityTimeout, userActionDataAttribute } from './const';
 import { UserActionController } from './userActionController';
-import { convertDataAttributeName } from './util';
+import {
+  convertDataAttributeName,
+  deriveUserActionTimeoutDataAttribute,
+  normalizeInitialActivityTimeout,
+  type TimeoutWarning,
+} from './util';
 
-export function getUserEventHandler(faro: Faro) {
+export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning = () => undefined) {
   const { api, config } = faro;
+  const globalInitialActivityTimeout = normalizeInitialActivityTimeout(
+    config.userActionsInstrumentation?.initialActivityTimeout,
+    defaultInitialActivityTimeout,
+    onTimeoutWarning
+  );
 
   function processUserEvent(event: PointerEvent | KeyboardEvent) {
-    const userActionName = getUserActionNameFromElement(
-      event.target as HTMLElement,
-      config.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute
-    );
+    const element = event.target as HTMLElement;
+    const dataAttributeName = config.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute;
+    const userActionName = getUserActionNameFromElement(element, dataAttributeName);
 
     // We don't have a data attribute
     if (!userActionName) {
       return;
     }
 
-    const userAction = api.startUserAction(userActionName, {}, { triggerName: event.type });
-    if (userAction) {
-      processUserActionStarted(userAction);
-    }
+    const initialActivityTimeout = getUserActionTimeoutFromElement(element, dataAttributeName);
+    api.startUserAction(
+      userActionName,
+      {},
+      {
+        triggerName: event.type,
+        ...(initialActivityTimeout === undefined ? {} : { initialActivityTimeout }),
+      }
+    );
   }
 
-  function processUserActionStarted(userAction: UserActionInterface) {
+  function processUserActionStarted(userAction: UserActionInterface, initialActivityTimeout?: number) {
     const internalUserAction = userAction as unknown as UserActionInternalInterface;
-    new UserActionController(internalUserAction).attach();
+    const effectiveInitialActivityTimeout = normalizeInitialActivityTimeout(
+      initialActivityTimeout,
+      globalInitialActivityTimeout,
+      onTimeoutWarning
+    );
+    new UserActionController(internalUserAction, effectiveInitialActivityTimeout).attach();
   }
 
   return { processUserEvent, processUserActionStarted };
+}
+
+export function getUserActionTimeoutFromElement(element: HTMLElement, dataAttributeName: string): number | undefined {
+  const value = element.getAttribute(deriveUserActionTimeoutDataAttribute(dataAttributeName));
+  return value === null ? undefined : Number(value);
 }
 
 export function getUserActionNameFromElement(element: HTMLElement, dataAttributeName: string): string | undefined {

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -1,3 +1,4 @@
+import { noop } from '@grafana/faro-core';
 import type { Faro, Subscription, UserActionInterface, UserActionInternalInterface } from '@grafana/faro-core';
 
 import { defaultInitialActivityTimeout, userActionDataAttribute } from './const';
@@ -9,7 +10,7 @@ import {
   type TimeoutWarning,
 } from './util';
 
-export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning = () => undefined) {
+export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning = noop) {
   const { api, config } = faro;
   const globalInitialActivityTimeout = normalizeInitialActivityTimeout(
     config.userActionsInstrumentation?.initialActivityTimeout,
@@ -28,14 +29,7 @@ export function getUserEventHandler(faro: Faro, onTimeoutWarning: TimeoutWarning
     }
 
     const initialActivityTimeout = getUserActionTimeoutFromElement(element, dataAttributeName);
-    api.startUserAction(
-      userActionName,
-      {},
-      {
-        triggerName: event.type,
-        ...(initialActivityTimeout === undefined ? {} : { initialActivityTimeout }),
-      }
-    );
+    api.startUserAction(userActionName, {}, { triggerName: event.type, initialActivityTimeout });
   }
 
   function processUserActionStarted(userAction: UserActionInterface, initialActivityTimeout?: number) {

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.test.ts
@@ -40,7 +40,7 @@ describe('UserActionController', () => {
   it('waits for the configured initial activity timeout before cancelling an action with no signals', () => {
     jest.useFakeTimers();
 
-    new UserActionController(fakeAction, 500).attach();
+    new UserActionController(fakeAction, jest.fn(), 500).attach();
 
     jest.advanceTimersByTime(499);
     expect(fakeAction.cancel).not.toHaveBeenCalled();
@@ -52,7 +52,7 @@ describe('UserActionController', () => {
   it('uses the fixed 100 ms inactivity window after the first signal', () => {
     jest.useFakeTimers();
 
-    new UserActionController(fakeAction, 500).attach();
+    new UserActionController(fakeAction, jest.fn(), 500).attach();
     jest.advanceTimersByTime(150);
     domObservable.notify({ type: 'dom-mutation' });
 
@@ -67,7 +67,7 @@ describe('UserActionController', () => {
   it('allows processing if there are running requests', () => {
     jest.useFakeTimers();
 
-    const controller = new UserActionController(fakeAction);
+    const controller = new UserActionController(fakeAction, jest.fn());
     controller.attach();
 
     httpObservable.notify({
@@ -105,7 +105,7 @@ describe('UserActionController', () => {
   it('does not allow processing if there are running requests but the request id is not pending', () => {
     jest.useFakeTimers();
 
-    const controller = new UserActionController(fakeAction);
+    const controller = new UserActionController(fakeAction, jest.fn());
     controller.attach();
 
     // Start a request with id 'foo'
@@ -141,7 +141,7 @@ describe('UserActionController', () => {
   it('keeps the fixed 10 second HTTP drain timeout', () => {
     jest.useFakeTimers();
 
-    new UserActionController(fakeAction, 500).attach();
+    new UserActionController(fakeAction, jest.fn(), 500).attach();
     httpObservable.notify({
       type: MESSAGE_TYPE_HTTP_REQUEST_START,
       request: { requestId: 'foo', url: '/bar', method: 'POST', apiType: 'xhr' },

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.test.ts
@@ -6,8 +6,9 @@ import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from '
 import { UserActionController } from './userActionController';
 
 let httpObservable = new Observable();
+let domObservable = new Observable();
 jest.mock('../_internal/monitors/httpRequestMonitor', () => ({ monitorHttpRequests: () => httpObservable }));
-jest.mock('../_internal/monitors/domMutationMonitor', () => ({ monitorDomMutations: () => new Observable() }));
+jest.mock('../_internal/monitors/domMutationMonitor', () => ({ monitorDomMutations: () => domObservable }));
 jest.mock('../_internal/monitors/performanceEntriesMonitor', () => ({
   monitorPerformanceEntries: () => new Observable(),
 }));
@@ -33,6 +34,34 @@ describe('UserActionController', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
     httpObservable = new Observable();
+    domObservable = new Observable();
+  });
+
+  it('waits for the configured initial activity timeout before cancelling an action with no signals', () => {
+    jest.useFakeTimers();
+
+    new UserActionController(fakeAction, 500).attach();
+
+    jest.advanceTimersByTime(499);
+    expect(fakeAction.cancel).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(fakeAction.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the fixed 100 ms inactivity window after the first signal', () => {
+    jest.useFakeTimers();
+
+    new UserActionController(fakeAction, 500).attach();
+    jest.advanceTimersByTime(150);
+    domObservable.notify({ type: 'dom-mutation' });
+
+    jest.advanceTimersByTime(99);
+    expect(fakeAction.end).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(fakeAction.end).toHaveBeenCalledTimes(1);
+    expect(fakeAction.cancel).not.toHaveBeenCalled();
   });
 
   it('allows processing if there are running requests', () => {
@@ -107,5 +136,23 @@ describe('UserActionController', () => {
     // Action should not end or cancel because the pending request hasn't finished
     expect(fakeAction.end).not.toHaveBeenCalled();
     expect(fakeAction.cancel).not.toHaveBeenCalled();
+  });
+
+  it('keeps the fixed 10 second HTTP drain timeout', () => {
+    jest.useFakeTimers();
+
+    new UserActionController(fakeAction, 500).attach();
+    httpObservable.notify({
+      type: MESSAGE_TYPE_HTTP_REQUEST_START,
+      request: { requestId: 'foo', url: '/bar', method: 'POST', apiType: 'xhr' },
+    });
+    jest.advanceTimersByTime(100);
+
+    expect(fakeAction.halt).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(9999);
+    expect(fakeAction.end).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(fakeAction.end).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
@@ -78,7 +78,7 @@ export class UserActionController {
       .first()
       .subscribe(() => this.cleanup());
 
-    this.startupTid = setTimeout(() => this.cancelAction(), this.initialActivityTimeout) as any;
+    this.startupTid = startTimeout(this.startupTid, () => this.cancelAction(), this.initialActivityTimeout) as any;
   }
 
   private scheduleFollowUp() {

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
@@ -1,6 +1,6 @@
 // packages/web-sdk/src/instrumentations/userActions/userActionController.ts
 import { Observable, UserActionState } from '@grafana/faro-core';
-import type { Subscription, UserActionInternalInterface } from '@grafana/faro-core';
+import type { InternalLogger, Subscription, UserActionInternalInterface } from '@grafana/faro-core';
 
 import { monitorDomMutations } from '../_internal/monitors/domMutationMonitor';
 import { monitorHttpRequests } from '../_internal/monitors/httpRequestMonitor';
@@ -29,6 +29,7 @@ export class UserActionController {
 
   constructor(
     private userAction: UserActionInternalInterface,
+    private logDebug: InternalLogger['debug'],
     private initialActivityTimeout = defaultInitialActivityTimeout
   ) {}
 
@@ -78,7 +79,14 @@ export class UserActionController {
       .first()
       .subscribe(() => this.cleanup());
 
-    this.startupTid = startTimeout(this.startupTid, () => this.cancelAction(), this.initialActivityTimeout) as any;
+    this.startupTid = startTimeout(
+      this.startupTid,
+      () => {
+        this.logDebug('User action not sent; no DOM, resource, or HTTP activity:', this.userAction.name);
+        this.cancelAction();
+      },
+      this.initialActivityTimeout
+    ) as any;
   }
 
   private scheduleFollowUp() {

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
@@ -86,12 +86,12 @@ export class UserActionController {
         this.cancelAction();
       },
       this.initialActivityTimeout
-    ) as any;
+    );
   }
 
   private scheduleFollowUp() {
     this.clearTimer(this.followUpTid);
-    this.followUpTid = setTimeout(() => {
+    this.followUpTid = window.setTimeout(() => {
       // If action just started and there's pending work, go to halted
       if (this.userAction.getState() === UserActionState.Started && this.runningRequests.size > 0) {
         this.haltAction();
@@ -106,7 +106,7 @@ export class UserActionController {
 
       // Otherwise, no signals => cancel
       this.cancelAction();
-    }, defaultFollowUpActionTimeRange) as any;
+    }, defaultFollowUpActionTimeRange);
   }
 
   private haltAction() {
@@ -128,7 +128,7 @@ export class UserActionController {
         }
       },
       defaultHaltTimeout
-    ) as any;
+    );
   }
 
   private endAction() {
@@ -154,7 +154,7 @@ export class UserActionController {
 
   private clearTimer(id?: number) {
     if (id !== undefined) {
-      clearTimeout(id);
+      window.clearTimeout(id);
     }
   }
 }

--- a/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/userActionController.ts
@@ -7,6 +7,7 @@ import { monitorHttpRequests } from '../_internal/monitors/httpRequestMonitor';
 import { monitorPerformanceEntries } from '../_internal/monitors/performanceEntriesMonitor';
 import type { HttpRequestMessagePayload } from '../_internal/monitors/types';
 
+import { defaultInitialActivityTimeout } from './const';
 import { isRequestEndMessage, isRequestStartMessage, startTimeout } from './util';
 
 const defaultFollowUpActionTimeRange = 100;
@@ -19,13 +20,17 @@ export class UserActionController {
 
   private allMonitorsSub?: Subscription;
   private stateSub?: Subscription;
+  private startupTid?: number;
   private followUpTid?: number;
   private haltTid?: number;
 
   private isValid = false;
   private runningRequests = new Map<string, HttpRequestMessagePayload>();
 
-  constructor(private userAction: UserActionInternalInterface) {}
+  constructor(
+    private userAction: UserActionInternalInterface,
+    private initialActivityTimeout = defaultInitialActivityTimeout
+  ) {}
 
   attach(): void {
     // Subscribe to monitors while action is active/halting
@@ -59,6 +64,7 @@ export class UserActionController {
         if (!isRequestEndMessage(msg)) {
           if (!this.isValid) {
             this.isValid = true;
+            this.clearTimer(this.startupTid);
           }
           this.scheduleFollowUp();
         } else if (this.userAction.getState() === UserActionState.Halted && this.runningRequests.size === 0) {
@@ -72,8 +78,7 @@ export class UserActionController {
       .first()
       .subscribe(() => this.cleanup());
 
-    // initial follow-up window in case nothing else happens
-    this.scheduleFollowUp();
+    this.startupTid = setTimeout(() => this.cancelAction(), this.initialActivityTimeout) as any;
   }
 
   private scheduleFollowUp() {
@@ -129,6 +134,7 @@ export class UserActionController {
   }
 
   private cleanup() {
+    this.clearTimer(this.startupTid);
     this.clearTimer(this.followUpTid);
     this.clearTimer(this.haltTid);
     this.allMonitorsSub?.unsubscribe();
@@ -139,7 +145,7 @@ export class UserActionController {
   }
 
   private clearTimer(id?: number) {
-    if (id) {
+    if (id !== undefined) {
       clearTimeout(id);
     }
   }

--- a/packages/web-sdk/src/instrumentations/userActions/util.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.test.ts
@@ -6,6 +6,7 @@ import {
   isRequestStartMessage,
   normalizeDataAttributeName,
   normalizeInitialActivityTimeout,
+  startTimeout,
 } from './util';
 
 describe('util', () => {
@@ -47,6 +48,16 @@ describe('util', () => {
 
     expect(normalizeInitialActivityTimeout(1001, 100, warn)).toBe(1000);
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears an existing timeout with an id of zero', () => {
+    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+    const timeoutId = startTimeout(0, jest.fn(), 100);
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(0);
+    clearTimeout(timeoutId);
+    clearTimeoutSpy.mockRestore();
   });
 
   it('isRequestStartMessage type guard', () => {

--- a/packages/web-sdk/src/instrumentations/userActions/util.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.test.ts
@@ -39,6 +39,13 @@ describe('util', () => {
     }
   );
 
+  it('warns and falls back when the initial activity timeout cannot be converted to a number', () => {
+    const warn = jest.fn();
+
+    expect(normalizeInitialActivityTimeout(Symbol(), 250, warn)).toBe(250);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts a valid initial activity timeout', () => {
     expect(normalizeInitialActivityTimeout(450)).toBe(450);
   });

--- a/packages/web-sdk/src/instrumentations/userActions/util.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.test.ts
@@ -1,9 +1,52 @@
 import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './const';
-import { convertDataAttributeName, isRequestEndMessage, isRequestStartMessage } from './util';
+import {
+  convertDataAttributeName,
+  deriveUserActionTimeoutDataAttribute,
+  isRequestEndMessage,
+  isRequestStartMessage,
+  normalizeDataAttributeName,
+  normalizeInitialActivityTimeout,
+} from './util';
 
 describe('util', () => {
   it('converts data attribute to camelCase and remove the "data-" prefix', () => {
     expect(convertDataAttributeName('data-test-action-name')).toBe('testActionName');
+  });
+
+  it.each([
+    ['data-test-action-name', 'data-test-action-name'],
+    ['testActionName', 'data-test-action-name'],
+  ])('normalizes the action attribute %s to HTML form', (input, expected) => {
+    expect(normalizeDataAttributeName(input)).toBe(expected);
+  });
+
+  it.each([
+    ['data-test-action-name', 'data-test-action-timeout'],
+    ['testActionName', 'data-test-action-timeout'],
+    ['data-test-action', 'data-test-action-timeout'],
+  ])('derives the timeout attribute for %s', (input, expected) => {
+    expect(deriveUserActionTimeoutDataAttribute(input)).toBe(expected);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'warns and falls back for an invalid initial activity timeout: %s',
+    (input) => {
+      const warn = jest.fn();
+
+      expect(normalizeInitialActivityTimeout(input, 250, warn)).toBe(250);
+      expect(warn).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('accepts a valid initial activity timeout', () => {
+    expect(normalizeInitialActivityTimeout(450)).toBe(450);
+  });
+
+  it('warns and clamps an initial activity timeout above the maximum', () => {
+    const warn = jest.fn();
+
+    expect(normalizeInitialActivityTimeout(1001, 100, warn)).toBe(1000);
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('isRequestStartMessage type guard', () => {

--- a/packages/web-sdk/src/instrumentations/userActions/util.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.ts
@@ -1,6 +1,52 @@
 import type { HttpRequestEndMessage, HttpRequestStartMessage } from '../_internal/monitors/types';
 
-import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from './const';
+import {
+  defaultInitialActivityTimeout,
+  maxInitialActivityTimeout,
+  MESSAGE_TYPE_HTTP_REQUEST_END,
+  MESSAGE_TYPE_HTTP_REQUEST_START,
+} from './const';
+
+export type TimeoutWarning = (message: string) => void;
+
+export function normalizeDataAttributeName(dataAttributeName: string): string {
+  const withoutPrefix = dataAttributeName.startsWith('data-') ? dataAttributeName.slice(5) : dataAttributeName;
+  const kebabCase = withoutPrefix.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+  return `data-${kebabCase}`;
+}
+
+export function deriveUserActionTimeoutDataAttribute(dataAttributeName: string): string {
+  const normalizedName = normalizeDataAttributeName(dataAttributeName);
+
+  return normalizedName.endsWith('-name')
+    ? `${normalizedName.slice(0, -'-name'.length)}-timeout`
+    : `${normalizedName}-timeout`;
+}
+
+export function normalizeInitialActivityTimeout(
+  value: unknown,
+  fallback = defaultInitialActivityTimeout,
+  warn: TimeoutWarning = () => undefined
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const timeout = typeof value === 'string' && value.trim() === '' ? Number.NaN : Number(value);
+
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    warn(`initialActivityTimeout must be a finite number greater than zero; using ${fallback} ms`);
+    return fallback;
+  }
+
+  if (timeout > maxInitialActivityTimeout) {
+    warn(`initialActivityTimeout cannot exceed ${maxInitialActivityTimeout} ms; clamping to the maximum`);
+    return maxInitialActivityTimeout;
+  }
+
+  return timeout;
+}
 
 /**
  * Parses the action attribute name by removing the 'data-' prefix and converting
@@ -10,9 +56,8 @@ import { MESSAGE_TYPE_HTTP_REQUEST_END, MESSAGE_TYPE_HTTP_REQUEST_START } from '
  * data attributes and make then camelCase.
  */
 export function convertDataAttributeName(userActionDataAttribute: string) {
-  const withoutData = userActionDataAttribute.split('data-')[1];
-  const withUpperCase = withoutData?.replace(/-(.)/g, (_, char) => char.toUpperCase());
-  return withUpperCase?.replace(/-/g, '');
+  const withoutData = normalizeDataAttributeName(userActionDataAttribute).slice(5);
+  return withoutData.replace(/-(.)/g, (_, char) => char.toUpperCase());
 }
 
 export function startTimeout(timeoutId: number | undefined, cb: () => void, delay: number) {

--- a/packages/web-sdk/src/instrumentations/userActions/util.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.ts
@@ -1,3 +1,5 @@
+import { noop } from '@grafana/faro-core';
+
 import type { HttpRequestEndMessage, HttpRequestStartMessage } from '../_internal/monitors/types';
 
 import {
@@ -27,7 +29,7 @@ export function deriveUserActionTimeoutDataAttribute(dataAttributeName: string):
 export function normalizeInitialActivityTimeout(
   value: unknown,
   fallback = defaultInitialActivityTimeout,
-  warn: TimeoutWarning = () => undefined
+  warn: TimeoutWarning = noop
 ): number {
   if (value === undefined) {
     return fallback;

--- a/packages/web-sdk/src/instrumentations/userActions/util.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.ts
@@ -35,7 +35,13 @@ export function normalizeInitialActivityTimeout(
     return fallback;
   }
 
-  const timeout = typeof value === 'string' && value.trim() === '' ? Number.NaN : Number(value);
+  let timeout = Number.NaN;
+
+  try {
+    timeout = typeof value === 'string' && value.trim() === '' ? Number.NaN : Number(value);
+  } catch {
+    // Invalid values are handled below.
+  }
 
   if (!Number.isFinite(timeout) || timeout <= 0) {
     warn(`initialActivityTimeout must be a finite number greater than zero; using ${fallback} ms`);

--- a/packages/web-sdk/src/instrumentations/userActions/util.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/util.ts
@@ -55,7 +55,7 @@ export function normalizeInitialActivityTimeout(
  * the remaining string to camelCase.
  *
  * This is needed because the browser will remove the 'data-' prefix and the dashes from
- * data attributes and make then camelCase.
+ * data attributes and make them camelCase.
  */
 export function convertDataAttributeName(userActionDataAttribute: string) {
   const withoutData = normalizeDataAttributeName(userActionDataAttribute).slice(5);
@@ -63,16 +63,13 @@ export function convertDataAttributeName(userActionDataAttribute: string) {
 }
 
 export function startTimeout(timeoutId: number | undefined, cb: () => void, delay: number) {
-  if (timeoutId) {
-    clearTimeout(timeoutId);
+  if (timeoutId !== undefined) {
+    window.clearTimeout(timeoutId);
   }
 
-  //@ts-expect-error for some reason vscode is using the node types
-  timeoutId = setTimeout(() => {
+  return window.setTimeout(() => {
     cb();
   }, delay);
-
-  return timeoutId;
 }
 
 export function isRequestStartMessage(msg: any): msg is HttpRequestStartMessage {


### PR DESCRIPTION
## Why

User actions currently cancel when their first qualifying signal arrives more than 100 ms after startup. Applications with delayed rendering or asynchronous work need a bounded way to extend only this initial grace period without changing the established rolling inactivity and HTTP drain behavior.

## What

- Add global, startUserAction API, and per-element initial activity timeout configuration.
- Apply element/API, global, then 100 ms default precedence.
- Validate invalid values and clamp values above 1,000 ms.
- Keep the rolling inactivity window fixed at 100 ms and the HTTP drain timeout fixed at 10 seconds.
- Normalize custom declarative data attribute names and derive matching timeout attributes.
- Prevent declarative starts from attaching duplicate user-action controllers.
- Export the default timeout data attribute constant.
- Add focused coverage for validation, precedence, timers, triggers, payload stability, and controller attachment.

## Links

- Documentation: https://github.com/grafana/website/pull/32348

## Checklist

- [x] Tests added
- [x] Changelog updated
- [x] Documentation updated