### PR TITLE
chore(renovate): pin legacy brace-expansion to v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,13 @@
       "allowedVersions": "<2.0.0"
     },
     {
+      "description": "Keep legacy brace-expansion resolutions on the patched 2.x line. minimatch 3 and 9 expect brace-expansion's CommonJS callable export, while brace-expansion 5 exposes a named expand function. Resolutions already on 5.x remain eligible for updates.",
+      "matchPackageNames": ["brace-expansion"],
+      "matchDepTypes": ["resolutions"],
+      "matchCurrentVersion": "<3.0.0",
+      "allowedVersions": "<3.0.0"
+    },
+    {
       "description": "react-router-dom-v5 is a pinned compatibility-matrix fixture for packages/react (see src/router/__matrix__). Renovate treats these aliases as ordinary deps and proposes the latest major, which silently replaces the version under test and deletes the coverage the fixture exists to provide. react-router-v8 is deliberately left unconstrained so it tracks the latest v8.",
       "matchDepNames": ["react-router-dom-v5"],
       "allowedVersions": "<6.0.0"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -47,12 +47,3 @@ jobs:
             pkg:npm/lightningcss-linux-x64-musl,
             pkg:npm/lightningcss-win32-arm64-msvc,
             pkg:npm/lightningcss-win32-x64-msvc
-          # GHSA-mh99-v99m-4gvg (brace-expansion, OOM DoS): the advisory range is
-          # <=5.0.7, which covers every release of the 1.x and 2.x lines. Upstream
-          # only patched 5.0.8, and 5.x changed the module export from a callable to
-          # a named `expand`, so forcing it onto minimatch 3 and 9 breaks jest and
-          # glob at runtime. The 1.x/2.x copies are dev tooling only and reach no
-          # published package. Moving 1.1.15 -> 1.1.16 and 2.1.1 -> 2.1.2 does fix
-          # GHSA-3jxr-9vmj-r5cp on those lines, but registers here as newly added
-          # versions that still match this advisory. Revisit if upstream backports.
-          allow-ghsas: GHSA-mh99-v99m-4gvg


### PR DESCRIPTION
## Why

Renovate PR #2213 upgrades legacy brace-expansion resolutions from patched 2.1.4 to vulnerable 3.0.6. Moving those resolutions to v5 is also incompatible with the callable export expected by minimatch 3 and 9.

## What

- Keep brace-expansion resolution entries currently below v3 on the patched 2.x line.
- Leave existing v5 resolution entries eligible for updates.
- Remove the obsolete GHSA-mh99-v99m-4gvg dependency-review exception.
- Validate the rule with a Renovate local dry run and targeted formatting checks.

## Links

- #2213
- https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

## Checklist

- [ ] Tests added
- [ ] Changelog updated
- [ ] Documentation updated

The checklist items do not apply because this only changes internal dependency automation configuration.