### PR TITLE
fix: remove instrumentations regardless of position

### DIFF
--- a/packages/core/src/instrumentations/initialize.test.ts
+++ b/packages/core/src/instrumentations/initialize.test.ts
@@ -1,0 +1,69 @@
+import type { API } from '../api';
+import type { Metas } from '../metas';
+import { mockConfig } from '../testUtils/mockConfig';
+import { mockInternalLogger } from '../testUtils/mockInternalLogger';
+import type { Transports } from '../transports';
+
+import { BaseInstrumentation } from './base';
+import { initializeInstrumentations } from './initialize';
+
+class MockInstrumentation extends BaseInstrumentation {
+  readonly version = '1.0.0';
+
+  initialize = jest.fn();
+  destroy = jest.fn();
+
+  constructor(readonly name: string) {
+    super();
+  }
+}
+
+function createInstrumentations() {
+  return initializeInstrumentations(
+    console,
+    mockInternalLogger,
+    mockConfig(),
+    {} as Metas,
+    {} as Transports,
+    {} as API
+  );
+}
+
+function createMockInstrumentations() {
+  return ['A', 'B', 'C'].map((name) => new MockInstrumentation(name));
+}
+
+describe('instrumentations', () => {
+  describe('remove', () => {
+    it.each([
+      [0, ['B', 'C']],
+      [1, ['A', 'C']],
+      [2, ['A', 'B']],
+    ])('removes an instrumentation at index %i', (index, expectedNames) => {
+      const mockInstrumentations = createMockInstrumentations();
+      const instrumentations = createInstrumentations();
+      const instrumentationToRemove = mockInstrumentations[index]!;
+
+      instrumentations.add(...mockInstrumentations);
+      instrumentations.remove(instrumentationToRemove);
+
+      expect(instrumentations.instrumentations.map(({ name }) => name)).toEqual(expectedNames);
+      expect(instrumentationToRemove.destroy).toHaveBeenCalledTimes(1);
+
+      mockInstrumentations
+        .filter((instrumentation) => instrumentation !== instrumentationToRemove)
+        .forEach((instrumentation) => expect(instrumentation.destroy).not.toHaveBeenCalled());
+    });
+
+    it('removes multiple instrumentations in the order provided', () => {
+      const mockInstrumentations = createMockInstrumentations();
+      const instrumentations = createInstrumentations();
+
+      instrumentations.add(...mockInstrumentations);
+      instrumentations.remove(...mockInstrumentations);
+
+      expect(instrumentations.instrumentations).toEqual([]);
+      mockInstrumentations.forEach((instrumentation) => expect(instrumentation.destroy).toHaveBeenCalledTimes(1));
+    });
+  });
+});

--- a/packages/core/src/instrumentations/initialize.ts
+++ b/packages/core/src/instrumentations/initialize.ts
@@ -54,18 +54,11 @@ export function initializeInstrumentations(
     instrumentationsToRemove.forEach((instrumentationToRemove) => {
       internalLogger.debug(`Removing "${instrumentationToRemove.name}" instrumentation`);
 
-      const existingInstrumentationIndex = instrumentations.reduce<number | null>(
-        (acc, existingInstrumentation, existingTransportIndex) => {
-          if (acc === null && existingInstrumentation.name === instrumentationToRemove.name) {
-            return existingTransportIndex;
-          }
-
-          return null;
-        },
-        null
+      const existingInstrumentationIndex = instrumentations.findIndex(
+        (existingInstrumentation) => existingInstrumentation.name === instrumentationToRemove.name
       );
 
-      if (existingInstrumentationIndex === null) {
+      if (existingInstrumentationIndex === -1) {
         internalLogger.warn(`Instrumentation "${instrumentationToRemove.name}" is not added`);
 
         return;


### PR DESCRIPTION
## Why

`Instrumentations.remove()` uses a reducer that resets a previously found index when a later instrumentation does not match. Because of that, removing an instrumentation only works when it is the last item in the array, or when multiple removals are supplied in reverse order.

## What

- Replace the reducer-based lookup with `findIndex`, so a matching instrumentation can be removed from any position.
- Add regression coverage for removing the first, middle, and last instrumentation.
- Cover multiple instrumentations removed in forward order and verify that `destroy()` runs exactly once for every removed instrumentation.

## Links

Closes #2235

## Testing

The regression test was first run against the unchanged implementation: 3 cases failed and only the last-position removal passed. After the fix:

- Focused regression suite: 4 tests passed
- Full `@grafana/faro-core` suite: 188 tests passed
- Core package build passed
- Core TypeScript check passed
- ESLint passed for both changed files
- Prettier check passed for both changed files

## Checklist

- [x] Tests added
- [ ] Changelog updated — release-please generates the changelog from commit messages
- [ ] Documentation updated — no documentation changes are needed for this internal bug fix