### PR TITLE
test(e2e): guard against Faro tracing its own collector requests

### DIFF
--- a/e2e/smoke/tests/self-tracing.spec.ts
+++ b/e2e/smoke/tests/self-tracing.spec.ts
@@ -1,0 +1,44 @@
+import type { TransportBody } from '@grafana/faro-core';
+
+import { expect, test } from './fixtures';
+
+type Span = { name?: string };
+
+function allSpans(bodies: TransportBody[]): Span[] {
+  return bodies.flatMap((body) =>
+    ((body.traces?.resourceSpans ?? []) as Array<Record<string, any>>)
+      .flatMap((resourceSpan) => (resourceSpan['scopeSpans'] ?? []) as Array<Record<string, any>>)
+      .flatMap((scopeSpan) => (scopeSpan['spans'] ?? []) as Span[])
+  );
+}
+
+test.describe('Smoke / self-tracing', () => {
+  // The harness is configured with a relative collector url, which is the setup reported in
+  // issue #426: a relative url is not an exact match for the request url the browser resolves,
+  // so Faro traced its own collector requests and each export produced more spans to export.
+  test('does not trace its own collector requests when the collector url is relative', async ({ page }) => {
+    const bodies: TransportBody[] = [];
+
+    await page.route('**/collect', async (route) => {
+      bodies.push(route.request().postDataJSON() as TransportBody);
+      await route.fulfill({ status: 201, body: '{}' });
+    });
+
+    await page.goto('/');
+
+    // several signals, so the transport posts to the relative collector url more than once
+    await page.locator('[data-cy="btn-push-log"]').click();
+    await page.locator('[data-cy="btn-push-event"]').click();
+    await page.locator('[data-cy="btn-emit-span"]').click();
+
+    // Wait until a span has actually been exported. Without this the assertion below would also
+    // pass if tracing were simply inactive, which would make the test worthless.
+    await expect
+      .poll(() => allSpans(bodies).some((span) => span.name === 'smoke-harness-span'), { timeout: 10_000 })
+      .toBe(true);
+
+    const collectorSpans = allSpans(bodies).filter((span) => JSON.stringify(span).includes('/collect'));
+
+    expect(collectorSpans).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

#426 is the most-upvoted open bug in the repo (6 reactions): a **relative** collector url made Faro trace its own collector requests, so every export produced more spans, which produced more exports.

The root cause is that OTel's `urlMatches` compares string ignore patterns by **exact equality**, and `/collect` is never equal to the `http://host/collect` the browser actually requests.

It is already fixed. #685 (2024-09-23, nine months after the report) added a default ignore pattern `/\/collect(?:\/[\w]*)?$/`, which matches the resolved absolute url regardless of how the collector url was configured. Verified with the resolved url against a relative config:

```
IGNORE PATTERNS: [ '/collect', '/collect', /\/collect(?:\/[\w]*)?$/ ]
OTEL would ignore: true | FARO would ignore: true
```

What is missing is anything pinning it. This family of failure keeps coming back in other forms — #663 (most-commented open bug), #1787, #1818 — so it is worth an actual guard rather than trusting a regex nobody tests.

## What

Test only, no production change.

The smoke harness is already configured with a relative collector url (`url: '/collect'`), which is exactly the reported setup, so no new fixture is needed. The spec pushes several signals plus a span and asserts that **no exported span describes a request to the collector**.

The spec waits for a known span (`smoke-harness-span`) to arrive before asserting absence. Without that it would also pass if tracing were simply inactive, which would make it worthless.

## Links

Refs #426 — **suggest closing it**, along with a look at whether #663 and #1818 are the same root cause and also already resolved.

## Checklist

- [x] Tests added
- [ ] Changelog updated — n/a, test only
- [ ] Documentation updated — n/a

## Verification

Confirmed the guard actually catches the reported symptom: removing the default ignore pattern from `makeCoreConfig` and rebuilding makes it fail with exported spans named `HTTP POST` for the collector url. Full Playwright suite 9/9; `yarn quality:lint:packages` green.
