### PR TITLE
feat(web-tracing): omit trace context for unsampled sessions

### DIFF
--- a/docs/sources/tutorials/quick-start-browser.md
+++ b/docs/sources/tutorials/quick-start-browser.md
@@ -235,6 +235,48 @@ const faro = initializeFaro({
 });
 ```
 
+### With session sampling below 100%
+
+Session sampling is all or nothing per session. When a session is not part of the sample, Faro
+discards every signal it produces in the browser. The fetch and XMLHttpRequest instrumentations
+still add a `traceparent` header to outgoing requests, but that header carries the unsampled flag
+`00`.
+
+Backend OpenTelemetry SDKs use the `parentbased_always_on` sampler by default, which honors an
+unsampled parent and drops the server span. Lowering `sessionTracking.samplingRate` therefore also
+removes traces from your backend services, not only from the browser.
+
+Set `omitTraceContextForUnsampledSessions` to leave the header off entirely for unsampled sessions,
+so each backend service applies its own sampling rules to those requests.
+
+```ts
+import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
+import { TracingInstrumentation } from '@grafana/faro-web-tracing';
+
+const faro = initializeFaro({
+  url: 'http://localhost:12345/collect',
+  apiKey: 'secret',
+  sessionTracking: {
+    samplingRate: 0.1, // 10% of sessions send frontend signals
+  },
+  instrumentations: [
+    ...getWebInstrumentations(),
+    new TracingInstrumentation({ omitTraceContextForUnsampledSessions: true }),
+  ],
+  app: {
+    name: 'frontend',
+    version: '1.0.0',
+  },
+});
+```
+
+Requests from an unsampled session then begin a new trace on the backend instead of joining the
+browser's, so those traces are recorded but no longer link back to the frontend. The frontend side
+of that link would have pointed at browser data Faro already discarded.
+
+This option defaults to `false` to preserve existing behavior, and is expected to become the default
+in the next major version.
+
 ### With custom OpenTelemetry tracing configuration
 
 The following example, demonstrates how to configure OpenTelemetry

--- a/packages/web-tracing/src/faroPausablePropagator.test.ts
+++ b/packages/web-tracing/src/faroPausablePropagator.test.ts
@@ -2,7 +2,10 @@ import { ROOT_CONTEXT, trace, TraceFlags } from '@opentelemetry/api';
 import type { TextMapPropagator } from '@opentelemetry/api';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
 
+import type { MetaSession } from '@grafana/faro-web-sdk';
+
 import { FaroPausablePropagator } from './faroPausablePropagator';
+import { isSessionSampled } from './sampler';
 
 describe('FaroPausablePropagator', () => {
   let paused: boolean;
@@ -85,5 +88,79 @@ describe('FaroPausablePropagator', () => {
     w3c.inject(contextWithSpan, pausedCarrier, setter);
 
     expect(pausedCarrier).toEqual({});
+  });
+});
+
+describe('FaroPausablePropagator / unsampled sessions', () => {
+  // The span context is deliberately SAMPLED: an unsampled Faro session still produces a span
+  // context, and today it is that context which gets injected as a `traceparent` ending in `00`.
+  const contextWithSpan = trace.setSpanContext(ROOT_CONTEXT, {
+    traceId: '0af7651916cd43dd8448eb211c80319c',
+    spanId: 'b7ad6b7169203331',
+    traceFlags: TraceFlags.SAMPLED,
+  });
+
+  const setter = {
+    set: (carrier: Record<string, string>, key: string, value: string) => {
+      carrier[key] = value;
+    },
+  };
+
+  function injectInto(propagator: TextMapPropagator): Record<string, string> {
+    const carrier: Record<string, string> = {};
+    propagator.inject(contextWithSpan, carrier, setter);
+
+    return carrier;
+  }
+
+  it('withholds the traceparent header while the session is not part of the sample', () => {
+    let session: MetaSession = { attributes: { isSampled: 'false' } };
+    const propagator = new FaroPausablePropagator(new W3CTraceContextPropagator(), () => !isSessionSampled(session));
+
+    expect(injectInto(propagator)).toEqual({});
+
+    session = { attributes: { isSampled: 'true' } };
+
+    expect(injectInto(propagator)['traceparent']).toBe('00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01');
+  });
+
+  it('injects only when Faro is neither paused nor running an unsampled session', () => {
+    let paused = false;
+    let session: MetaSession = {};
+
+    // Mirrors the predicate TracingInstrumentation builds with
+    // omitTraceContextForUnsampledSessions enabled.
+    const propagator = new FaroPausablePropagator(
+      new W3CTraceContextPropagator(),
+      () => paused || !isSessionSampled(session)
+    );
+
+    const injected = ([sampled, isPaused]: [boolean, boolean]) => {
+      session = { attributes: { isSampled: String(sampled) } };
+      paused = isPaused;
+
+      return 'traceparent' in injectInto(propagator);
+    };
+
+    expect(injected([true, false])).toBe(true);
+    expect(injected([true, true])).toBe(false);
+    expect(injected([false, false])).toBe(false);
+    expect(injected([false, true])).toBe(false);
+  });
+
+  it('delegates fields whether or not the trace context is withheld', () => {
+    let session: MetaSession = { attributes: { isSampled: 'true' } };
+    const delegate: jest.Mocked<TextMapPropagator> = {
+      inject: jest.fn(),
+      extract: jest.fn((context, _carrier, _getter) => context),
+      fields: jest.fn(() => ['traceparent', 'tracestate']),
+    };
+    const propagator = new FaroPausablePropagator(delegate, () => !isSessionSampled(session));
+
+    expect(propagator.fields()).toEqual(['traceparent', 'tracestate']);
+
+    session = { attributes: { isSampled: 'false' } };
+
+    expect(propagator.fields()).toEqual(['traceparent', 'tracestate']);
   });
 });

--- a/packages/web-tracing/src/faroPausablePropagator.ts
+++ b/packages/web-tracing/src/faroPausablePropagator.ts
@@ -1,22 +1,26 @@
 import type { Context, TextMapGetter, TextMapPropagator, TextMapSetter } from '@opentelemetry/api';
 
 /**
- * Wraps a propagator so that no trace context is written onto outgoing requests while Faro is
- * paused. Pausing already stops signals from being sent, but the OTel propagator is registered
- * globally and kept injecting `traceparent`, which made a paused SDK look like it was still
- * tracking. See https://github.com/grafana/faro-web-sdk/issues/710.
+ * Wraps a propagator so that no trace context is written onto outgoing requests while Faro is not
+ * emitting signals for the current session. Faro withholds it for two reasons:
  *
- * Extraction stays enabled while paused: reading an incoming trace context sends nothing, and
- * dropping it would detach a resumed session from the trace it belongs to.
+ * - Faro is paused. Pausing already stops signals from being sent, but the OTel propagator is
+ *   registered globally and kept injecting `traceparent`, which made a paused SDK look like it was
+ *   still tracking. See https://github.com/grafana/faro-web-sdk/issues/710.
+ * - The session is not part of the sample and `omitTraceContextForUnsampledSessions` is enabled.
+ *   See https://github.com/grafana/faro-web-sdk/issues/2250.
+ *
+ * Extraction stays enabled in both cases: reading an incoming trace context sends nothing, and
+ * dropping it would detach a resumed or later-sampled session from the trace it belongs to.
  */
 export class FaroPausablePropagator implements TextMapPropagator {
   constructor(
     private readonly propagator: TextMapPropagator,
-    private readonly isPaused: () => boolean
+    private readonly shouldOmitTraceContext: () => boolean
   ) {}
 
   inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
-    if (this.isPaused()) {
+    if (this.shouldOmitTraceContext()) {
       return;
     }
 

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -18,7 +18,7 @@ import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcess
 import { FaroPausablePropagator } from './faroPausablePropagator';
 import { FaroTraceExporter } from './faroTraceExporter';
 import { getDefaultOTELInstrumentations } from './getDefaultOTELInstrumentations';
-import { getSamplingDecision } from './sampler';
+import { getSamplingDecision, isSessionSampled } from './sampler';
 import {
   ATTR_BROWSER_BRANDS,
   ATTR_BROWSER_LANGUAGE,
@@ -126,10 +126,14 @@ export class TracingInstrumentation extends BaseInstrumentation {
       ],
     });
 
+    const omitForUnsampledSessions = options.omitTraceContextForUnsampledSessions === true;
+
     provider.register({
-      // wrapped so that pausing Faro also stops trace context from being injected into requests
-      propagator: new FaroPausablePropagator(options.propagator ?? new W3CTraceContextPropagator(), () =>
-        this.transports.isPaused()
+      // wrapped so that pausing Faro, or running an unsampled session, also stops trace context
+      // from being injected into requests
+      propagator: new FaroPausablePropagator(
+        options.propagator ?? new W3CTraceContextPropagator(),
+        () => this.transports.isPaused() || (omitForUnsampledSessions && !isSessionSampled(this.api.getSession()))
       ),
       contextManager: options.contextManager,
     });

--- a/packages/web-tracing/src/sampler.test.ts
+++ b/packages/web-tracing/src/sampler.test.ts
@@ -1,6 +1,24 @@
 import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
 
-import { getSamplingDecision } from './sampler';
+import { getSamplingDecision, isSessionSampled } from './sampler';
+
+describe('isSessionSampled', () => {
+  it('is true when the session carries the sampled attribute', () => {
+    expect(isSessionSampled({ attributes: { isSampled: 'true' } })).toBe(true);
+  });
+
+  it('is false when the session is not part of the sample', () => {
+    expect(isSessionSampled({ attributes: { isSampled: 'false' } })).toBe(false);
+  });
+
+  it('is false when the session carries no attributes', () => {
+    expect(isSessionSampled({ id: 'abc' })).toBe(false);
+  });
+
+  it('is false when there is no session at all', () => {
+    expect(isSessionSampled()).toBe(false);
+  });
+});
 
 describe('Sampler', () => {
   afterEach(() => {

--- a/packages/web-tracing/src/sampler.ts
+++ b/packages/web-tracing/src/sampler.ts
@@ -2,9 +2,14 @@ import { SamplingDecision } from '@opentelemetry/sdk-trace-web';
 
 import type { MetaSession } from '@grafana/faro-web-sdk';
 
+export function isSessionSampled(sessionMeta: MetaSession = {}): boolean {
+  return sessionMeta.attributes?.['isSampled'] === 'true';
+}
+
 export function getSamplingDecision(sessionMeta: MetaSession = {}): SamplingDecision {
-  const isSessionSampled = sessionMeta.attributes?.['isSampled'] === 'true';
-  const samplingDecision = isSessionSampled ? SamplingDecision.RECORD_AND_SAMPLED : SamplingDecision.NOT_RECORD;
+  const samplingDecision = isSessionSampled(sessionMeta)
+    ? SamplingDecision.RECORD_AND_SAMPLED
+    : SamplingDecision.NOT_RECORD;
 
   return samplingDecision;
 }

--- a/packages/web-tracing/src/types.ts
+++ b/packages/web-tracing/src/types.ts
@@ -21,6 +21,26 @@ export interface TracingInstrumentationOptions {
   instrumentations?: InstrumentationOption[];
   spanProcessor?: SpanProcessor;
   instrumentationOptions?: Omit<DefaultInstrumentationsOptions, 'ignoreUrls'>;
+
+  /**
+   * Withhold trace context from outgoing requests while the session is not part of the sample.
+   *
+   * Faro drops every signal for an unsampled session, but the fetch and XHR instrumentations still
+   * inject a `traceparent` carrying the unsampled flag `00`. Backend OTel SDKs default to
+   * `parentbased_always_on`, which honours that flag and drops the server span, so lowering
+   * `sessionTracking.samplingRate` silently removes backend traces too. Omitting the header instead
+   * lets the backend take its own sampling decision.
+   *
+   * The trade-off is that requests from unsampled sessions start a new trace on the backend rather
+   * than joining the browser's, so the frontend-to-backend link is lost. That link would have
+   * pointed at browser data Faro already discarded.
+   *
+   * This skips the whole `inject` call, so a custom `propagator` has *all* the headers it writes
+   * withheld - `tracestate` and `baggage` included - not only `traceparent`.
+   *
+   * @default false - expected to become true in the next major version
+   */
+  omitTraceContextForUnsampledSessions?: boolean;
 }
 
 export type MatchUrlDefinitions = Patterns;


### PR DESCRIPTION
Faro drops every signal for an unsampled session, but the fetch and XHR instrumentations still injected a `traceparent` carrying the unsampled flag `00`. Backend OTel SDKs default to `parentbased_always_on`, which honours that flag and drops the server span, so lowering `sessionTracking.samplingRate` silently removed backend traces too and blocked any backend tail-sampling strategy.

Add an opt-in `omitTraceContextForUnsampledSessions` on `TracingInstrumentationOptions`. When enabled, no trace context is written onto requests from an unsampled session, so each backend service applies its own sampling rules. Defaults to false to preserve current behaviour.

`FaroPausablePropagator` already implemented the whole mechanism -- suppress `inject` while a predicate holds, always delegate `extract` and `fields` -- with nothing pause-specific in it, so both reasons Faro withholds trace context now share that one wrapper rather than nesting a second near-identical propagator. Its constructor parameter is renamed accordingly and the class TSDoc names both reasons.

`isSessionSampled` is lifted out of `getSamplingDecision` so the propagator and the sampler read the same comparison and cannot drift. It stays internal to the package; the option is the whole public interface, so the export surface is unchanged.

Closes #2250