### PR TITLE
fix(core): make removeBeforeSendHooks remove the hooks

### DIFF
--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -165,7 +165,9 @@ export function initializeTransports(
   };
 
   const removeBeforeSendHooks: Transports['removeBeforeSendHooks'] = (...beforeSendHooksToRemove) => {
-    beforeSendHooks.filter((beforeSendHook) => !beforeSendHooksToRemove.includes(beforeSendHook));
+    internalLogger.debug('Removing beforeSendHooks');
+
+    beforeSendHooks = beforeSendHooks.filter((beforeSendHook) => !beforeSendHooksToRemove.includes(beforeSendHook));
   };
 
   const unpause: Transports['unpause'] = () => {

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -191,6 +191,55 @@ describe('transports', () => {
     });
   });
 
+  describe('removeBeforeSendHooks', () => {
+    it('stops calling a hook after it is removed', () => {
+      const transport = new MockTransport();
+      const hook = jest.fn((item: TransportItem) => item);
+
+      const { transports } = initializeFaro(
+        mockConfig({
+          isolate: true,
+          instrumentations: [],
+          transports: [transport],
+        })
+      );
+
+      transports.addBeforeSendHooks(hook);
+      transports.execute(makeExceptionTransportItem('Error', 'Kaboom'));
+      expect(hook).toHaveBeenCalledTimes(1);
+
+      transports.removeBeforeSendHooks(hook);
+      expect(transports.getBeforeSendHooks()).not.toContain(hook);
+
+      transports.execute(makeExceptionTransportItem('Error', 'Kaboom'));
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(transport.sentItems).toHaveLength(2);
+    });
+
+    it('keeps the hooks which are not removed', () => {
+      const transport = new MockTransport();
+      const hookToRemove = jest.fn((item: TransportItem) => item);
+      const hookToKeep = jest.fn((item: TransportItem) => item);
+
+      const { transports } = initializeFaro(
+        mockConfig({
+          isolate: true,
+          instrumentations: [],
+          transports: [transport],
+        })
+      );
+
+      transports.addBeforeSendHooks(hookToRemove, hookToKeep);
+      transports.removeBeforeSendHooks(hookToRemove);
+
+      transports.execute(makeExceptionTransportItem('Error', 'Kaboom'));
+
+      expect(hookToRemove).not.toHaveBeenCalled();
+      expect(hookToKeep).toHaveBeenCalledTimes(1);
+      expect(transports.getBeforeSendHooks()).toEqual([hookToKeep]);
+    });
+  });
+
   describe('multiple transports of the same type', () => {
     const transport1 = new MockTransport();
     const transport2 = new MockTransport();


### PR DESCRIPTION
## Summary

- `removeBeforeSendHooks` called `Array.prototype.filter` but threw the result away, so hooks were never removed. Callers that unregister a hook on teardown keep running it, and hooks accumulate across teardown and re-initialize cycles. Fixed in [`packages/core/src/transports/initialize.ts`](https://github.com/grafana/faro-web-sdk/blob/main/packages/core/src/transports/initialize.ts) by assigning the filtered array back.
- Added coverage in [`packages/core/src/transports/transports.test.ts`](https://github.com/grafana/faro-web-sdk/blob/main/packages/core/src/transports/transports.test.ts): a removed hook stops running, and the hooks which are not removed stay registered. Both tests fail without the fix.

Found while reviewing #2127, whose `destroy()` path depends on this function.

_PR description authored by Claude on Domas's behalf._