### PR TITLE
ci: fix formatter-bump lint failures at the source

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,26 @@
       "groupName": "patch updates"
     },
     {
+      "description": "Keep formatters and linters out of the other groups. A newer prettier or eslint reformats files across the repository, and Renovate does not run the formatter itself, so such an upgrade lands with the 'Check for unfixed lint issues' job failing. Isolating them means the frequent dependency groups stay green and the reformat arrives in one pull request. That pull request is expected to fail the lint job: a maintainer runs 'yarn quality:lint:fix', reviews the reformat and commits it. Placed after the npm-dependencies and patch rules so it wins for these packages whatever the update type.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "prettier",
+        "eslint",
+        "typescript",
+        "husky",
+        "lint-staged",
+        "markdownlint-cli",
+        "@eslint/js",
+        "@grafana/eslint-config",
+        "@stylistic/eslint-plugin-ts",
+        "/^@typescript-eslint\\//",
+        "/^eslint-config-/",
+        "/^eslint-plugin-/"
+      ],
+      "groupName": "formatters-and-linters",
+      "schedule": ["before 5am on Monday"]
+    },
+    {
       "description": "Restrict ua-parser-js to version below 2.x.x as it changes licensing model with v2 onwards",
       "matchPackageNames": ["ua-parser-js"],
       "allowedVersions": "<2.0.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Faro Web SDK agent instructions
+
+## Formatting and CI fixes
+
+- When continuous integration reports auto-fixable lint or formatting issues in files within the
+  current task, run `yarn quality:lint:fix` and include the resulting task-related fixes without
+  asking the user to apply them manually.
+- Before running a fixer, inspect the working tree. Preserve all pre-existing and unrelated changes.
+- After applying fixes, run `yarn quality:lint` and the tests relevant to the changed files.
+- If the fixer changes files outside the task scope, do not silently include or discard those
+  changes. Report them to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+
+@AGENTS.md

--- a/docs/sources/developer/local-development.md
+++ b/docs/sources/developer/local-development.md
@@ -43,3 +43,19 @@ for inspection).
 This repo intentionally does **not** ship a Docker-based local stack: those configurations drift
 silently with upstream version bumps and inflate the SDK's contributor surface. Run your own
 infrastructure with the tools you already use.
+
+## Formatting
+
+`yarn install` sets up a Git pre-commit hook that formats the files you stage, so in normal use you do
+not need to think about formatting at all. If continuous integration still reports auto-fixable lint
+issues, for example because you committed with `--no-verify`, run the fixer and then review what it
+changed:
+
+```bash
+yarn quality:lint:fix
+git diff
+```
+
+Commit those changes and continuous integration goes green. To check whether anything is outstanding
+without printing a diff, use `git diff --exit-code`, which exits with a non-zero status when there are
+uncommitted changes.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "prepublish": "yarn build",
+    "postinstall": "husky",
     "clean": "run-s 'clean:*'",
     "clean:packages": "lerna run --parallel clean",
     "clean:root": "rimraf .cache yarn-error.log",


### PR DESCRIPTION
## Why

All recent `Check for unfixed lint issues` failures come from Renovate branches. Of the last 40 failing
`Pull Request` runs, 24 failed on that step, and every one of them was a `renovate/*` branch.

The cause is narrow. Renovate's `npm-dependencies` group bumps `prettier` or `eslint`, the newer version
reformats existing files, and Renovate does not run the formatter. The check then fails on files the
upgrade never meant to touch:

```diff
-    for (let idx = length; idx-- !== 0; ) {
+    for (let idx = length; idx-- !== 0;) {
```

Separately, the repository already had a `.husky/pre-commit` hook running `lint-staged`, but no script
installed it. On a fresh clone `yarn install` never set `core.hooksPath`, so the hook existed for nobody.

## What

**Group formatters and linters into their own Renovate pull request.** A reformat can then only arrive in
that one pull request, so the frequent dependency groups stay green. The rule sits after the
`npm-dependencies` and patch rules so it wins for these packages whatever the update type.

That one pull request is expected to fail the lint job. This is intended: a maintainer runs
`yarn quality:lint:fix`, reviews the reformat and commits it. Renovate is not asked to format on our
behalf, because `allowedCommands` defaults to empty and cannot be set from this repository.

**Run husky from `postinstall`.** Yarn 4 does not run the `prepare` script, so `postinstall` is the hook
that works. Verified in a fresh clone: `yarn install` sets `core.hooksPath` to `.husky/_`, and committing
an unformatted file produces a formatted commit. `enableScripts: false` in `.yarnrc.yml` still blocks
dependency build scripts, so the supply-chain posture is unchanged. Only the root workspace's own script
runs.

Also adds `AGENTS.md` (with `CLAUDE.md` pointing at it) so agent tooling formats the same way, and
documents the hook in the local development guide.

## Links

Example failure this fixes: [run 31322761256](https://github.com/grafana/faro-web-sdk/actions/runs/31322761256),
a `renovate/npm-dependencies` branch failing on a prettier reformat.

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [x] Documentation updated
