### PR TITLE
fix(web-sdk): stop stack parsing from stalling on large error payloads

### DIFF
--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/const.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/const.ts
@@ -10,8 +10,15 @@ export const webkitEvalString = 'eval';
 export const webkitAddressAtString = 'address at ';
 export const webkitAddressAtStringLength = webkitAddressAtString.length;
 
+// The leading lookahead is a fast reject, not a matching rule. The filename group can only
+// match something containing "/" (the ":/" and "/path" branches), the literal "[native code]",
+// or a path ending in "bundle" or "<digits>.js" — so a line holding none of those substrings
+// can never match. Without the lookahead the lazy `(.*?)` still tries every split point first
+// and each attempt rescans the rest of the line, which is quadratic in the line length: a
+// single 1KB line of hex from a wallet/RPC error message blocked the main thread for ~500ms.
+// See https://github.com/grafana/faro-web-sdk/issues/844.
 export const firefoxLineRegex =
-  /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|safari-extension|safari-web-extension|capacitor)?:\/.*?|\[native code]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i;
+  /^(?=[\s\S]*?(?:\/|bundle|\.js|\[native code]))\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|safari-extension|safari-web-extension|capacitor)?:\/.*?|\[native code]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i;
 export const firefoxEvalRegex = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i;
 export const firefoxEvalString = ' > eval';
 

--- a/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
+++ b/packages/web-sdk/src/instrumentations/errors/stackFrames/getStackFramesFromError.test.ts
@@ -215,6 +215,40 @@ describe('getStackFramesFromError', () => {
 
     expect(result).toEqual([buildStackFrame(`http://localhost:8080/${filler}.js`, 'boundaryFrame', 41, 27)]);
   });
+
+  // Wallet and RPC libraries put large hex payloads into error messages, and those lines used to
+  // cost hundreds of milliseconds each in the Firefox line regex. See issue #844.
+  describe('error messages carrying large non-frame payloads', () => {
+    const hexPayloadError = (payloadLength: number) => ({
+      message: 'User rejected the request.',
+      name: 'TransactionExecutionError',
+      stack:
+        'TransactionExecutionError: User rejected the request.\n' +
+        '  from:   0xB770B86b1544eDf51BBf82Dd01e8e867607Dba51\n' +
+        `  data:   0x${'0'.repeat(payloadLength)}\n` +
+        '  gas:    467935\n' +
+        '    at sendTransaction (http://localhost:5173/deps/chunk.js:1750:11)',
+    });
+
+    it('does not report the payload lines as stack frames', () => {
+      const result = getStackFramesFromError(hexPayloadError(600) as any);
+
+      expect(result).toEqual([buildStackFrame('http://localhost:5173/deps/chunk.js', 'sendTransaction', 1750, 11)]);
+    });
+
+    it('parses without blocking on the payload lines', () => {
+      // The payload sits just under the max line length so it is parsed rather than skipped.
+      const error = hexPayloadError(1000) as any;
+
+      const start = performance.now();
+      getStackFramesFromError(error);
+      const elapsed = performance.now() - start;
+
+      // Before the fast reject in firefoxLineRegex this single line took ~500ms. The budget is
+      // deliberately loose so the test asserts "not pathological" rather than a wall-clock target.
+      expect(elapsed).toBeLessThan(100);
+    });
+  });
 });
 
 /* Taken from: https://github.com/stacktracejs/error-stack-parser/blob/master/spec/fixtures/captured-errors.js */


### PR DESCRIPTION
## Why

Pages intermittently froze for seconds after an error was captured (#844). The reporter's Chrome profile showed a single long-running block, and later supplied [a reproducing error string](https://gist.github.com/elee1766/ed79c091c510ab1d4373227534432d27) — a `viem`/MetaMask `TransactionExecutionError` whose message embeds a 3.8KB hex `data:` blob.

The cost is in `firefoxLineRegex`, not `webkitLineRegex` as the issue title suggests. Its leading lazy `(.*?)` tries every split point in the line, and several branches of the filename group rescan the remainder on each attempt, so runtime grows quadratically with line length. Measured on this machine, per single line:

| line | before | after |
|---|---|---|
| the reported 3860-char line | 4049 ms | 0.007 ms |
| 1KB hex blob (just under `MAX_STACK_LINE_LENGTH`) | 505 ms | 0.003 ms |

`MAX_STACK_LINE_LENGTH` (added after this issue was filed) skips the reporter's 3.8KB line, but it does not make things safe: a line at the 1024 cap still cost ~500 ms, and a stack with several such lines still freezes the page for seconds.

## What

Add a leading lookahead to `firefoxLineRegex` that rejects lines which cannot possibly match, before the ambiguous part of the pattern runs.

This is a **necessary condition of the existing pattern**, not a new matching rule. The filename group has four branches, and each requires one of a small set of substrings: `:/` and `/path` require `/`, one branch is the literal `[native code]`, and one requires `bundle` or `<digits>.js`. A line containing none of those can never match, so rejecting it early cannot change any result — it just replaces a quadratic exploration with one linear scan.

## Scope — what this does not fix

The pattern is still quadratic for lines that *do* contain one of those substrings; an adversarial 1KB line containing a `/` still costs ~170 ms. Making it linear requires atomic matching, and I verified that an atomic-group emulation (lookahead + backreference) **changes results** — it produced different groups on 540 of 20k fuzzed lines — so it is not a safe drop-in. A genuinely linear parser means restructuring the line parse rather than patching the regex, which is worth a follow-up issue. This PR fixes the reported real-world class (large non-path payloads) decisively and leaves the pattern no worse anywhere.

## Links

Fixes #844

## Checklist

- [x] Tests added — a correctness test (payload lines are not reported as frames) and a regression test asserting the parse is not pathological. The latter was verified non-vacuous: it reports 501 ms against `main` and passes with the fix.
- [ ] Changelog updated — handled by release-please
- [ ] Documentation updated — n/a

## Verification

- Equivalence: differential harness comparing every capture group of the old and new patterns over the 90 stack lines in the captured-exception corpus and **420,000 fuzzed lines** (biased toward `/ @ : . ( ) [ ]`, `bundle`, `.js`, `[native code]`, scheme prefixes, and case variants) — **0 mismatches**.
- `yarn quality:test` green across all 7 projects; `yarn quality:lint:packages` green.
- The 19 pre-existing Chrome/Firefox/Safari/IE/Edge/Opera parser tests are unchanged and still pass.
