### PR TITLE
chore(react): guard the peerDependencies ranges against automated rewrites

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
   "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "enabled": true,
     "labels": ["security"],
     "prPriority": 10
   },
@@ -52,6 +51,12 @@
       ],
       "groupName": "formatters-and-linters",
       "schedule": ["before 5am on Monday"]
+    },
+    {
+      "description": "peerDependencies ranges in this repository are compatibility declarations that are maintained by hand, so Renovate must not rewrite them. A security update did rewrite the react-router range from '^7.12.0 || ^8.0.0' to '^7.18.2 ^7.18.2'. A space means AND in semantic versioning, so that range stayed valid, collapsed to '^7.18.2' and silently dropped React Router v8, a generation this package supports and tests. Two notes for whoever changes this next. First, this rule only takes effect because the 'vulnerabilityAlerts' object above no longer sets 'enabled'. Renovate appends one package rule per advisory carrying 'force: { ...vulnerabilityAlerts }' (lib/workers/repository/process/vulnerabilities.ts), 'force' beats every other setting (lib/config/utils.ts, mergeChildConfig ends with '{ ...config, ...config.force }'), and applyPackageRules clears the skip whenever 'force.enabled' is truthy (lib/config/index.ts). Setting 'enabled: true' there would therefore defeat this rule. Second, Renovate configuration applied at the organisation level is not visible in this file and could still override this, so packages/react/src/peerDependencies.test.ts asserts the same invariant in a way that does not depend on Renovate at all.",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
     },
     {
       "description": "Restrict ua-parser-js to version below 2.x.x as it changes licensing model with v2 onwards",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,6 +69,7 @@
     "@types/hoist-non-react-statics": "3.3.7",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
+    "@types/semver": "7.7.1",
     "history-v4": "npm:history@4.10.1",
     "react": "19.2.8",
     "react-18": "npm:react@18.3.1",
@@ -77,7 +78,8 @@
     "react-router": "7.18.1",
     "react-router-dom-v5": "npm:react-router-dom@5.3.4",
     "react-router-v6": "npm:react-router@6.30.4",
-    "react-router-v8": "npm:react-router@8.3.0"
+    "react-router-v8": "npm:react-router@8.3.0",
+    "semver": "7.8.5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/react/src/peerDependencies.test.ts
+++ b/packages/react/src/peerDependencies.test.ts
@@ -1,0 +1,86 @@
+import { satisfies, validRange } from 'semver';
+
+import packageJson from '../package.json';
+
+// The router compatibility matrix (see src/router/__matrix__) pins one fixture per
+// supported React Router generation and runs a dedicated Jest project against each.
+// Those fixtures are aliases with exact versions, so the matrix never resolves the
+// peerDependencies ranges and cannot notice when a range stops covering a generation
+// it tests. That gap let an automated dependency update rewrite the react-router peer
+// range from "^7.12.0 || ^8.0.0" to "^7.18.2 ^7.18.2". A space means AND in semantic
+// versioning, so the range stayed valid, collapsed to "^7.18.2" and silently dropped
+// React Router v8, with every check still green.
+//
+// These tests close that gap: every generation the matrix tests must be admitted by a
+// declared peer range.
+
+const { devDependencies, peerDependencies } = packageJson;
+
+/**
+ * Reads the exact version out of a devDependency entry. Matrix fixtures are npm
+ * aliases such as "npm:react-router@8.3.0"; the plain entries are exact versions.
+ */
+function fixtureVersion(name: keyof typeof devDependencies): string {
+  const entry: string = devDependencies[name];
+  const version = entry.startsWith('npm:') ? entry.slice(entry.lastIndexOf('@') + 1) : entry;
+
+  if (!version) {
+    throw new Error(`Could not read a version out of devDependency "${name}": "${entry}"`);
+  }
+
+  return version;
+}
+
+// Which peer range has to admit each matrix fixture.
+//
+// React Router v6 is the exception worth explaining. Its matrix project imports from
+// "react-router", but consumers on that generation install "react-router-dom" v6,
+// which depends on "react-router" v6 itself. The v6 fixture is therefore checked
+// against the react-router-dom range. From v7 onwards react-router-dom was merged
+// into react-router, so v7 and v8 are checked against the react-router range.
+const matrix = [
+  {
+    description: 'React Router v5 (via react-router-dom)',
+    fixture: 'react-router-dom-v5',
+    peer: 'react-router-dom',
+  },
+  {
+    description: 'React Router v6 (via react-router-dom)',
+    fixture: 'react-router-v6',
+    peer: 'react-router-dom',
+  },
+  {
+    description: 'React Router v7',
+    fixture: 'react-router',
+    peer: 'react-router',
+  },
+  {
+    description: 'React Router v8',
+    fixture: 'react-router-v8',
+    peer: 'react-router',
+  },
+] as const;
+
+describe('peerDependencies', () => {
+  it.each(Object.entries(peerDependencies))('declares %s as a valid semver range', (_name, range) => {
+    expect(validRange(range)).not.toBeNull();
+  });
+
+  it.each(matrix)('covers the $description fixture in the $peer range', ({ fixture, peer }) => {
+    const version = fixtureVersion(fixture);
+    const range = peerDependencies[peer];
+
+    expect(satisfies(version, range)).toBe(true);
+  });
+
+  // A space between two comparator sets means AND, which is almost never what a peer
+  // range is meant to express and is how the v8 regression slipped through. Every
+  // alternative in these ranges has to be separated by "||".
+  it.each(Object.entries(peerDependencies))('separates every alternative in %s with "||"', (_name, range) => {
+    const alternatives = range.split('||').map((alternative) => alternative.trim());
+
+    for (const alternative of alternatives) {
+      expect(alternative).not.toMatch(/\s/);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,7 @@ __metadata:
     "@types/hoist-non-react-statics": "npm:3.3.7"
     "@types/react": "npm:19.2.18"
     "@types/react-dom": "npm:19.2.4"
+    "@types/semver": "npm:7.7.1"
     history-v4: "npm:history@4.10.1"
     hoist-non-react-statics: "npm:^3.3.2"
     react: "npm:19.2.8"
@@ -726,6 +727,7 @@ __metadata:
     react-router-dom-v5: "npm:react-router-dom@5.3.4"
     react-router-v6: "npm:react-router@6.30.4"
     react-router-v8: "npm:react-router@8.3.0"
+    semver: "npm:7.8.5"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3370,6 +3372,13 @@ __metadata:
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
   checksum: 10c0/c5b7e1770feb5ccfb6802f6ad82a7b0d50874c99331e0c9b259e415e55a38d7a86ad0901c57665d93f75938be2a6a0bc9aa06c9749192cadb2e4512800bbc6e6
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@types/semver@npm:7.7.1"
+  checksum: 10c0/c938aef3bf79a73f0f3f6037c16e2e759ff40c54122ddf0b2583703393d8d3127130823facb880e694caa324eb6845628186aac1997ee8b31dc2d18fafe26268
   languageName: node
   linkType: hard
 
@@ -12025,21 +12034,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.8.5, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
 "semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
     semver: bin/semver.js
   checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.5":
-  version: 7.8.5
-  resolution: "semver@npm:7.8.5"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Renovate pull request #2214 rewrote the `react-router` peer dependency range in
`packages/react/package.json`:

```diff
-    "react-router": "^7.12.0 || ^8.0.0",
+    "react-router": "^7.18.2 ^7.18.2",
```

In semantic versioning a space is an AND operator, so `^7.18.2 ^7.18.2` is valid syntax.
It is the intersection of a range with itself, which simply means `^7.18.2`. React
Router v8 was silently dropped from the supported range.

Every check on that pull request stayed green. The router compatibility matrix pins
exact versions through npm aliases (`react-router-v8: npm:react-router@8.3.0`) and
therefore never resolves the peer ranges, so nothing in this repository could notice.
Consumers would have found out instead, through an unmet peer dependency or `ERESOLVE`
error with no obvious cause.

The same exposure exists for `react-router-dom`, whose range is
`^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0`.

## What

Two layers, because neither is sufficient alone.

### Layer 1: prevention, in `.github/renovate.json`

A package rule stops Renovate touching npm `peerDependencies`. Peer ranges here are
compatibility declarations, maintained by hand. The existing rule for
`react-router` devDependencies already stated that intent; this makes it enforceable.

The rule only takes effect because the `vulnerabilityAlerts` object no longer sets
`"enabled": true`. The mechanism, which is recorded in the rule description because it
depends on Renovate internals:

1. Renovate appends one package rule per advisory, carrying
   `force: { ...vulnerabilityAlerts }`, after every rule in this file
   (`lib/workers/repository/process/vulnerabilities.ts`).
2. `force` beats every other setting: `mergeChildConfig` ends with
   `return { ...config, ...config.force }` (`lib/config/utils.ts`).
3. `applyPackageRules` clears the skip whenever `force.enabled` is truthy
   (`lib/config/index.ts`).

So `"enabled": true` in `vulnerabilityAlerts` would have defeated the new rule. Removing
that key changes nothing on its own, because `true` is the documented default. It was
only ever there to state intent.

### Layer 2: detection, in `packages/react/src/peerDependencies.test.ts`

A new test asserts that:

- every React Router generation the compatibility matrix tests is admitted by a declared
  peer range;
- all four declared ranges parse as valid semver;
- every alternative within a range is separated by `||` rather than a space.

The React Router v6 fixture is deliberately checked against the `react-router-dom` range
rather than the `react-router` one, because v6 consumers reach `react-router` through
`react-router-dom` v6. That is explained in the file.

This layer depends on nothing outside the repository.

### Honest limitation

Layer 1 is best effort and cannot be verified from here. Renovate configuration applied
at the organisation level is not visible in this file, and if it sets
`vulnerabilityAlerts.enabled`, this rule is silently defeated. There is direct evidence
that such configuration exists: pull request #2214 carries the label
`automerge-security-update`, which is not the `security` label this file configures.

Layer 2 is the part that actually guarantees the invariant. It would have turned #2214
red.

### Dependencies

Adds `semver` and `@types/semver` as devDependencies of `packages/react`. `semver` was
previously present only as a hoisted transitive dependency, which is not safe to import.

## Links

- Pull request #2214, where the range was rewritten and has since been corrected
- [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), the advisory
  that triggered it. It has two affected ranges (`>= 7.12.0, < 7.18.2` patched by
  7.18.2, and `>= 8.0.0, < 8.3.0` patched by 8.3.0), so a correct remediation would have
  been `^7.18.2 || ^8.3.0`. Renovate wrote the 7.x fix into both slots and joined them
  with a space.

Known follow-up, not in this pull request: report the dropped `||` upstream to
[renovatebot/renovate](https://github.com/renovatebot/renovate/issues).

## Verification

The guard was confirmed by reproducing the regression rather than by assertion alone.
Reapplying `^7.18.2 ^7.18.2` locally fails three assertions:

```
● peerDependencies › covers the React Router v7 fixture in the react-router range
● peerDependencies › covers the React Router v8 fixture in the react-router range
● peerDependencies › separates every alternative in react-router with "||"
```

With the range restored, all 37 tests pass across the five Jest projects (`react`,
`rr-v5`, `rr-v6`, `rr-v7`, `rr-v8`). `yarn install --immutable`, the package build and
Prettier are all clean, and the test file is not emitted into `dist/`.

`renovate-config-validator` reports one warning, that `prPriority` cannot be used inside
`vulnerabilityAlerts`. That warning is **pre-existing on `main`** and is byte-identical
before and after this change, so `prPriority: 10` is currently being ignored. Left
alone here as out of scope, but worth a separate look.

## Checklist

- [x] Tests added
- [ ] Changelog updated (not applicable: no user-facing behaviour change, matching the
      convention for recent `chore` and `ci` pull requests such as #2219 and #2218)
- [ ] Documentation updated (not applicable: the reasoning is documented inline, in the
      Renovate rule description and the test file)
