### PR TITLE
chore(renovate): pin history v4 fixture

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,6 +64,11 @@
       "allowedVersions": "<6.0.0"
     },
     {
+      "description": "history-v4 is pinned below v5 because React Router v4 and v5 require the history v4 API. Keep v4 updates eligible so Renovate can still propose compatible security fixes.",
+      "matchDepNames": ["history-v4"],
+      "allowedVersions": "<5.0.0"
+    },
+    {
       "description": "Pinned v6 compatibility-matrix fixture for packages/react. See the react-router-dom-v5 rule above.",
       "matchDepNames": ["react-router-v6"],
       "allowedVersions": "<7.0.0"


### PR DESCRIPTION
## Why

Renovate PR #2163 updates the `history-v4` alias from `history@4.10.1` to `history@5.3.0`, which breaks the React Router v5 compatibility test. React Router v4 and v5 both use the history v4 listener API, while history v5 was designed for React Router v6-era APIs. The package major versions do not align.

The alias must remain on history v4, but compatible v4 updates should stay eligible so Renovate can still propose security fixes.

## What

- Restrict the `history-v4` alias to versions below 5.0.0.
- Keep v4 patch updates enabled instead of ignoring the dependency.

Validated with `jq empty`, scoped Prettier, and `git diff --check`.

## Links

- https://github.com/grafana/faro-web-sdk/pull/2163

## Checklist

- [ ] Tests added (not applicable, configuration-only change)
- [ ] Changelog updated (not applicable)
- [ ] Documentation updated (not applicable)