### PR TITLE
fix(web-sdk): remove the CSP listener that destroy left attached

### DIFF
--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
@@ -64,8 +64,12 @@ describe('CSPInstrumentation', () => {
     expect(attributes?.['sample']).toBe('alert("xss")');
   });
 
-  it('ensures listener gets removed on teardown', () => {
+  it('removes the same listener reference that it registered on teardown', () => {
+    // removeEventListener matches listeners by identity, so asserting only that it was called is not
+    // enough: passing it a different function object than the one registered removes nothing and
+    // leaves the instrumentation reporting after teardown.
     const mockTransport = new MockTransport();
+    const addSpy = jest.spyOn(document, 'addEventListener');
     const removeSpy = jest.spyOn(document, 'removeEventListener');
 
     const instrumentation = new CSPInstrumentation();
@@ -79,7 +83,13 @@ describe('CSPInstrumentation', () => {
     );
     faro.internalLogger.warn = jest.fn();
 
+    const registered = addSpy.mock.calls.find(([type]) => type === 'securitypolicyviolation')?.[1];
+
     faro.instrumentations.remove(instrumentation);
-    expect(removeSpy).toHaveBeenCalledWith('securitypolicyviolation', instrumentation.securitypolicyviolationHandler);
+
+    const removed = removeSpy.mock.calls.find(([type]) => type === 'securitypolicyviolation')?.[1];
+
+    expect(registered).toBeDefined();
+    expect(removed).toBe(registered);
   });
 });

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
@@ -5,16 +5,23 @@ export class CSPInstrumentation extends BaseInstrumentation implements Instrumen
   readonly name = '@grafana/faro-web-sdk:instrumentation-csp';
   readonly version = VERSION;
 
+  // Bound once here rather than in initialize, because removeEventListener matches listeners by
+  // identity. Binding inside initialize created a new function object every time, so the listener
+  // destroy tried to remove was never the one that had been registered: it stayed attached and kept
+  // reporting violations after the instrumentation had been removed.
+  private readonly boundSecuritypolicyviolationHandler: (ev: SecurityPolicyViolationEvent) => void =
+    this.securitypolicyviolationHandler.bind(this);
+
   constructor() {
     super();
   }
 
   initialize() {
-    document.addEventListener('securitypolicyviolation', this.securitypolicyviolationHandler.bind(this));
+    document.addEventListener('securitypolicyviolation', this.boundSecuritypolicyviolationHandler);
   }
 
   destroy() {
-    document.removeEventListener('securitypolicyviolation', this.securitypolicyviolationHandler);
+    document.removeEventListener('securitypolicyviolation', this.boundSecuritypolicyviolationHandler);
   }
 
   public securitypolicyviolationHandler(ev: SecurityPolicyViolationEvent) {


### PR DESCRIPTION
## Why

`CSPInstrumentation` never removed its event listener on teardown, so it kept reporting content
security policy violations after it had been removed.

`initialize` registered `this.securitypolicyviolationHandler.bind(this)`. `.bind()` returns a new
function object every time it is called, and `destroy` passed the unbound method to
`removeEventListener`, which matches listeners by identity. So teardown asked the browser to remove a
function that had never been registered, and the real listener stayed attached.

This is reachable rather than theoretical:

- The instrumentation is enabled by default. `getWebInstrumentations()` adds it unless
  `enableContentSecurityPolicyInstrumentation: false` is passed.
- Removal is a public API. `faro.instrumentations.remove()` calls `destroy()` and then splices the
  object out of an array without tearing it down, so the orphaned handler still holds a live `api` and
  carries on calling `pushEvent`.
- The payload is not purely technical. A violation report includes `sample`, which can carry a snippet
  of the blocked inline script, alongside `sourceFile` and `blockedURI`. Anyone who switched CSP
  reporting off at run time was still sending that.

The limit on severity, stated plainly: reaching it needs `faro.instrumentations.remove()` at run time,
which is a niche API. Disabling CSP reporting through configuration never registers a listener, so
that path was never affected.

## What

The handler is bound once into a private field, and the same reference is passed to both
`addEventListener` and `removeEventListener`.

The test that covered teardown asserted that `removeEventListener` had been called with the *unbound*
method, which is the bug written down as the expectation, and that is why it passed for so long. It now
asserts the invariant that matters: the listener removed is the same object that was registered.
Verified red then green on this branch. Against the old implementation the test reports a registered
`[Function bound securitypolicyviolationHandler]` against a removed
`[Function securitypolicyviolationHandler]`.

Found by the automated reviewer on #2229, where the same fix currently also sits. It is split out here
so that it lands in the changelog as a bug fix, which a `build:` titled pull request would not do.

## Links

- #2229, the build change that surfaced it

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated

The changelog is generated by release-please from the commit messages. No documentation changes are
needed, because no documented behaviour changes: teardown now does what it already claimed to do.
