### PR TITLE
test(web-sdk): cover the view changed sequence across setView calls

### DIFF
--- a/packages/web-sdk/src/instrumentations/view/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/view/instrumentation.test.ts
@@ -23,4 +23,30 @@ describe('ViewInstrumentation', () => {
     let event = transport.items[0]! as TransportItem<EventEvent>;
     expect(event.meta.view?.name).toEqual(view.name);
   });
+  // Reported in issue #349: calling setView on every route change appeared to emit a duplicate
+  // view_changed per navigation, interleaved with events for the default view.
+  it('emits one view changed event per distinct view and none for a repeated view', () => {
+    const transport = new MockTransport();
+
+    const { api } = initializeFaro(
+      mockConfig({
+        transports: [transport],
+        instrumentations: [new ViewInstrumentation()],
+      })
+    );
+
+    api.setView({ name: 'A' });
+    api.setView({ name: 'B' });
+    api.setView({ name: 'C' });
+    // navigating to the route that is already active must not emit again
+    api.setView({ name: 'C' });
+
+    const events = (transport.items as Array<TransportItem<EventEvent>>).map((item) => item.payload.attributes);
+
+    expect(events).toEqual([
+      { fromView: 'unknown', toView: 'A' },
+      { fromView: 'A', toView: 'B' },
+      { fromView: 'B', toView: 'C' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Why

#349 reported that calling `setView` on every route change emitted a duplicate `view_changed` per navigation, interleaved with events for the default view:

```
1. view_changed default
2. view_changed A
4. view_changed B
3. view_changed default   <- unexpected
...
```

That behaviour is **already correct on `main`**. The `notifiedView` guard in `ViewInstrumentation` landed in #397 (2023-11-29), after the issue was filed (2023-10-19). Reproducing the reporter's sequence against `main` gives exactly what they expected:

```
view_changed {"fromView":"unknown","toView":"A"}
view_changed {"fromView":"A","toView":"B"}
view_changed {"fromView":"B","toView":"C"}
view_changed {"fromView":"C","toView":"D"}
```

What is missing is a test that pins it. The one existing test calls `setView` with the name already present in the config, so the single event it asserts is the one emitted during initialization — not one caused by `setView`. Nothing would catch a regression that reintroduced duplicates.

## What

Test only, no production change. Asserts the full `view_changed` sequence across several navigations, including that navigating to the already-active view emits nothing.

## Links

Refs #349 — **suggest closing it once this lands**, since the reported behaviour is fixed and now covered.

## Checklist

- [x] Tests added
- [ ] Changelog updated — n/a, test only
- [ ] Documentation updated — n/a

## Verification

`yarn quality:test` green across all 7 projects; `yarn quality:lint:packages` green.
