### PR TITLE
fix(core): keep config.paused in sync with pause and unpause

### DIFF
--- a/e2e/smoke/tests/pause.spec.ts
+++ b/e2e/smoke/tests/pause.spec.ts
@@ -1,0 +1,32 @@
+import type { Faro } from '@grafana/faro-core';
+
+import { expect, test } from './fixtures';
+
+declare global {
+  interface Window {
+    faro: Faro;
+  }
+}
+
+test.describe('Smoke / pause', () => {
+  test('exposes the paused state on the global faro instance', async ({ page, collector }) => {
+    await page.goto('/');
+
+    const readConfigPaused = () => page.evaluate(() => window.faro.config.paused);
+
+    expect(await readConfigPaused()).toBe(false);
+
+    await page.evaluate(() => window.faro.pause());
+    expect(await readConfigPaused()).toBe(true);
+
+    await page.evaluate(() => window.faro.unpause());
+    expect(await readConfigPaused()).toBe(false);
+
+    // ingestion resumes once unpaused
+    await page.locator('[data-cy="btn-push-log"]').click();
+
+    const log = await collector.waitForMatch((b) => b.logs?.find((l) => l.message === 'smoke harness log'));
+
+    expect(log.level).toBe('info');
+  });
+});

--- a/packages/core/src/faro.test.ts
+++ b/packages/core/src/faro.test.ts
@@ -75,4 +75,36 @@ describe('faro', () => {
     expect(items[0]?.payload.message).toEqual('test1');
     expect(items[1]?.payload.message).toEqual('test3');
   });
+
+  it('reflects the paused state in config.paused', () => {
+    const faro = initializeFaro(
+      mockConfig({
+        isolate: true,
+        transports: [new MockTransport()],
+      })
+    );
+
+    expect(faro.config.paused).toBe(false);
+
+    faro.pause();
+    expect(faro.config.paused).toBe(true);
+    expect(faro.transports.isPaused()).toBe(true);
+
+    faro.unpause();
+    expect(faro.config.paused).toBe(false);
+    expect(faro.transports.isPaused()).toBe(false);
+  });
+
+  it('starts with config.paused set when initialized paused', () => {
+    const faro = initializeFaro(
+      mockConfig({
+        isolate: true,
+        paused: true,
+        transports: [new MockTransport()],
+      })
+    );
+
+    expect(faro.config.paused).toBe(true);
+    expect(faro.transports.isPaused()).toBe(true);
+  });
 });

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -18,8 +18,8 @@ export function initializeTransports(
 
   const transports: Transport[] = [];
 
-  let paused = config.paused;
-
+  // `config.paused` is the single source of truth so that the paused state stays
+  // observable through `faro.config.paused` after `faro.pause()` / `faro.unpause()`
   let beforeSendHooks: BeforeSendHook[] = [];
 
   const add: Transports['add'] = (...newTransports) => {
@@ -112,7 +112,7 @@ export function initializeTransports(
     batchExecutor = new BatchExecutor(batchedSend, {
       sendTimeout: config.batching.sendTimeout,
       itemLimit: config.batching.itemLimit,
-      paused,
+      paused: config.paused,
     });
   }
 
@@ -124,7 +124,7 @@ export function initializeTransports(
   // 3i. If batching is enabled, enqueue the signal
   // 3ii. Send the signal instantly to all un-batched transports
   const execute: Transports['execute'] = (item) => {
-    if (paused) {
+    if (config.paused) {
       return;
     }
 
@@ -137,13 +137,13 @@ export function initializeTransports(
 
   const getBeforeSendHooks: Transports['getBeforeSendHooks'] = () => [...beforeSendHooks];
 
-  const isPaused: Transports['isPaused'] = () => paused;
+  const isPaused: Transports['isPaused'] = () => config.paused;
 
   const pause: Transports['pause'] = () => {
     internalLogger.debug('Pausing transports');
     batchExecutor?.pause();
 
-    paused = true;
+    config.paused = true;
   };
 
   const remove: Transports['remove'] = (...transportsToRemove) => {
@@ -172,7 +172,7 @@ export function initializeTransports(
     internalLogger.debug('Unpausing transports');
     batchExecutor?.start();
 
-    paused = false;
+    config.paused = false;
   };
 
   return {


### PR DESCRIPTION
## Why

`faro.pause()` and `faro.unpause()` did not update `faro.config.paused`, so anything inspecting the instance — including `window.faro.config.paused`, which is how #205 was reported — kept reading the value the SDK was initialized with. Ingestion did stop correctly; only the observable state was stale.

`initializeTransports` tracked the paused state in a local `let paused`, a second copy of `config.paused` that nothing ever wrote back.

## What

Use `config.paused` as the single source of truth in `initializeTransports` and drop the local mirror. `config` is the same object reference that `registerFaro` exposes as `faro.config`, so `faro.config.paused`, `faro.transports.isPaused()`, and the global instance now agree.

No behavioural change to ingestion — `execute` reads the same flag it always did, just from one place.

## Links

Fixes #205

## Checklist

- [x] Tests added — unit tests in `packages/core/src/faro.test.ts` covering both transitions and the initialized-paused case, plus a Playwright spec asserting the reported symptom in a real browser
- [ ] Changelog updated — handled by release-please
- [ ] Documentation updated — n/a

## Verification

- `yarn quality:test` green across all 7 projects; `yarn quality:lint:packages` green.
- Playwright smoke suite green in real Chromium, 9/9 including the new `pause.spec.ts`.
- The new e2e spec was checked to be non-vacuous: reverting `transports/initialize.ts` to `main` and rebuilding makes it fail on `Expected: true, Received: false`, and it passes with the fix in place.
