### PR TITLE
fix(web-sdk): initialize without throwing when there is no DOM

### DIFF
--- a/packages/web-sdk/src/config/makeCoreConfig.node.test.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.node.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+import { isFunction } from '@grafana/faro-core';
+
+import { initializeFaro } from '../initialize';
+
+import { makeCoreConfig } from './makeCoreConfig';
+
+const browserConfig = {
+  url: 'http://example.com/my-collector',
+  app: { name: 'no-dom-app' },
+};
+
+describe('makeCoreConfig in an environment without a DOM', () => {
+  it('does not throw while detecting a k6 session', () => {
+    expect(() => makeCoreConfig(browserConfig)).not.toThrow();
+  });
+
+  it('skips the web instrumentations because they depend on DOM APIs', () => {
+    const config = makeCoreConfig(browserConfig);
+
+    expect(config?.instrumentations).toEqual([]);
+  });
+
+  it('keeps instrumentations which are not provided by the web SDK', () => {
+    const customInstrumentation = {
+      name: 'custom-instrumentation',
+      version: '1.0.0',
+      initialize: () => {},
+    };
+
+    const config = makeCoreConfig({
+      ...browserConfig,
+      instrumentations: [customInstrumentation as any],
+    });
+
+    expect(config?.instrumentations).toEqual([customInstrumentation]);
+  });
+
+  it('omits the browser and page metas and keeps the DOM independent ones', () => {
+    const config = makeCoreConfig(browserConfig);
+    const metas = config?.metas.map((item) => (isFunction(item) ? item() : item));
+
+    // the os meta resolves to an empty object because there is no user agent to parse
+    expect(metas).toEqual([{}, { sdk: expect.objectContaining({ name: 'faro-web' }) }]);
+  });
+});
+
+describe('initializeFaro in an environment without a DOM', () => {
+  it('initializes without throwing and exposes a working API', () => {
+    let faro: ReturnType<typeof initializeFaro>;
+
+    expect(() => {
+      faro = initializeFaro({
+        app: browserConfig.app,
+        transports: [],
+        batching: { enabled: false },
+        isolate: true,
+      });
+    }).not.toThrow();
+
+    expect(faro!).toBeTruthy();
+    expect(() => faro.metas.value).not.toThrow();
+    expect(() => faro.api.pushEvent('an-event')).not.toThrow();
+  });
+});

--- a/packages/web-sdk/src/config/makeCoreConfig.ts
+++ b/packages/web-sdk/src/config/makeCoreConfig.ts
@@ -5,11 +5,12 @@ import {
   defaultInternalLoggerLevel,
   defaultLogArgsSerializer,
   defaultUnpatchedConsole,
+  globalObject,
   isBoolean,
   isEmpty,
   isObject,
 } from '@grafana/faro-core';
-import type { Config, Instrumentation, MetaItem, MetaSession, Transport } from '@grafana/faro-core';
+import type { Config, Instrumentation, InternalLogger, MetaItem, MetaSession, Transport } from '@grafana/faro-core';
 
 import { defaultEventDomain } from '../consts';
 import { parseStacktrace } from '../instrumentations';
@@ -20,9 +21,12 @@ import { browserMeta, osMeta, sdkMeta } from '../metas';
 import { k6Meta } from '../metas/k6';
 import { createPageMeta } from '../metas/page';
 import { FetchTransport } from '../transports';
+import { isBrowserEnvironment } from '../utils';
 
 import { getWebInstrumentations } from './getWebInstrumentations';
 import type { BrowserConfig } from './types';
+
+const webInstrumentationNamePrefix = '@grafana/faro-web-sdk:instrumentation-';
 
 export function makeCoreConfig(browserConfig: BrowserConfig): Config {
   const transports: Transport[] = [];
@@ -91,7 +95,7 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
     },
     dedupe: dedupe,
     globalObjectKey,
-    instrumentations: getFilteredInstrumentations(instrumentations, browserConfig),
+    instrumentations: getFilteredInstrumentations(instrumentations, browserConfig, internalLogger),
     internalLoggerLevel,
     isolate,
     logArgsSerializer,
@@ -126,14 +130,28 @@ export function makeCoreConfig(browserConfig: BrowserConfig): Config {
 
 function getFilteredInstrumentations(
   instrumentations: Instrumentation[],
-  { experimental }: BrowserConfig
+  { experimental }: BrowserConfig,
+  internalLogger: InternalLogger
 ): Instrumentation[] {
   const trackNavigation = experimental?.trackNavigation ?? false;
+  const isBrowser = isBrowserEnvironment();
+
+  if (!isBrowser) {
+    internalLogger.warn(
+      'no DOM detected, skipping the web instrumentations. Faro will only send signals reported via its API.'
+    );
+  }
 
   return instrumentations.filter((instr) => {
     if (instr.name === '@grafana/faro-web-sdk:instrumentation-navigation' && !trackNavigation) {
       return false;
     }
+
+    // the web instrumentations require DOM APIs which throw when they are not available
+    if (!isBrowser && instr.name.startsWith(webInstrumentationNamePrefix)) {
+      return false;
+    }
+
     return true;
   });
 }
@@ -141,15 +159,20 @@ function getFilteredInstrumentations(
 function createDefaultMetas(browserConfig: BrowserConfig): MetaItem[] {
   const { page, generatePageId } = browserConfig?.pageTracking ?? {};
 
+  // the browser and page metas read from the DOM, so they are only added where one exists
+  const isBrowser = isBrowserEnvironment();
+
   const initialMetas: MetaItem[] = [
-    browserMeta,
+    ...(isBrowser ? [browserMeta] : []),
     osMeta,
-    createPageMeta({ generatePageId, initialPageMeta: page }),
+    ...(isBrowser ? [createPageMeta({ generatePageId, initialPageMeta: page })] : []),
     ...(browserConfig.metas ?? []),
     sdkMeta,
   ];
 
-  const isK6BrowserSession = isObject((window as any)?.k6);
+  // `globalObject` instead of `window` because the latter throws a ReferenceError
+  // in environments where it is not declared at all (SSR, workers, extension tests)
+  const isK6BrowserSession = isObject((globalObject as any)?.k6);
   if (isK6BrowserSession) {
     return [...initialMetas, k6Meta];
   }

--- a/packages/web-sdk/src/metas/k6/meta.ts
+++ b/packages/web-sdk/src/metas/k6/meta.ts
@@ -1,3 +1,4 @@
+import { globalObject } from '@grafana/faro-core';
 import type { Meta, MetaItem } from '@grafana/faro-core';
 
 type K6Properties = {
@@ -5,7 +6,7 @@ type K6Properties = {
 };
 
 export const k6Meta: MetaItem<Pick<Meta, 'k6'>> = () => {
-  const k6Properties: K6Properties = (window as any).k6;
+  const k6Properties: K6Properties = (globalObject as any)?.k6;
 
   return {
     k6: {

--- a/packages/web-sdk/src/utils/browserEnvironment.ts
+++ b/packages/web-sdk/src/utils/browserEnvironment.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether the current environment provides the DOM APIs the web instrumentations
+ * and the browser related metas depend on.
+ *
+ * `window` and `document` are checked with `typeof` because a bare reference throws a
+ * `ReferenceError` in environments where they are not declared at all, for example SSR,
+ * workers or test setups without a DOM.
+ */
+export function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -8,6 +8,8 @@ export {
   webStorageType,
 } from './webStorage';
 
+export { isBrowserEnvironment } from './browserEnvironment';
+
 export { throttle } from './throttle';
 
 export { getIgnoreUrls, getUrlFromResource } from './url';


### PR DESCRIPTION
## Why

`initializeFaro` throws a `ReferenceError: window is not defined` in environments that do not declare `window` — SSR, workers, and test contexts such as the Chrome extension setup in #1643.

The issue points at the k6 session detection, and that is the first thing to crash, but it is not the only one. With just that line fixed, initialization dies next in `performanceObserverSupported`, and after that in `browserMeta`. There are 42 bare `window` references across 13 files in `web-sdk`, so guarding each access individually is not a sensible fix — the web instrumentations and the browser metas genuinely require a DOM.

## What

- `makeCoreConfig` reads the k6 properties off core's `globalObject` instead of `window`, so detection no longer throws where `window` is undeclared.
- When no DOM is present, the DOM-dependent defaults are left out rather than made defensive one call at a time:
  - the `browser` and `page` metas are skipped (`os` and `sdk` remain, `getUAResult` already guards `navigator`);
  - instrumentations named `@grafana/faro-web-sdk:instrumentation-*` are filtered out and a warning is logged once. Instrumentations supplied by the caller pass through untouched, since they may be environment-agnostic.
- New `isBrowserEnvironment()` helper in `packages/web-sdk/src/utils`. It uses `typeof window`/`typeof document` rather than reading off `globalObject` — `typeof` is safe for undeclared identifiers, and going through `globalObject` breaks any test that mocks that module.

Faro now initializes without a DOM and keeps serving everything reported through its API (`pushEvent`, `pushLog`, `pushError`, metas).

## Links

Fixes #1643

## Checklist

- [x] Tests added — `makeCoreConfig.node.test.ts`, a new suite running under `@jest-environment node` so there is a real no-DOM environment; covers k6 detection, instrumentation filtering, pass-through of caller instrumentations, meta selection, and `initializeFaro` end to end
- [ ] Changelog updated — handled by release-please
- [ ] Documentation updated — n/a

## Verification

- `yarn quality:test` green across all 7 projects.
- `yarn quality:lint:packages` green.
- Playwright smoke suite green in real Chromium (`e2e/smoke`, 8/8). This is the meaningful regression guard here: had the DOM detection been wrong in a browser, every instrumentation would have been silently dropped, and `init.spec.ts` asserts browser meta on `/collect` payloads.
- Reproduced the original crash against the built CJS output in plain node before the fix, and confirmed init, `metas.value`, and the push APIs all work after it.
