### PR TITLE
fix(web-tracing): stop injecting traceparent while Faro is paused

### DIFF
--- a/e2e/smoke/src/main.tsx
+++ b/e2e/smoke/src/main.tsx
@@ -70,6 +70,9 @@ function App() {
       <button data-cy="btn-push-error" onClick={() => faro.api.pushError(new Error('smoke harness pushError'))}>
         Push error via API
       </button>
+      <button data-cy="btn-traced-fetch" onClick={() => void fetch('/api/ping').catch(() => undefined)}>
+        Traced fetch
+      </button>
       <button
         data-cy="btn-emit-span"
         onClick={() => {

--- a/e2e/smoke/tests/tracing-pause.spec.ts
+++ b/e2e/smoke/tests/tracing-pause.spec.ts
@@ -1,0 +1,39 @@
+import type { Faro } from '@grafana/faro-core';
+
+import { expect, test } from './fixtures';
+
+declare global {
+  interface Window {
+    faro: Faro;
+  }
+}
+
+test.describe('Smoke / tracing while paused', () => {
+  test('stops adding traceparent to requests while paused', async ({ page }) => {
+    const traceparents: Array<string | undefined> = [];
+
+    await page.route('**/api/ping', async (route) => {
+      traceparents.push(route.request().headers()['traceparent']);
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+
+    await page.goto('/');
+
+    const fetchOnce = async () => {
+      const request = page.waitForRequest('**/api/ping');
+      await page.locator('[data-cy="btn-traced-fetch"]').click();
+      await request;
+    };
+
+    await fetchOnce();
+    expect(traceparents[0]).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+
+    await page.evaluate(() => window.faro.pause());
+    await fetchOnce();
+    expect(traceparents[1]).toBeUndefined();
+
+    await page.evaluate(() => window.faro.unpause());
+    await fetchOnce();
+    expect(traceparents[2]).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+  });
+});

--- a/packages/web-tracing/src/faroPausablePropagator.test.ts
+++ b/packages/web-tracing/src/faroPausablePropagator.test.ts
@@ -1,0 +1,89 @@
+import { ROOT_CONTEXT, trace, TraceFlags } from '@opentelemetry/api';
+import type { TextMapPropagator } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+
+import { FaroPausablePropagator } from './faroPausablePropagator';
+
+describe('FaroPausablePropagator', () => {
+  let paused: boolean;
+  let delegate: jest.Mocked<TextMapPropagator>;
+  let propagator: FaroPausablePropagator;
+
+  beforeEach(() => {
+    paused = false;
+    delegate = {
+      inject: jest.fn(),
+      extract: jest.fn((context, _carrier, _getter) => context),
+      fields: jest.fn(() => ['traceparent', 'tracestate']),
+    };
+    propagator = new FaroPausablePropagator(delegate, () => paused);
+  });
+
+  it('injects while not paused', () => {
+    const carrier = {};
+    const setter = { set: jest.fn() };
+
+    propagator.inject(ROOT_CONTEXT, carrier, setter);
+
+    expect(delegate.inject).toHaveBeenCalledWith(ROOT_CONTEXT, carrier, setter);
+  });
+
+  it('does not inject while paused', () => {
+    paused = true;
+
+    propagator.inject(ROOT_CONTEXT, {}, { set: jest.fn() });
+
+    expect(delegate.inject).not.toHaveBeenCalled();
+  });
+
+  it('reads the paused state per call rather than at construction time', () => {
+    const setter = { set: jest.fn() };
+
+    propagator.inject(ROOT_CONTEXT, {}, setter);
+    paused = true;
+    propagator.inject(ROOT_CONTEXT, {}, setter);
+    paused = false;
+    propagator.inject(ROOT_CONTEXT, {}, setter);
+
+    expect(delegate.inject).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps extracting while paused so a resumed session stays on the same trace', () => {
+    paused = true;
+    const carrier = {};
+    const getter = { get: jest.fn(), keys: jest.fn(() => []) };
+
+    propagator.extract(ROOT_CONTEXT, carrier, getter);
+
+    expect(delegate.extract).toHaveBeenCalledWith(ROOT_CONTEXT, carrier, getter);
+  });
+
+  it('delegates fields', () => {
+    expect(propagator.fields()).toEqual(['traceparent', 'tracestate']);
+  });
+
+  it('omits the traceparent header from a real carrier while paused', () => {
+    const w3c = new FaroPausablePropagator(new W3CTraceContextPropagator(), () => paused);
+    const setter = {
+      set: (carrier: Record<string, string>, key: string, value: string) => {
+        carrier[key] = value;
+      },
+    };
+    const contextWithSpan = trace.setSpanContext(ROOT_CONTEXT, {
+      traceId: '0af7651916cd43dd8448eb211c80319c',
+      spanId: 'b7ad6b7169203331',
+      traceFlags: TraceFlags.SAMPLED,
+    });
+
+    const activeCarrier: Record<string, string> = {};
+    w3c.inject(contextWithSpan, activeCarrier, setter);
+
+    expect(activeCarrier['traceparent']).toBe('00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01');
+
+    paused = true;
+    const pausedCarrier: Record<string, string> = {};
+    w3c.inject(contextWithSpan, pausedCarrier, setter);
+
+    expect(pausedCarrier).toEqual({});
+  });
+});

--- a/packages/web-tracing/src/faroPausablePropagator.ts
+++ b/packages/web-tracing/src/faroPausablePropagator.ts
@@ -1,0 +1,33 @@
+import type { Context, TextMapGetter, TextMapPropagator, TextMapSetter } from '@opentelemetry/api';
+
+/**
+ * Wraps a propagator so that no trace context is written onto outgoing requests while Faro is
+ * paused. Pausing already stops signals from being sent, but the OTel propagator is registered
+ * globally and kept injecting `traceparent`, which made a paused SDK look like it was still
+ * tracking. See https://github.com/grafana/faro-web-sdk/issues/710.
+ *
+ * Extraction stays enabled while paused: reading an incoming trace context sends nothing, and
+ * dropping it would detach a resumed session from the trace it belongs to.
+ */
+export class FaroPausablePropagator implements TextMapPropagator {
+  constructor(
+    private readonly propagator: TextMapPropagator,
+    private readonly isPaused: () => boolean
+  ) {}
+
+  inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
+    if (this.isPaused()) {
+      return;
+    }
+
+    this.propagator.inject(context, carrier, setter);
+  }
+
+  extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+    return this.propagator.extract(context, carrier, getter);
+  }
+
+  fields(): string[] {
+    return this.propagator.fields();
+  }
+}

--- a/packages/web-tracing/src/index.ts
+++ b/packages/web-tracing/src/index.ts
@@ -12,4 +12,6 @@ export { setSpanStatusOnFetchError, fetchCustomAttributeFunctionWithDefaults } f
 
 export { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
 
+export { FaroPausablePropagator } from './faroPausablePropagator';
+
 export { FaroUserActionSpanProcessor } from './faroUserActionSpanProcessor';

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -15,6 +15,7 @@ import { BaseInstrumentation, isArray, VERSION } from '@grafana/faro-web-sdk';
 import type { Transport } from '@grafana/faro-web-sdk';
 
 import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
+import { FaroPausablePropagator } from './faroPausablePropagator';
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
 import { getSamplingDecision } from './sampler';
@@ -126,7 +127,10 @@ export class TracingInstrumentation extends BaseInstrumentation {
     });
 
     provider.register({
-      propagator: options.propagator ?? new W3CTraceContextPropagator(),
+      // wrapped so that pausing Faro also stops trace context from being injected into requests
+      propagator: new FaroPausablePropagator(options.propagator ?? new W3CTraceContextPropagator(), () =>
+        this.transports.isPaused()
+      ),
       contextManager: options.contextManager,
     });
 


### PR DESCRIPTION
## Why

`faro.pause()` stops signals from being sent, but the OTel propagator is registered globally and kept injecting `traceparent` into every outgoing request (#710). A paused SDK therefore still looked like it was tracking.

That matters beyond tidiness — the reporter pauses Faro specifically for customers who do not want tracking enabled, and a `traceparent` header on their requests makes it look like tracking continued.

Note that turning off sampling would not fix this: a non-recording span still has a valid span context, so the W3C propagator writes a `traceparent` with the sampled flag cleared. The header has to be suppressed at the propagator.

## What

Wrap the propagator in `FaroPausablePropagator`, which skips `inject` while `transports.isPaused()` and otherwise delegates.

- A caller-supplied `options.propagator` is wrapped too, so pausing behaves the same with a custom propagator.
- The paused state is read per call, not captured at construction, so pause/unpause take effect immediately.
- `extract` stays enabled while paused: reading an incoming trace context sends nothing, and dropping it would detach a resumed session from the trace it belongs to.
- `fields()` delegates, so CORS header allowlisting is unaffected.

`FaroPausablePropagator` is exported, matching how the other Faro span processors and exporters in this package are exposed.

## Links

Fixes #710

## Checklist

- [x] Tests added — unit tests for the wrapper (including a real `W3CTraceContextPropagator` with a live span context, asserting the exact `traceparent` is written when active and nothing at all when paused), plus a Playwright spec asserting the reported symptom in a real browser
- [ ] Changelog updated — handled by release-please
- [ ] Documentation updated — n/a

## Verification

- New `e2e/smoke/tests/tracing-pause.spec.ts` drives a real fetch in Chromium and inspects the outgoing request headers: `traceparent` present, `pause()`, header absent, `unpause()`, header present again. It needed a `Traced fetch` button in the harness.
- Verified non-vacuous: with the propagator wiring reverted to `main` the spec fails with a `traceparent` of `00-28d58bf6c9064146d5478949a223f32a-a1ef2034909927ff-01` on the paused request.
- `yarn quality:test` green across all 7 projects; `yarn quality:lint:packages` green; full Playwright suite 9/9.
