### PR TITLE
chore(renovate): pin react-18 fixtures below v19

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,6 +55,11 @@
       "allowedVersions": "<8.0.0"
     },
     {
+      "description": "react-18 and react-dom-18 are pinned compatibility-matrix fixtures for packages/react. The rr-v5 jest project maps react and react-dom to them because react-router v5 does not run on React 19 (see packages/react/jest.config.js). A major bump points the alias at React 19, which makes that project test the wrong version and still report green. See the react-router-dom-v5 rule above.",
+      "matchDepNames": ["react-18", "react-dom-18"],
+      "allowedVersions": "<19.0.0"
+    },
+    {
       "description": "Enforce a 3-day release-age cooldown on ALL npm depTypes (incl @grafana/*, which the org preset exempts) to match yarn's npmMinimalAgeGate (.yarnrc.yml). Placed last so it overrides the injected Grafana org preset rule (grafana-renovate-config//presets/npm). Without this, Renovate proposes versions younger than the gate that yarn then quarantines (YN0016), producing un-mergeable PRs.",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"


### PR DESCRIPTION
## Summary

- Add a Renovate `packageRule` in [`.github/renovate.json`](.github/renovate.json) that holds `react-18` and `react-dom-18` below v19. These are aliases to React 18.3.1 in `packages/react`, and the `rr-v5` jest project maps `react`/`react-dom` to them because react-router v5 does not run on React 19 (see `packages/react/jest.config.js`).

Renovate had no rule for these two names, so it proposed the latest major (#2166). That points the alias at React 19, and the `rr-v5` project then runs against React 19 instead of React 18 — and still reports green, because nothing asserts which version is loaded. `packages/react` declares peer support for React 16 through 19, so the React 18 coverage disappears without any signal.

The sibling fixtures `react-router-dom-v5`, `react-router-v6` and `react-router` already carry the same guard. This adds the missing one.

Follow-up worth considering, not included here: the matrix passes when its fixture is swapped. A version assertion in `src/router/__matrix__/shared.tsx` would make that fail loudly instead.

_PR description authored by Claude on Domas's behalf._