### PR TITLE
chore(ci): close pull requests after 60 days without activity

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
+  "labels": ["dependencies"],
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "prPriority": 10

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
-  "labels": ["dependencies"],
+  "addLabels": ["dependencies"],
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "prPriority": 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,140 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # Daily at 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Report what would be labelled or closed, without changing anything'
+        type: boolean
+        default: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      # actions/stale keeps a state cache through @actions/cache to resume when
+      # it runs out of operations, and its README asks for actions: write. With
+      # an explicit permissions map every omitted scope is denied.
+      actions: write
+      issues: write # labels are applied through the issues API
+      pull-requests: write
+
+    steps:
+      # actions/stale swallows the error when it cannot apply its label, so a
+      # missing label would leave PRs commented on but never labelled or
+      # closed. Creating both labels here keeps the workflow self-contained.
+      # --force makes this idempotent, so any nonzero exit is a real failure
+      # (auth, permissions, API) and should fail the job loudly.
+      - name: Ensure the stale and keep-open labels exist
+        if: ${{ !inputs.dryRun }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create stale \
+            --force \
+            --repo "$GITHUB_REPOSITORY" \
+            --color aaaaaa \
+            --description "No activity for 60 days. Closes automatically after 14 more days."
+
+          gh label create keep-open \
+            --force \
+            --repo "$GITHUB_REPOSITORY" \
+            --color 0e8a16 \
+            --description "Never closed automatically, however long it stays open."
+
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          # Only manage PRs. There is no automated policy for issues.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Label PRs with no activity for 60 days
+          days-before-pr-stale: 60
+          # Close 14 days after the label is applied
+          days-before-pr-close: 14
+
+          stale-pr-label: 'stale'
+
+          # Do not @-mention the author here, and do not replace this with a
+          # step that does. A mention makes GitHub record `mentioned` and
+          # `subscribed` events, and hasOnlyStaleLabelingEventsSince requires
+          # every event since the label to be a `labeled` event, so
+          # remove-stale-when-updated below would strip the label on the next
+          # run and the PR would never close. It would only be re-labelled and
+          # re-warned every 60 days. A comment without a mention creates no
+          # events at all, and the action ignores its own bot comment because it
+          # only counts activity from authors of type User.
+          # See docs/PULL_REQUESTS.md for the policy this message describes.
+          stale-pr-message: >
+            This pull request has had no activity for 60 days, so it has been
+            labelled `stale`. It will be closed automatically in 14 days.
+
+            Thank you for the contribution. If you are waiting on a review from
+            a maintainer, a comment here is enough to keep this open.
+
+            To keep it open, do any one of these:
+
+            - push a commit, or leave a comment
+
+            - remove the `stale` label
+
+            - add the `keep-open` label
+
+            Closing is not final. The branch is kept, so a closed pull request
+            can be reopened at any time.
+
+            Draft pull requests are included, so parked work in progress is also
+            affected.
+
+          close-pr-message: >
+            This pull request has been closed because there was no activity for
+            74 days. The branch was not deleted, so you can reopen this pull
+            request at any time to continue the work.
+
+          # Never stale these.
+          #
+          # Closing a Renovate PR would drop that version update silently,
+          # because renovate.json does not set recreateWhen. `dependencies` is
+          # the label renovate.json now applies to every PR it opens.
+          # update-major is listed as well: major bumps are the ones most likely
+          # to sit unreviewed, and they only gained `dependencies` from
+          # renovate.json in this change, so older ones do not carry it.
+          #
+          # automerge-security-update, security-needs-review and 1.security are
+          # the labels security PRs carry in this repository. There are also
+          # severity:* labels, deliberately not listed: the security labels
+          # above already cover every security PR, and exempting only some
+          # severities would be an inconsistent half-set.
+          #
+          # `autorelease: pending` is the release-please PR. It is meant to stay
+          # open between releases, and closing it would break the release
+          # process.
+          #
+          # The colon in `autorelease: pending` is why this is a folded block
+          # scalar. The action splits the list on commas only, so the space
+          # inside the label name survives.
+          exempt-pr-labels: >-
+            dependencies,
+            update-major,
+            automerge-security-update,
+            security-needs-review,
+            1.security,
+            autorelease: pending,
+            keep-open
+
+          # Drafts are included. A draft nobody has touched for two months is
+          # abandoned too. Use the keep-open label to park work in progress.
+          exempt-draft-pr: false
+
+          # Reset the clock on any activity
+          remove-stale-when-updated: true
+
+          # A closed PR must stay reopenable
+          delete-branch: false
+
+          # The default of 30 would silently truncate the run
+          operations-per-run: 100
+
+          debug-only: ${{ inputs.dryRun == true }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -74,13 +74,13 @@ jobs:
             Thank you for the contribution. If you are waiting on a review from
             a maintainer, a comment here is enough to keep this open.
 
-            To keep it open, do any one of these:
+            To keep it open, push a commit or leave a comment. That works for
+            everyone, including contributors from outside Grafana.
 
-            - push a commit, or leave a comment
-
-            - remove the `stale` label
-
-            - add the `keep-open` label
+            Maintainers can also remove the `stale` label, or add the
+            `keep-open` label to exempt this pull request from now on. Changing
+            labels needs write access to this repository, so if you do not have
+            it, ask for it in a comment.
 
             Closing is not final. The branch is kept, so a closed pull request
             can be reopened at any time.
@@ -97,13 +97,18 @@ jobs:
           #
           # Closing a Renovate PR would drop that version update silently,
           # because renovate.json does not set recreateWhen. `dependencies` is
-          # the label renovate.json now applies to every PR it opens.
+          # the label renovate.json now applies to every PR it opens. It is set
+          # there with `addLabels`, not `labels`, on purpose: `labels` is
+          # non-mergeable, so the `labels` under `vulnerabilityAlerts` would
+          # replace it and a security PR would arrive without `dependencies`.
           # update-major is listed as well: major bumps are the ones most likely
           # to sit unreviewed, and they only gained `dependencies` from
           # renovate.json in this change, so older ones do not carry it.
           #
           # automerge-security-update, security-needs-review and 1.security are
-          # the labels security PRs carry in this repository. There are also
+          # the labels security PRs carry in this repository. They come from
+          # Grafana-wide automation rather than from renovate.json, so they are
+          # a second line of defence, not the first one. There are also
           # severity:* labels, deliberately not listed: the security labels
           # above already cover every security PR, and exempting only some
           # severities would be an inconsistent half-set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,11 @@
 - After applying fixes, run `yarn quality:lint` and the tests relevant to the changed files.
 - If the fixer changes files outside the task scope, do not silently include or discard those
   changes. Report them to the user.
+
+## Pull requests
+
+- A pull request with no activity for 60 days is labelled `stale` and closed 14 days later. Any
+  activity resets the clock, and the `keep-open` label exempts a pull request completely. Drafts are
+  included. See [docs/PULL_REQUESTS.md](docs/PULL_REQUESTS.md).
+- The exempt label list in `.github/workflows/stale.yml` is the single source of truth. Do not
+  duplicate it elsewhere.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ See [quick start for web applications][faro-quick-start].
 Contributing to the SDK? See [local development][faro-local-dev] for the three supported paths:
 the in-repo smoke harness, your own Grafana Cloud free-tier stack, or a local Alloy install.
 
+[Pull requests][faro-pull-requests] explains how pull requests work here, including the automation
+that closes a pull request after 60 days without activity and how to keep one open.
+
 ## Packages
 
 ### Core
@@ -55,6 +58,7 @@ the [README.md][faro-web-sdk-readme] for more information.
 [faro-core-readme]: ./packages/core/README.md
 [faro-demo]: https://github.com/grafana/quickpizza
 [faro-local-dev]: ./docs/sources/developer/local-development.md
+[faro-pull-requests]: ./docs/PULL_REQUESTS.md
 [faro-quick-start]: ./docs/sources/tutorials/quick-start-browser.md
 [faro-react]: ./packages/react
 [faro-react-readme]: ./packages/react/README.md

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Contributing to the SDK? See [local development][faro-local-dev] for the three s
 the in-repo smoke harness, your own Grafana Cloud free-tier stack, or a local Alloy install.
 
 [Pull requests][faro-pull-requests] explains how pull requests work here, including the automation
-that closes a pull request after 60 days without activity and how to keep one open.
+that labels a pull request `stale` after 60 days without activity, closes it 14 days after that, and
+how to keep one open.
 
 ## Packages
 

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -1,0 +1,41 @@
+# Pull Requests
+
+How pull requests work in this repository. For local setup, see
+[local-development.md](./sources/developer/local-development.md).
+
+## Inactive pull requests
+
+A pull request with no activity for a long time is closed automatically. The
+[Stale PRs workflow](../.github/workflows/stale.yml) runs once a day and works
+like this:
+
+1. After **60 days** with no activity, it adds the `stale` label and writes a
+   comment on the pull request. You get a notification, because you are
+   subscribed to your own pull request.
+2. **14 days later**, it closes the pull request.
+
+Closing is not final. The branch is kept, so you can reopen the pull request at
+any time and continue where you stopped.
+
+Draft pull requests are included. A draft that nobody has touched for two months
+is treated the same as any other pull request.
+
+### How to keep a pull request open
+
+Any one of these is enough:
+
+- Leave a comment, or push a commit. Any activity removes the label and starts
+  the 60 days again.
+- Remove the `stale` label.
+- Add the `keep-open` label. Use this for work that is meant to stay open for a
+  long time, for example a proposal that is waiting on a decision. The workflow
+  then leaves the pull request alone.
+
+If you are waiting for a review from a maintainer, a comment on the pull request
+is enough to keep it open. Please do not let a contribution close only because
+the review took a while.
+
+Some pull requests are never closed by the workflow. Renovate pull requests are
+exempt, because closing one would drop that dependency update without telling
+anyone. Security pull requests and the automated release pull request are exempt
+as well. The full list is the `exempt-pr-labels` option in the workflow file.

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -22,18 +22,22 @@ is treated the same as any other pull request.
 
 ### How to keep a pull request open
 
-Any one of these is enough:
-
-- Leave a comment, or push a commit. Any activity removes the label and starts
-  the 60 days again.
-- Remove the `stale` label.
-- Add the `keep-open` label. Use this for work that is meant to stay open for a
-  long time, for example a proposal that is waiting on a decision. The workflow
-  then leaves the pull request alone.
+**Anyone, including contributors from outside Grafana:** leave a comment, or
+push a commit. Any activity removes the label and starts the 60 days again. This
+is all you need to do.
 
 If you are waiting for a review from a maintainer, a comment on the pull request
 is enough to keep it open. Please do not let a contribution close only because
 the review took a while.
+
+**Maintainers**, or anyone else with write access to this repository, have two
+more options. Changing labels needs that access, so if you do not have it, ask
+for one of these in a comment:
+
+- Remove the `stale` label.
+- Add the `keep-open` label. Use this for work that is meant to stay open for a
+  long time, for example a proposal that is waiting on a decision. The workflow
+  then leaves the pull request alone.
 
 Some pull requests are never closed by the workflow. Renovate pull requests are
 exempt, because closing one would drop that dependency update without telling


### PR DESCRIPTION
## Why

Nothing in this repository reacts to a pull request that is abandoned. Open pull
requests stay open until a maintainer cleans them up by hand. Sibling
repositories already automate this, most recently
[app-o11y-kwl#3930](https://github.com/grafana/app-o11y-kwl/pull/3930), which
this change is based on.

Two things are different here, and they shape every setting below:

1. **This repository is public.** Most idle pull requests are community
   contributions, and the wait is often on maintainer review rather than on the
   contributor. The timings are therefore longer than in `app-o11y-kwl`
   (60 + 14 days instead of 30 + 7), and the messages are written for an outside
   reader.
2. **There is no Slack digest here.** The `app-o11y-kwl` change also added an
   "Inactive, closing soon" section to `daily-digest.js`. That file does not
   exist in this repository, so that part is dropped.

Please note: on the day this is enabled, it closes nothing. The most idle pull
request today is #2178, last updated on 21 July 2026, which is 22 days idle. It
reaches the 60 day mark around 19 September 2026 and would be the first one
labelled. Cleaning up the pull requests that are already stale stays a human
job.

## What

A new workflow, `.github/workflows/stale.yml`:

- It runs every day at 09:00 UTC. It can also be started by hand with a
  `dryRun` input that changes nothing.
- After 60 days without activity, it adds the `stale` label and comments on the
  pull request. 14 days later, it closes it. Any activity in between removes the
  label and resets the clock.
- The comment deliberately does not mention the author. A mention makes GitHub
  record `mentioned` and `subscribed` events, and the action removes the label on
  the next run when it sees an event it cannot attribute to labelling, so the
  pull request would never close. The workflow carries a comment explaining this
  so it does not get reintroduced.
- The branch is kept, so a closed pull request can be reopened.
- Draft pull requests are included. A draft that nobody has touched for two
  months is abandoned too. Use the new `keep-open` label to park work in
  progress.
- These labels are never closed: `dependencies`, `update-major`,
  `automerge-security-update`, `security-needs-review`, `1.security`,
  `autorelease: pending`, `keep-open`. Renovate pull requests are exempt because
  closing one would drop that version update silently. `autorelease: pending` is
  the release-please pull request (#2203), which is meant to stay open between
  releases.
- Issues are not affected.
- The workflow creates the `stale` and `keep-open` labels itself in a first step.
  When `actions/stale` cannot apply a label, it only writes a log line and
  continues, so a missing label would mean pull requests get comments but are
  never closed.

`.github/renovate.json` now sets a top-level `"addLabels": ["dependencies"]`.
This is required, not cosmetic: Renovate applies no `dependencies` label in this
repository today, so #2225 ("lock file maintenance") carries no labels at all and
`exempt-pr-labels: dependencies` would not protect it.

`addLabels` rather than `labels`, because `labels` is non-mergeable: the `labels`
under `vulnerabilityAlerts` would replace the top-level list, and a security pull
request would arrive without `dependencies`. `addLabels` is mergeable, so every
Renovate pull request now carries an exempt label from this repository's own
configuration instead of relying on Grafana-wide automation.

Documentation: `docs/PULL_REQUESTS.md` is the contributor facing version, linked
from the README. `AGENTS.md` carries the short agent facing version and points at
it. The exempt label list lives in the workflow only, so the policy has one
source of truth.

## How to test

1. `actionlint .github/workflows/stale.yml`
2. `yarn quality:lint`
3. After merge, do a rehearsal that changes nothing:
   `gh workflow run "Stale PRs" -f dryRun=true`, then `gh run view --log`.
   Expected today: no pull request is labelled, and the Renovate and
   release-please pull requests are reported as skipped.

## Links

Two follow-ups that are deliberately not in this pull request:

1. Renovate labels only apply to pull requests it creates from now on, so #2225
   needs the `dependencies` label added by hand once, or it needs to be
   recreated. #2215 is already covered by the labels it carries.
2. `renovate.json` sets `vulnerabilityAlerts.labels: ["security"]`, but this
   repository has no `security` label. It has `1.security`. That looks like a
   real bug and deserves its own pull request, so the exempt list above names
   the labels security pull requests actually carry instead.

The exempt list also names the labels security pull requests carry. Those come
from Grafana-wide automation rather than from this repository, so with the
`addLabels` fix above they are a second line of defence rather than the first
one.

A cross-model review of this pull request (OpenAI GPT-5.6 as reviewer) raised
three findings, all accepted and fixed in the second commit: the `labels` versus
`addLabels` problem above, contributor-facing instructions that told authors to
change labels when contributors from outside Grafana cannot, and a README
sentence that said a pull request closes after 60 days when it closes after 74.

## Checklist

- [ ] Tests added — not applicable, this is a workflow and documentation change
- [ ] Changelog updated — release-please generates the changelog
- [x] Documentation updated

