### PR TITLE
fix(user-actions): trigger user actions from clicks on nested child elements

### DIFF
--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
@@ -55,6 +55,11 @@ describe('Utility functions', () => {
     expect(result).toBeUndefined();
   });
 
+  it('getUserActionNameFromElement returns undefined when the element is null', () => {
+    const result = getUserActionNameFromElement(null, defaultDataAttribute);
+    expect(result).toBeUndefined();
+  });
+
   it('unsubscribeAllMonitors calls unsubscribe on subscription', () => {
     const sub: Subscription = { unsubscribe: jest.fn() };
     unsubscribeAllMonitors(sub);
@@ -114,6 +119,32 @@ describe('getUserEventHandler', () => {
     processUserEvent(event);
 
     expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'click' });
+  });
+
+  it('finds the data attribute on an ancestor when the event target is a nested child element', () => {
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+
+    const button = document.createElement('button');
+    button.setAttribute('data-foo-bar', 'save');
+    const span = document.createElement('span');
+    span.textContent = 'Save';
+    button.appendChild(span);
+
+    processUserEvent({ type: 'click', target: span } as unknown as PointerEvent);
+
+    expect(startSpy).toHaveBeenCalledWith('save', {}, { triggerName: 'click' });
+  });
+
+  it('does not start a user action when no ancestor has the data attribute', () => {
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+
+    const wrapper = document.createElement('div');
+    const span = document.createElement('span');
+    wrapper.appendChild(span);
+
+    processUserEvent({ type: 'click', target: span } as unknown as PointerEvent);
+
+    expect(startSpy).not.toHaveBeenCalled();
   });
 
   it('passes the element initial activity timeout to the user action start message', () => {

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.test.ts
@@ -181,6 +181,17 @@ describe('getUserEventHandler', () => {
     expect(startSpy).toHaveBeenCalledWith('my-action', {}, { triggerName: 'pointerdown', initialActivityTimeout: NaN });
   });
 
+  it('does not throw when the configured data attribute name contains CSS selector special characters', () => {
+    faro.config!.userActionsInstrumentation!.dataAttributeName = 'data-foo]';
+    const { processUserEvent } = getUserEventHandler(faro as Faro);
+
+    const element = document.createElement('div');
+    const event = { type: 'click', target: element } as unknown as PointerEvent;
+
+    expect(() => processUserEvent(event)).not.toThrow();
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
   it('does not start a new action if one already exists', () => {
     getCurrentSpy.mockReturnValue(fakeAction);
     const { processUserEvent } = getUserEventHandler(faro as Faro);

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -6,6 +6,7 @@ import { UserActionController } from './userActionController';
 import {
   convertDataAttributeName,
   deriveUserActionTimeoutDataAttribute,
+  normalizeDataAttributeName,
   normalizeInitialActivityTimeout,
   type TimeoutWarning,
 } from './util';
@@ -25,12 +26,14 @@ export function getUserEventHandler(
   );
 
   function processUserEvent(event: PointerEvent | KeyboardEvent): void {
-    const element = event.target as HTMLElement;
     const dataAttributeName = config.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute;
+    const element = (event.target as HTMLElement).closest(
+      `[${normalizeDataAttributeName(dataAttributeName)}]`
+    ) as HTMLElement | null;
     const userActionName = getUserActionNameFromElement(element, dataAttributeName);
 
-    // We don't have a data attribute
-    if (!userActionName) {
+    // We don't have a matching element or data attribute
+    if (!element || !userActionName) {
       return;
     }
 
@@ -56,7 +59,14 @@ export function getUserActionTimeoutFromElement(element: HTMLElement, dataAttrib
   return value === null ? undefined : Number(value);
 }
 
-export function getUserActionNameFromElement(element: HTMLElement, dataAttributeName: string): string | undefined {
+export function getUserActionNameFromElement(
+  element: HTMLElement | null,
+  dataAttributeName: string
+): string | undefined {
+  if (!element) {
+    return undefined;
+  }
+
   const parsedDataAttributeName = convertDataAttributeName(dataAttributeName);
   const dataset = element.dataset;
 

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -27,9 +27,13 @@ export function getUserEventHandler(
 
   function processUserEvent(event: PointerEvent | KeyboardEvent): void {
     const dataAttributeName = config.userActionsInstrumentation?.dataAttributeName ?? userActionDataAttribute;
-    const element = (event.target as HTMLElement).closest(
-      `[${normalizeDataAttributeName(dataAttributeName)}]`
-    ) as HTMLElement | null;
+
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const element = target.closest(`[${normalizeDataAttributeName(dataAttributeName)}]`) as HTMLElement | null;
     const userActionName = getUserActionNameFromElement(element, dataAttributeName);
 
     // We don't have a matching element or data attribute

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -33,7 +33,7 @@ export function getUserEventHandler(
       return;
     }
 
-    const element = target.closest(`[${normalizeDataAttributeName(dataAttributeName)}]`) as HTMLElement | null;
+    const element = findClosestElementWithAttribute(target, normalizeDataAttributeName(dataAttributeName));
     const userActionName = getUserActionNameFromElement(element, dataAttributeName);
 
     // We don't have a matching element or data attribute
@@ -56,6 +56,19 @@ export function getUserEventHandler(
   }
 
   return { processUserEvent, processUserActionStarted };
+}
+
+export function findClosestElementWithAttribute(element: Element, attributeName: string): HTMLElement | null {
+  let current: Element | null = element;
+
+  while (current) {
+    if (current.hasAttribute(attributeName)) {
+      return current as HTMLElement;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
 }
 
 export function getUserActionTimeoutFromElement(element: HTMLElement, dataAttributeName: string): number | undefined {

--- a/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
+++ b/packages/web-sdk/src/instrumentations/userActions/processUserActionEventHandler.ts
@@ -58,7 +58,7 @@ export function getUserEventHandler(
   return { processUserEvent, processUserActionStarted };
 }
 
-export function findClosestElementWithAttribute(element: Element, attributeName: string): HTMLElement | null {
+function findClosestElementWithAttribute(element: Element, attributeName: string): HTMLElement | null {
   let current: Element | null = element;
 
   while (current) {


### PR DESCRIPTION
## Why

data-faro-user-action-name only matched event.target directly. Grafana UI's Button renders
its label inside a span, so a click there never matched the button's attribute and the
action was silently dropped - the report is exactly this case: `<button data-faro-user-action-name="save"><span>Save</span></button>`.

## What

processUserEvent now walks up with closest() to find the attribute on an ancestor, not just
the exact click target. That surfaced two more bugs on the way, so I fixed all three:

- closest() returns null when nothing matches - the old code read element.dataset directly,
  so every untracked click threw.
- the closest() selector was built from the raw config value instead of the normalized
  data- attribute, so a camelCase dataAttributeName config never matched anything.
- getUserActionNameFromElement now accepts a null element and returns undefined instead of
  throwing.

Added tests for the nested-element case, the no-ancestor case, and null handling.

## Links

<!-- link the report/issue about the Grafana UI Button case -->

## Checklist

- [x] Tests added
- [x] Changelog updated
- [ ] Documentation updated
