### PR TITLE
fix(web-sdk): measure the keepalive budget in bytes

### DIFF
--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -295,6 +295,37 @@ describe('FetchTransport', () => {
     await Promise.all([firstSend, secondSend]);
   });
 
+  // The browser budget is a byte limit, so the reservation has to measure bytes rather than
+  // UTF-16 code units. A CJK message is three bytes per code unit. See issue #1898.
+  it('will turn off keepalive for a non-ASCII payload whose byte size is over 60_000', async () => {
+    const nonAsciiItem: TransportItem<LogEvent> = {
+      type: TransportItemType.LOG,
+      payload: {
+        context: {},
+        level: LogLevel.INFO,
+        // 25_000 code units, but 75_000 bytes once encoded as UTF-8
+        message: '错'.repeat(25_000),
+        timestamp: new Date().toISOString(),
+      },
+      meta: {
+        session: { id: mockSessionId },
+      },
+    };
+
+    const transport = new FetchTransport({ url: 'http://example.com/collect' });
+    transport.metas.value = { session: { id: mockSessionId } };
+    transport.internalLogger = mockInternalLogger;
+
+    const jsonBody = JSON.stringify(getTransportBody([nonAsciiItem]));
+    expect(jsonBody.length).toBeLessThan(60_000);
+    expect(new TextEncoder().encode(jsonBody).byteLength).toBeGreaterThan(60_000);
+
+    await transport.send([nonAsciiItem]);
+
+    const requestInit = (fetch.mock.calls[0] as unknown[])[1] as RequestInit;
+    expect(requestInit.keepalive).toBe(false);
+  });
+
   it('will retry a failed keepalive request with keepalive disabled', async () => {
     fetch
       .mockImplementationOnce(() => Promise.reject(new TypeError('Failed to fetch')))

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -23,6 +23,20 @@ interface KeepaliveReservation {
   release: () => void;
 }
 
+/**
+ * The browser keepalive budget is measured in bytes, while `String.length` counts UTF-16 code
+ * units. A payload of non-ASCII text is up to three times larger than its length suggests, so
+ * reserving by length lets Faro send far more than it accounted for and reintroduces the silent
+ * keepalive failures this budget exists to prevent.
+ */
+function getBodyByteSize(body: string): number {
+  if (typeof TextEncoder === 'undefined') {
+    return body.length;
+  }
+
+  return new TextEncoder().encode(body).byteLength;
+}
+
 export class FetchTransport extends BaseTransport {
   readonly name = '@grafana/faro-web-sdk:transport-fetch';
   readonly version = VERSION;
@@ -85,7 +99,7 @@ export class FetchTransport extends BaseTransport {
         }
 
         let body: string | Blob = jsonBody;
-        let bodySize = jsonBody.length;
+        let bodySize = getBodyByteSize(jsonBody);
         const compressionHeaders: Record<string, string> = {};
 
         if (this.compressionEnabled) {


### PR DESCRIPTION
## Why

While picking up #1898 I found that **both things the issue asks for already landed** in #2151 (merged 2026-06-26, five months after the issue was filed): `reserveKeepalive` tracks cumulative pending body size and request count, and a failed keepalive request is retried once with `keepalive: false`. The issue was simply never closed. So this PR is not that work.

What is still wrong is the unit of measurement. The browser keepalive budget is a **byte** limit, but the reservation used `String.length`, which counts UTF-16 code units:

```
payload            codeUnits   utf8Bytes   ratio
ascii error             1014        1014    1.00
accented (de/fr)        1014        2014    1.99
emoji message           1014        2014    1.99
CJK message             1014        3014    2.97
```

So a payload of CJK, emoji or accented text — an error message, a user attribute, a log line — was undercounted by up to 3x. A 20,000 code unit CJK body is really 60,000 bytes, passes the individual check, and three of them reserve 60KB of budget while actually sending 180KB. That is over the shared 64KiB limit and produces exactly the silent keepalive failure the budget was added to prevent.

## What

Measure the encoded byte length in `getBodyByteSize`, falling back to `String.length` where `TextEncoder` is unavailable.

The compressed path was already correct — it reserves `Blob.size`, which is in bytes.

## Links

Refs #1898

**#1898 can be closed** once this lands: the cumulative tracking and the retry safety net it asks for are on `main` already via #2151, and this PR fixes the remaining accounting gap in them.

## Checklist

- [x] Tests added — a non-ASCII payload that is under 60,000 code units but over 60,000 bytes must not get keepalive. Verified non-vacuous: the test reports `Expected: false, Received: true` against `main`.
- [ ] Changelog updated — handled by release-please
- [ ] Documentation updated — n/a

## Verification

- `yarn quality:test` green across all 7 projects; `yarn quality:lint:packages` green.
- The existing keepalive tests (individual limit, cumulative budget, retry fallback, compression threshold) are unchanged and still pass.
