### PR TITLE
docs: document the environments the Faro Web SDK supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,33 @@ the [README.md][faro-web-sdk-readme] for more information.
 [faro-quick-start]: ./docs/sources/tutorials/quick-start-browser.md
 [faro-react]: ./packages/react
 [faro-react-readme]: ./packages/react/README.md
+[faro-supported-environments]: https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/introduction/supported-environments/
 [faro-web-sdk]: ./packages/web-sdk
 [faro-web-sdk-readme]: ./packages/web-sdk/README.md
 [faro-web-tracing]: ./packages/web-tracing
 [faro-web-tracing-readme]: ./packages/web-tracing/README.md
+
+## Supported environments
+
+The Faro Web SDK instruments web pages that run in a browser. During initialization, the SDK and most of its default
+instrumentations read browser APIs such as `window`, `document`, `PerformanceObserver` and `sessionStorage`. Any
+JavaScript environment without a full DOM is outside the supported scope.
+
+| Environment                                                                | Supported |
+| -------------------------------------------------------------------------- | --------- |
+| Web applications that run in a browser                                     | Yes       |
+| Client side of server-rendered applications, such as Next.js and React SSR | Yes       |
+| Server runtime of server-rendered applications                             | No        |
+| Browser extensions                                                         | No        |
+| Web workers and service workers                                            | No        |
+| Node.js, React Native, and other non-browser JavaScript environments       | No        |
+
+Browser extensions come up often, so to be explicit, they are not supported. Some users have made Faro run inside an
+extension by supplying their own set of instrumentations. That configuration is unsupported and we do not accept
+issues for it.
+
+For the reasoning behind each row, and for what to use instead when monitoring a server or a backend, see
+[supported environments][faro-supported-environments].
 
 ## Releases
 
@@ -77,6 +100,9 @@ Faro releases follow the [Semantic Versioning](https://semver.org/) naming schem
   > and the upgrade guide whenever choosing a new version of Faro to install.
 
 ## Supported Node versions
+
+This section is about the Node versions used to build, test and publish the SDK. Node.js is not a runtime that the SDK
+itself supports. See [supported environments](#supported-environments).
 
 Faro supports all active LTS (Long Term Support) and current Node versions. When Node.js versions
 reach end-of-life, we remove them from our test matrix and add new versions as they are released.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ the [README.md][faro-web-sdk-readme] for more information.
 ## Supported environments
 
 The Faro Web SDK instruments web pages that run in a browser. During initialization, the SDK and most of its default
-instrumentations read browser APIs such as `window`, `document`, `PerformanceObserver` and `sessionStorage`. Any
-JavaScript environment without a full DOM is outside the supported scope.
+instrumentations read browser APIs such as `window`, `document`, `PerformanceObserver` and `sessionStorage`. JavaScript
+that doesn't run in a typical web page context is outside the supported scope.
 
 | Environment                                                                | Supported |
 | -------------------------------------------------------------------------- | --------- |
 | Web applications that run in a browser                                     | Yes       |
-| Client side of server-rendered applications, such as Next.js and React SSR | Yes       |
+| Client-side of server-rendered applications, such as Next.js and React SSR | Yes       |
 | Server runtime of server-rendered applications                             | No        |
 | Browser extensions                                                         | No        |
 | Web workers and service workers                                            | No        |


### PR DESCRIPTION
## Why

The Faro Web SDK needs a browser DOM, but nothing states that. Neither the README nor the
Frontend Observability documentation says which runtimes the SDK targets, so users find the boundary
by hitting `ReferenceError: window is not defined` during initialization and then filing an issue.

#1643 is the current example: someone running Faro in a Chrome extension test context. #2195 proposed
making core initialize without a DOM. That PR was closed, because the scenario is not one we support
and the fix would add permanent complexity to core to serve it. The agreed alternative was to
document the boundary, which is what this PR does on the repository side.

## What

- New `## Supported environments` section in the root README, with a matrix of six environments:
  - Supported: web applications in a browser, and the client side of server-rendered applications
    such as Next.js and React SSR.
  - Not supported: the server runtime of server-rendered applications, browser extensions, web and
    service workers, and Node.js, React Native, and other non-browser JavaScript environments.
- An explicit paragraph on browser extensions, since they are the most frequent request. Some users
  have made Faro run in an extension with their own set of instrumentations. That configuration is
  unsupported and we do not accept issues for it. No workaround recipe is given on purpose.
- A clarifying sentence in the existing `## Supported Node versions` section. That section is about
  the build and test toolchain, which reads as a contradiction next to a matrix row saying Node.js is
  not a supported runtime.

The section links to a new documentation page that carries the full reasoning, including what to use
instead for server-side and backend monitoring. The README carries the summary, the docs page carries
the detail.

## Links

- Documentation counterpart: grafana/website#33226. Merge that first, otherwise the
  `[supported environments]` link in the README resolves to a 404.
- Related to #1643
- Related to #2195

## Checklist

- [ ] Tests added — not applicable, documentation only
- [ ] Changelog updated — not applicable, no user-facing code change
- [x] Documentation updated — grafana/website#33226
