### PR TITLE
fix(web-sdk): prevent CSP listener leak with stable handler reference

### DIFF
--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
@@ -66,6 +66,7 @@ describe('CSPInstrumentation', () => {
 
   it('ensures listener gets removed on teardown', () => {
     const mockTransport = new MockTransport();
+    const addSpy = jest.spyOn(document, 'addEventListener');
     const removeSpy = jest.spyOn(document, 'removeEventListener');
 
     const instrumentation = new CSPInstrumentation();
@@ -79,7 +80,16 @@ describe('CSPInstrumentation', () => {
     );
     faro.internalLogger.warn = jest.fn();
 
+    const addCall = addSpy.mock.calls.find(([eventName]) => eventName === 'securitypolicyviolation');
+    const addedListener = addCall?.[1] as EventListener | undefined;
+
     faro.instrumentations.remove(instrumentation);
-    expect(removeSpy).toHaveBeenCalledWith('securitypolicyviolation', instrumentation.securitypolicyviolationListener);
+
+    const removeCall = removeSpy.mock.calls.find(([eventName]) => eventName === 'securitypolicyviolation');
+    const removedListener = removeCall?.[1] as EventListener | undefined;
+
+    expect(addedListener).toBeDefined();
+    expect(removedListener).toBeDefined();
+    expect(removedListener).toBe(addedListener);
   });
 });

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.test.ts
@@ -80,6 +80,6 @@ describe('CSPInstrumentation', () => {
     faro.internalLogger.warn = jest.fn();
 
     faro.instrumentations.remove(instrumentation);
-    expect(removeSpy).toHaveBeenCalledWith('securitypolicyviolation', instrumentation.securitypolicyviolationHandler);
+    expect(removeSpy).toHaveBeenCalledWith('securitypolicyviolation', instrumentation.securitypolicyviolationListener);
   });
 });

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
@@ -4,17 +4,18 @@ import type { Instrumentation } from '@grafana/faro-core';
 export class CSPInstrumentation extends BaseInstrumentation implements Instrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-csp';
   readonly version = VERSION;
+  readonly securitypolicyviolationListener = this.securitypolicyviolationHandler.bind(this);
 
   constructor() {
     super();
   }
 
   initialize() {
-    document.addEventListener('securitypolicyviolation', this.securitypolicyviolationHandler.bind(this));
+    document.addEventListener('securitypolicyviolation', this.securitypolicyviolationListener);
   }
 
   destroy() {
-    document.removeEventListener('securitypolicyviolation', this.securitypolicyviolationHandler);
+    document.removeEventListener('securitypolicyviolation', this.securitypolicyviolationListener);
   }
 
   public securitypolicyviolationHandler(ev: SecurityPolicyViolationEvent) {

--- a/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/csp/instrumentation.ts
@@ -4,7 +4,7 @@ import type { Instrumentation } from '@grafana/faro-core';
 export class CSPInstrumentation extends BaseInstrumentation implements Instrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-csp';
   readonly version = VERSION;
-  readonly securitypolicyviolationListener = this.securitypolicyviolationHandler.bind(this);
+  private readonly securitypolicyviolationListener = this.securitypolicyviolationHandler.bind(this);
 
   constructor() {
     super();


### PR DESCRIPTION
## Why

`securitypolicyviolation` listener registration used `bind(this)` inline, but teardown attempted to remove a different function reference. Because `removeEventListener` requires the exact same callback reference, listeners could remain attached across re-initialization cycles, increasing memory usage and duplicate handler work over time.

## What

- Added a stable `securitypolicyviolationListener` reference in CSP instrumentation.
- Updated listener registration/removal to use the same function reference.
- Updated CSP teardown test to assert removal with the stable listener reference.

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
