### PR TITLE
feat(replay): preserve recording identity across tab handoffs

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+- Feature (`@grafana/faro-instrumentation-replay`): Add per-tab recording identity, checkpoint
+  generations, and recording-wide sequence numbers. Preserve identity through clean navigation
+  using owner-scoped handoffs, and expose accepted-event serialization failures as sequence gaps.
+  Recover with a new identity after ownership loss, including same-document replacement when
+  the tab pointer cannot be updated.
+
 ## 2.4.0
 
 - Feature (`@grafana/faro-transport-otlp-http`): OTLP HTTP transport now supports async dynamic header values.

--- a/experimental/instrumentation-replay/README.md
+++ b/experimental/instrumentation-replay/README.md
@@ -119,12 +119,6 @@ initializeFaro({
 | ------------ | -------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
 | `beforeSend` | `(event: eventWithTime) => eventWithTime \| null \| undefined` | `undefined` | Transform or filter events before they are sent. Return `null` or `undefined` to skip sending |
 
-Replay reconciles session state before starting, pausing, resuming, or accepting recorder events.
-Synchronous capture keeps that decision consistent through event submission. If `beforeSend` or
-rrweb callbacks such as `maskInputFn` change the session, revoke sampling, or destroy Replay,
-the invalidated attempt's pending events are discarded. Startup publishes nothing until rrweb
-returns a stop function and the attempt remains eligible.
-
 ## Privacy and Security
 
 This instrumentation records user interactions on your website. Make sure to:

--- a/experimental/instrumentation-replay/src/instrumentation.namespace.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.namespace.test.ts
@@ -1,0 +1,107 @@
+import { initializeFaro, type MetaApp } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+import { EventType, type eventWithTime } from '@grafana/rrweb-types';
+
+import { ReplayInstrumentation } from './instrumentation';
+
+jest.mock('@grafana/rrweb', () => {
+  const record = Object.assign(jest.fn(), { takeFullSnapshot: jest.fn() });
+  return { record };
+});
+
+describe('replay handoff owner namespace', () => {
+  let removeRecorders: Array<() => void>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    removeRecorders = [];
+    require('@grafana/rrweb').record.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
+      options.emit({
+        type: EventType.Meta,
+        data: { href: 'https://example.com/', width: 1, height: 1 },
+        timestamp: Date.now(),
+      });
+      return jest.fn();
+    });
+  });
+
+  afterEach(() => {
+    removeRecorders.forEach((remove) => remove());
+    jest.restoreAllMocks();
+  });
+
+  function startOwner(app: MetaApp) {
+    const faro = initializeFaro(mockConfig({ app, globalObjectKey: 'shared-faro' }));
+    faro.api.setSession({ id: 'shared-session', attributes: { isSampled: 'true' } });
+    const pushEvent = jest.spyOn(faro.api, 'pushEvent');
+    const instrumentation = new ReplayInstrumentation();
+    const remove = () => faro.instrumentations.remove(instrumentation);
+    removeRecorders.push(remove);
+    faro.instrumentations.add(instrumentation);
+
+    const replay = pushEvent.mock.calls.find(([name]) => name === 'faro.session_recording.event');
+    expect(replay).toBeDefined();
+    return { attributes: replay![1]!, remove };
+  }
+
+  it.each([
+    [{ name: 'app-a' }, { name: 'app-b' }],
+    [
+      { name: 'app', namespace: 'team-a' },
+      { name: 'app', namespace: 'team-b' },
+    ],
+    [
+      { name: 'app', environment: 'production' },
+      { name: 'app', environment: 'staging' },
+    ],
+  ])('preserves A through an intervening B replacement (%j, %j)', (appA, appB) => {
+    const firstA = startOwner(appA);
+    firstA.remove();
+
+    const ownerB = startOwner(appB);
+    expect(ownerB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
+    ownerB.remove();
+
+    const nextA = startOwner(appA);
+    expect(nextA.attributes).toEqual(
+      expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
+    );
+  });
+
+  it('preserves clean navigation handoffs across application releases without admitting another app', () => {
+    const firstA = startOwner({ name: 'navigation-a', version: '1.0.0', release: 'first' });
+    window.dispatchEvent(new Event('pagehide'));
+    firstA.remove();
+
+    const ownerB = startOwner({ name: 'navigation-b', version: '1.0.0', release: 'first' });
+    expect(ownerB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
+    window.dispatchEvent(new Event('pagehide'));
+    ownerB.remove();
+
+    const nextA = startOwner({ name: 'navigation-a', version: '2.0.0', release: 'second' });
+    expect(nextA.attributes).toEqual(
+      expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
+    );
+  });
+
+  it('keeps concurrently recording owners isolated through a shared navigation', () => {
+    const firstA = startOwner({ name: 'concurrent-a' });
+    const firstB = startOwner({ name: 'concurrent-b' });
+    expect(firstB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
+
+    window.dispatchEvent(new Event('pagehide'));
+    firstA.remove();
+    firstB.remove();
+
+    const nextB = startOwner({ name: 'concurrent-b' });
+    const nextA = startOwner({ name: 'concurrent-a' });
+    expect(nextA.attributes).toEqual(
+      expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
+    );
+    expect(nextB.attributes).toEqual(
+      expect.objectContaining({ recording_id: firstB.attributes['recording_id'], gen: '1', seq: '1' })
+    );
+  });
+});

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -29,6 +29,7 @@ describe('Replay callback and startup safety', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     window.sessionStorage.clear();
+    window.localStorage.clear();
     mockRecord = require('@grafana/rrweb').record;
     mockRecord.mockReset();
     stop = jest.fn();
@@ -46,6 +47,7 @@ describe('Replay callback and startup safety', () => {
     jest.restoreAllMocks();
     document.body.replaceChildren();
     window.sessionStorage.clear();
+    window.localStorage.clear();
     jest.clearAllTimers();
     jest.useRealTimers();
   });

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -11,12 +11,14 @@ import { EventType } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn } from './const';
 import { ReplayInstrumentation } from './instrumentation';
+import { replayRecordingCheckpointKeyPrefix } from './recordingState';
 import { MaskInputFn, ReplayInstrumentationOptions } from './types';
 
 // Mock rrweb
-jest.mock('@grafana/rrweb', () => ({
-  record: jest.fn(),
-}));
+jest.mock('@grafana/rrweb', () => {
+  const record = Object.assign(jest.fn(), { takeFullSnapshot: jest.fn() });
+  return { record };
+});
 
 class BatchedBodyTransport extends BaseTransport {
   readonly name = '@grafana/transport-batched-body-mock';
@@ -44,14 +46,16 @@ function createSeededRandom(seed: number): () => number {
 
 describe('ReplayInstrumentation', () => {
   let instrumentation: ReplayInstrumentation;
-  let mockRecord: jest.Mock;
+  let mockRecord: jest.Mock & { takeFullSnapshot: jest.Mock };
   let mockGetSession: jest.Mock;
   let mockAddListener: jest.Mock;
   let mockPushEvent: jest.Mock;
-  let mockCapture: jest.Mock;
+  const mockCapture = (callback?: () => void) => callback?.();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
     mockRecord = require('@grafana/rrweb').record;
     mockRecord.mockReturnValue(jest.fn());
 
@@ -59,7 +63,6 @@ describe('ReplayInstrumentation', () => {
     mockGetSession = jest.fn();
     mockAddListener = jest.fn();
     mockPushEvent = jest.fn();
-    mockCapture = jest.fn((callback?: () => void) => callback?.());
   });
 
   afterEach(() => {
@@ -68,6 +71,17 @@ describe('ReplayInstrumentation', () => {
       instrumentation.destroy();
     }
   });
+  function initSampled(
+    options: ReplayInstrumentationOptions = {},
+    sessionId: string = 'test-session'
+  ): ReplayInstrumentation {
+    const inst = new ReplayInstrumentation(options);
+    mockGetSession.mockReturnValue({ id: sessionId, attributes: { isSampled: 'true' } });
+    inst['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+    inst['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
+    inst.initialize();
+    return inst;
+  }
 
   describe('constructor', () => {
     it('should have correct name and version', () => {
@@ -351,7 +365,9 @@ describe('ReplayInstrumentation', () => {
 
       instrumentation.initialize();
 
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.started', {});
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.started', {
+        recording_id: expect.any(String),
+      });
     });
 
     it('should not push a faro.session_recording.started event when session is not sampled', () => {
@@ -419,6 +435,9 @@ describe('ReplayInstrumentation', () => {
 
       expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
         event: JSON.stringify(testEvent),
+        recording_id: expect.any(String),
+        gen: '0',
+        seq: '0',
       });
     });
 
@@ -443,6 +462,9 @@ describe('ReplayInstrumentation', () => {
       expect(beforeSend).toHaveBeenCalledWith(testEvent);
       expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
         event: JSON.stringify({ ...testEvent, modified: true }),
+        recording_id: expect.any(String),
+        gen: '0',
+        seq: '0',
       });
     });
 
@@ -759,8 +781,7 @@ describe('ReplayInstrumentation', () => {
         );
 
         api.setSession({ id: 'test-session', attributes: { isSampled: 'true' } });
-        // Session-triggered (re)starts are deferred out of the metas-listener call
-        // stack; flush that microtask before relying on the recorder being active.
+        // Listener-triggered starts are deferred by a microtask.
         await Promise.resolve();
         jest.advanceTimersByTime(1);
         transport.sentBodies = [];
@@ -816,6 +837,904 @@ describe('ReplayInstrumentation', () => {
     });
   });
 
+  describe('delivery identity', () => {
+    let emitCallback: (event: any, isCheckout?: boolean) => void;
+    let metaListener: (() => void) | undefined;
+
+    beforeEach(() => {
+      mockRecord.mockImplementation((opts: any) => {
+        emitCallback = opts.emit;
+        return jest.fn();
+      });
+      metaListener = undefined;
+      mockAddListener.mockImplementation((cb: () => void) => {
+        metaListener = cb;
+      });
+    });
+
+    function replayAttributes(): Array<Record<string, string>> {
+      return mockPushEvent.mock.calls
+        .filter((call: any[]) => call[0] === 'faro.session_recording.event')
+        .map((call: any[]) => call[1]);
+    }
+
+    function lifecycleAttributes(eventName: string): Array<Record<string, string>> {
+      return mockPushEvent.mock.calls.filter((call: any[]) => call[0] === eventName).map((call: any[]) => call[1]);
+    }
+
+    function metaEvent() {
+      return {
+        type: EventType.Meta,
+        data: { href: 'https://example.com/', width: 1, height: 1 },
+        timestamp: Date.now(),
+      };
+    }
+
+    function fullSnapshotEvent() {
+      return { type: EventType.FullSnapshot, data: {}, timestamp: Date.now() };
+    }
+
+    function incrementalEvent(data: Record<string, unknown> = {}) {
+      return { type: EventType.IncrementalSnapshot, data, timestamp: Date.now() };
+    }
+
+    it.each([
+      ['session-b', 'true'],
+      ['test-session', 'false'],
+    ])('discards an event invalidated inside beforeSend (%s, %s)', async (id, isSampled) => {
+      let rotate = false;
+      instrumentation = initSampled({
+        beforeSend: (event) => {
+          if (rotate) {
+            mockGetSession.mockReturnValue({ id, attributes: { isSampled } });
+            metaListener!();
+          }
+          return event;
+        },
+      });
+      emitCallback(metaEvent());
+      const original = replayAttributes()[0]!;
+      rotate = true;
+      emitCallback(metaEvent());
+      expect(replayAttributes()).toEqual([original]);
+      rotate = false;
+      await Promise.resolve();
+      if (isSampled === 'true') {
+        emitCallback(metaEvent());
+        expect(replayAttributes()[1]).toMatchObject({ seq: '0', gen: '0' });
+        expect(replayAttributes()[1]!['recording_id']).not.toBe(original['recording_id']);
+      }
+    });
+
+    it('exposes an unserializable accepted Meta as a gap in the new generation', () => {
+      instrumentation = initSampled();
+      emitCallback(metaEvent());
+      emitCallback(fullSnapshotEvent());
+      const circular: Record<string, unknown> = {};
+      circular['self'] = circular;
+      emitCallback({ ...metaEvent(), data: circular });
+      emitCallback(fullSnapshotEvent());
+      expect(replayAttributes().map((attrs) => [attrs['seq'], attrs['gen']])).toEqual([
+        ['0', '0'],
+        ['1', '0'],
+        ['3', '1'],
+      ]);
+    });
+
+    it('stamps an event with the gen captured before serialization re-enters with a later Meta', () => {
+      instrumentation = initSampled({
+        beforeSend: (event: any) =>
+          event.data?.['reenter'] === true
+            ? {
+                ...event,
+                data: {
+                  toJSON: () => {
+                    emitCallback(metaEvent());
+                    return { reentered: true };
+                  },
+                },
+              }
+            : event,
+      });
+
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent({ reenter: true }));
+
+      // The nested Meta is pushed before the outer event finishes, but the outer event was
+      // accepted first and must keep the generation that was open when it reserved its seq.
+      expect(replayAttributes().map((attrs) => [JSON.parse(attrs['event']!).type, attrs['seq'], attrs['gen']])).toEqual(
+        [
+          [EventType.Meta, '0', '0'],
+          [EventType.Meta, '2', '1'],
+          [EventType.IncrementalSnapshot, '1', '0'],
+        ]
+      );
+    });
+
+    it('should stamp events with a stable recording_id, gen 0, and a contiguous seq', () => {
+      instrumentation = initSampled();
+
+      emitCallback(metaEvent());
+      emitCallback(fullSnapshotEvent());
+      emitCallback(incrementalEvent());
+      emitCallback(incrementalEvent());
+
+      const attrs = replayAttributes();
+      expect(attrs).toHaveLength(4);
+
+      const recordingId = attrs[0]!['recording_id'];
+      expect(recordingId).toEqual(expect.any(String));
+      expect(recordingId!.length).toBeGreaterThan(0);
+      expect(attrs.every((a) => a['recording_id'] === recordingId)).toBe(true);
+
+      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0', '0']);
+      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3']);
+    });
+
+    it('should advance gen on each emitted Meta and keep seq contiguous across the checkout', () => {
+      instrumentation = initSampled();
+
+      emitCallback(metaEvent());
+      emitCallback(fullSnapshotEvent());
+      emitCallback(incrementalEvent());
+
+      // A scheduled checkout emits Meta and FullSnapshot, both flagged isCheckout=true.
+      // The flag must be irrelevant: only the Meta event advances gen.
+      emitCallback(metaEvent(), true);
+      emitCallback(fullSnapshotEvent(), true);
+      emitCallback(incrementalEvent());
+
+      const attrs = replayAttributes();
+      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0', '1', '1', '1']);
+      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3', '4', '5']);
+    });
+
+    it('should not advance gen or consume seq for events dropped by beforeSend', () => {
+      instrumentation = initSampled({
+        beforeSend: (event: any) => (event.data?.['drop'] === true ? null : event),
+      });
+
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent({ drop: true }));
+      emitCallback(incrementalEvent());
+      emitCallback({ ...metaEvent(), data: { drop: true } });
+      emitCallback(incrementalEvent());
+
+      const attrs = replayAttributes();
+      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0']);
+      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2']);
+    });
+
+    it('should keep identity attributes intact when beforeSend mutates the event', () => {
+      instrumentation = initSampled({
+        beforeSend: (event: any) => ({ ...event, data: { mutated: true } }),
+      });
+
+      emitCallback(incrementalEvent({ original: true }));
+
+      const attrs = replayAttributes();
+      expect(attrs).toHaveLength(1);
+      expect(JSON.parse(attrs[0]!['event']!).data).toEqual({ mutated: true });
+      expect(attrs[0]!['recording_id']).toEqual(expect.any(String));
+      expect(attrs[0]!['gen']).toBe('0');
+      expect(attrs[0]!['seq']).toBe('0');
+    });
+
+    it('should increment gen with no seq gap across an inactivity pause and resume', () => {
+      jest.useFakeTimers();
+      try {
+        instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
+
+        emitCallback(metaEvent());
+        emitCallback(fullSnapshotEvent());
+
+        jest.advanceTimersByTime(5_000);
+        expect(instrumentation['isPaused']).toBe(true);
+
+        document.dispatchEvent(new Event('pointerdown'));
+        expect(instrumentation['isPaused']).toBe(false);
+
+        // The resume restarted rrweb; drive its fresh snapshot through the new emit.
+        emitCallback(metaEvent());
+        emitCallback(fullSnapshotEvent());
+
+        const attrs = replayAttributes();
+        expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '1', '1']);
+        expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3']);
+        expect(new Set(attrs.map((a) => a['recording_id'])).size).toBe(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('should stamp lifecycle events with recording_id and no gen or seq', () => {
+      jest.useFakeTimers();
+      try {
+        instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
+
+        jest.advanceTimersByTime(5_000);
+        document.dispatchEvent(new Event('pointerdown'));
+
+        for (const eventName of [
+          'faro.session_recording.started',
+          'faro.session_recording.paused',
+          'faro.session_recording.resumed',
+        ]) {
+          const attrs = lifecycleAttributes(eventName);
+          expect(attrs.length).toBeGreaterThan(0);
+          for (const a of attrs) {
+            expect(a['recording_id']).toEqual(expect.any(String));
+            expect(a).not.toHaveProperty('gen');
+            expect(a).not.toHaveProperty('seq');
+          }
+        }
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('should mint a new recording_id and reset gen and seq when the session rotates', async () => {
+      instrumentation = initSampled({}, 'session-a');
+
+      emitCallback(metaEvent());
+      const firstRecordingId = replayAttributes()[0]!['recording_id'];
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+      metaListener!();
+
+      // The stop is synchronous; the restart is deferred out of the listener call stack.
+      expect(instrumentation['isRecording']).toBe(false);
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(instrumentation['isRecording']).toBe(true);
+
+      const startedAttrs = lifecycleAttributes('faro.session_recording.started');
+      expect(startedAttrs).toHaveLength(2);
+      expect(startedAttrs[1]!['recording_id']).not.toBe(startedAttrs[0]!['recording_id']);
+
+      emitCallback(metaEvent());
+      const attrs = replayAttributes();
+      const rotatedEvent = attrs[attrs.length - 1]!;
+      expect(rotatedEvent['recording_id']).not.toBe(firstRecordingId);
+      expect(rotatedEvent['gen']).toBe('0');
+      expect(rotatedEvent['seq']).toBe('0');
+    });
+
+    it('should ignore the transient no-session notification from setSession', async () => {
+      instrumentation = initSampled();
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+
+      // Core setSession removes the session meta before re-adding it, so listeners
+      // transiently observe a state with no session.
+      mockGetSession.mockReturnValue(undefined);
+      metaListener!();
+
+      expect(instrumentation['isRecording']).toBe(true);
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      metaListener!();
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(1);
+    });
+
+    it('should not restart recording when a session notification carries an unchanged id', async () => {
+      instrumentation = initSampled();
+
+      metaListener!();
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(1);
+    });
+
+    it('should coalesce a burst of rotations into one restart bound to the latest session', async () => {
+      instrumentation = initSampled({}, 'session-a');
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+      metaListener!();
+      mockGetSession.mockReturnValue({ id: 'session-c', attributes: { isSampled: 'true' } });
+      metaListener!();
+
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(2);
+
+      // The recording is bound to the latest session: another session-c notification
+      // is a no-op.
+      metaListener!();
+      await Promise.resolve();
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(2);
+    });
+
+    it('should keep recording identity when sampling flips off and back on for the same session', async () => {
+      instrumentation = initSampled();
+      const firstStarted = lifecycleAttributes('faro.session_recording.started')[0]!;
+      emitCallback(metaEvent());
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'false' } });
+      metaListener!();
+      expect(instrumentation['isRecording']).toBe(false);
+
+      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
+      metaListener!();
+      await Promise.resolve();
+
+      const started = lifecycleAttributes('faro.session_recording.started');
+      expect(started).toHaveLength(2);
+      expect(started[1]!['recording_id']).toBe(firstStarted['recording_id']);
+
+      emitCallback(metaEvent());
+      const attrs = replayAttributes();
+      const latest = attrs[attrs.length - 1]!;
+      expect(latest['recording_id']).toBe(started[1]!['recording_id']);
+      expect(latest['gen']).toBe('1');
+      expect(latest['seq']).toBe('1');
+    });
+
+    it('should stop a deferred start when sampling flips off while it is starting', async () => {
+      const initialStop = jest.fn();
+      const restartedStop = jest.fn();
+      mockRecord.mockReturnValueOnce(initialStop).mockReturnValueOnce(restartedStop);
+      instrumentation = initSampled({}, 'session-a');
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+      metaListener!();
+      expect(initialStop).toHaveBeenCalledTimes(1);
+
+      let samplingFlipTriggered = false;
+      mockPushEvent.mockImplementation((eventName: string) => {
+        if (eventName === 'faro.session_recording.started' && !samplingFlipTriggered) {
+          samplingFlipTriggered = true;
+          mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'false' } });
+          metaListener!();
+        }
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(restartedStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear recording state when the rrweb stop function throws', () => {
+      const stopError = new Error('rrweb stop failed');
+      mockRecord.mockReturnValueOnce(
+        jest.fn(() => {
+          throw stopError;
+        })
+      );
+      instrumentation = initSampled();
+      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'false' } });
+
+      expect(() => metaListener!()).not.toThrow();
+      expect(instrumentation['isRecording']).toBe(false);
+      expect(instrumentation['stopFn']).toBeNull();
+      expect(logWarnSpy).toHaveBeenCalledWith('Failed to stop session replay', stopError);
+    });
+
+    it.each([
+      ['a sampled new session', 'session-b', 'true', 2],
+      ['an unsampled new session', 'session-b', 'false', 1],
+      ['the same session becoming unsampled', 'session-a', 'false', 1],
+    ])(
+      'should reconcile an initial started-event rotation to %s',
+      async (_scenario, nextSessionId, isSampled, expectedStarts) => {
+        const stops: jest.Mock[] = [];
+        mockRecord.mockImplementation(() => {
+          const stop = jest.fn();
+          stops.push(stop);
+          return stop;
+        });
+
+        let rotationTriggered = false;
+        mockPushEvent.mockImplementation((eventName: string) => {
+          if (eventName === 'faro.session_recording.started' && !rotationTriggered) {
+            rotationTriggered = true;
+            mockGetSession.mockReturnValue({ id: nextSessionId, attributes: { isSampled } });
+            metaListener!();
+          }
+        });
+
+        instrumentation = initSampled({}, 'session-a');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(stops[0]).toHaveBeenCalledTimes(1);
+        expect(mockRecord).toHaveBeenCalledTimes(expectedStarts);
+        if (expectedStarts === 2) {
+          expect(stops[1]).not.toHaveBeenCalled();
+        }
+      }
+    );
+
+    it('should restart with a new recording id when the session rotates while paused', async () => {
+      jest.useFakeTimers();
+      try {
+        instrumentation = initSampled({ inactivityThresholdMs: 5_000 }, 'session-a');
+        emitCallback(metaEvent());
+
+        jest.advanceTimersByTime(5_000);
+        expect(instrumentation['isPaused']).toBe(true);
+
+        mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+        metaListener!();
+        await Promise.resolve();
+
+        expect(instrumentation['isPaused']).toBe(false);
+        const started = lifecycleAttributes('faro.session_recording.started');
+        expect(started).toHaveLength(2);
+        expect(started[1]!['recording_id']).not.toBe(started[0]!['recording_id']);
+
+        emitCallback(metaEvent());
+        const attrs = replayAttributes();
+        expect(attrs[attrs.length - 1]!['recording_id']).toBe(started[1]!['recording_id']);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('should stop recording when the session is deliberately cleared', () => {
+      instrumentation = initSampled();
+      expect(instrumentation['isRecording']).toBe(true);
+
+      // resetSession()/setSession(undefined) re-adds a session meta WITHOUT an id —
+      // unlike the transient mid-rotation state, where no session meta exists at all.
+      mockGetSession.mockReturnValue({});
+      metaListener!();
+
+      expect(instrumentation['isRecording']).toBe(false);
+    });
+
+    it('should not restart recording after destroy even with a pending start', async () => {
+      instrumentation = initSampled({}, 'session-a');
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+      metaListener!();
+      instrumentation.destroy();
+
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+      expect(instrumentation['isRecording']).toBe(false);
+    });
+
+    it('should emit no started marker for a declined start and one ordered marker when retry succeeds', async () => {
+      const successfulStop = jest.fn();
+      mockRecord
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce((opts: any) => {
+          emitCallback = opts.emit;
+          opts.emit(metaEvent());
+          return successfulStop;
+        });
+
+      instrumentation = initSampled();
+
+      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(0);
+      expect(replayAttributes()).toHaveLength(0);
+
+      metaListener!();
+      await Promise.resolve();
+
+      const names = mockPushEvent.mock.calls.map((call: any[]) => call[0]);
+      expect(names).toEqual(['faro.session_recording.started', 'faro.session_recording.event']);
+      expect(successfulStop).not.toHaveBeenCalled();
+    });
+
+    it.each([0, 2])(
+      'should emit one resumed marker before the fresh snapshot after %s declined attempts',
+      (declinedAttempts) => {
+        jest.useFakeTimers();
+        try {
+          instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
+          jest.advanceTimersByTime(5_000);
+          mockPushEvent.mockClear();
+
+          for (let attempt = 0; attempt < declinedAttempts; attempt++) {
+            mockRecord.mockReturnValueOnce(undefined);
+            document.dispatchEvent(new Event('pointerdown'));
+            expect(mockPushEvent).not.toHaveBeenCalled();
+          }
+          mockRecord.mockImplementationOnce((opts: { emit: (event: unknown) => void }) => {
+            // rrweb can emit its fresh snapshot synchronously inside record().
+            opts.emit(metaEvent());
+            return jest.fn();
+          });
+          document.dispatchEvent(new Event('pointerdown'));
+
+          expect(mockPushEvent.mock.calls.map((call) => call[0])).toEqual([
+            'faro.session_recording.resumed',
+            'faro.session_recording.event',
+          ]);
+        } finally {
+          jest.useRealTimers();
+        }
+      }
+    );
+
+    it('should mint distinct recording ids for two concurrent instances', () => {
+      const emits: Array<(event: any, isCheckout?: boolean) => void> = [];
+      mockRecord.mockImplementation((opts: any) => {
+        emits.push(opts.emit);
+        return jest.fn();
+      });
+
+      instrumentation = initSampled();
+      const secondInstrumentation = initSampled();
+
+      try {
+        emits[0]!(metaEvent());
+        emits[1]!(metaEvent());
+
+        const attrs = replayAttributes();
+        expect(attrs).toHaveLength(2);
+        expect(attrs[0]!['recording_id']).not.toBe(attrs[1]!['recording_id']);
+        expect(attrs.map((a) => a['seq'])).toEqual(['0', '0']);
+      } finally {
+        secondInstrumentation.destroy();
+      }
+    });
+
+    it('should deliver the new recording events when a rotation is detected mid-flush', async () => {
+      jest.useFakeTimers();
+      try {
+        const transport = new BatchedBodyTransport();
+        instrumentation = new ReplayInstrumentation();
+
+        let rotated = false;
+        const { api } = initializeFaro(
+          mockConfig({
+            instrumentations: [instrumentation],
+            transports: [transport],
+            batching: {
+              enabled: true,
+              sendTimeout: 1,
+              itemLimit: 10,
+            },
+            // Simulates the session instrumentation's transport hook rotating the
+            // session while the batch executor is flushing: items pushed synchronously
+            // during a flush are discarded by the executor's buffer reset.
+            beforeSend: (item) => {
+              if (!rotated) {
+                rotated = true;
+                api.setSession({ id: 'rotated-session', attributes: { isSampled: 'true' } });
+              }
+              return item;
+            },
+          })
+        );
+
+        api.setSession({ id: 'first-session', attributes: { isSampled: 'true' } });
+        await Promise.resolve();
+        expect(mockRecord).toHaveBeenCalledTimes(1);
+
+        // First flush: sends the first recording's started event and triggers the
+        // rotation from inside the flush.
+        jest.advanceTimersByTime(1);
+        const firstStarted = transport.sentBodies
+          .flatMap((body) => body.events ?? [])
+          .find((event) => event.name === 'faro.session_recording.started');
+        expect(firstStarted).toBeDefined();
+        transport.sentBodies = [];
+
+        // The restart is deferred out of the flush call stack, so the new recording's
+        // events land in the next batch instead of being wiped.
+        await Promise.resolve();
+        expect(mockRecord).toHaveBeenCalledTimes(2);
+
+        emitCallback({
+          type: EventType.Meta,
+          data: { href: 'https://example.com/', width: 1, height: 1 },
+          timestamp: Date.now(),
+        });
+        emitCallback({ type: EventType.FullSnapshot, data: {}, timestamp: Date.now() });
+        jest.advanceTimersByTime(1);
+
+        const sentEvents = transport.sentBodies.flatMap((body) => body.events ?? []);
+        const started = sentEvents.find((event) => event.name === 'faro.session_recording.started');
+        const replayEvents = sentEvents.filter((event) => event.name === 'faro.session_recording.event');
+
+        expect(started).toBeDefined();
+        expect(started!.attributes!['recording_id']).not.toBe(firstStarted!.attributes!['recording_id']);
+        expect(replayEvents).toHaveLength(2);
+        expect(
+          replayEvents.every((event) => event.attributes!['recording_id'] === started!.attributes!['recording_id'])
+        ).toBe(true);
+        expect(replayEvents.map((event) => event.attributes!['gen'])).toEqual(['0', '0']);
+        expect(replayEvents.map((event) => event.attributes!['seq'])).toEqual(['0', '1']);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('should continue recording identity across a clean full-page navigation', () => {
+      window.sessionStorage.clear();
+      const firstInstrumentation = initSampled({}, 'session-a');
+
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent());
+      const firstPageEvents = replayAttributes();
+      const recordingId = firstPageEvents[0]!['recording_id'];
+
+      window.dispatchEvent(new Event('pagehide'));
+      firstInstrumentation.destroy();
+      mockPushEvent.mockClear();
+
+      instrumentation = initSampled({}, 'session-a');
+      expect(lifecycleAttributes('faro.session_recording.started')).toEqual([
+        expect.objectContaining({ recording_id: recordingId }),
+      ]);
+      emitCallback(metaEvent());
+
+      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
+    });
+
+    it('should mint a recovery recording instead of reusing an active handoff', () => {
+      const firstDocument = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      const firstRecordingId = replayAttributes()[0]!['recording_id'];
+      mockPushEvent.mockClear();
+
+      instrumentation = initSampled({}, 'session-a');
+      try {
+        emitCallback(metaEvent());
+
+        expect(replayAttributes()).toEqual([expect.objectContaining({ gen: '0', seq: '0' })]);
+        expect(replayAttributes()[0]!['recording_id']).not.toBe(firstRecordingId);
+      } finally {
+        firstDocument.destroy();
+      }
+    });
+
+    it('should not write recording state while assigning replay event identity', () => {
+      window.sessionStorage.clear();
+      const storageSpy = jest.spyOn(Storage.prototype, 'setItem');
+      instrumentation = initSampled({}, 'session-a');
+      storageSpy.mockClear();
+
+      emitCallback(metaEvent());
+      for (let i = 0; i < 100; i++) {
+        emitCallback(incrementalEvent());
+      }
+
+      expect(storageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should rehydrate the latest clean handoff when restored from BFCache', () => {
+      window.sessionStorage.clear();
+      const firstDocument = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      const recordingId = replayAttributes()[0]!['recording_id'];
+      window.dispatchEvent(new Event('pagehide'));
+
+      const secondDocument = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent());
+      window.dispatchEvent(new Event('pagehide'));
+      secondDocument.destroy();
+
+      instrumentation = firstDocument;
+      mockPushEvent.mockClear();
+      const pageShowEvent = new Event('pageshow');
+      Object.defineProperty(pageShowEvent, 'persisted', { value: true });
+      window.dispatchEvent(pageShowEvent);
+      emitCallback(metaEvent());
+
+      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '2', seq: '3' })]);
+    });
+
+    it('should not run a pending session restart after pagehide seals the recording', async () => {
+      window.sessionStorage.clear();
+      instrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+
+      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
+      metaListener!();
+      window.dispatchEvent(new Event('pagehide'));
+      await Promise.resolve();
+
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not run a pending initial start after pagehide', async () => {
+      mockGetSession.mockReturnValue({ id: 'session-a', attributes: { isSampled: 'false' } });
+      instrumentation = new ReplayInstrumentation();
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
+      instrumentation.initialize();
+
+      mockGetSession.mockReturnValue({ id: 'session-a', attributes: { isSampled: 'true' } });
+      instrumentation['metasListener']();
+      window.dispatchEvent(new Event('pagehide'));
+      await Promise.resolve();
+
+      expect(mockRecord).not.toHaveBeenCalled();
+    });
+
+    it('should not force an rrweb checkpoint for SPA navigation', () => {
+      instrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      emitCallback(fullSnapshotEvent());
+
+      window.history.pushState({}, '', '/spa-navigation');
+
+      expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+      const attrs = replayAttributes();
+      expect(attrs.map((event) => event['gen'])).toEqual(['0', '0']);
+      expect(attrs.map((event) => event['seq'])).toEqual(['0', '1']);
+    });
+
+    it('should reconcile rotations after the same instance is removed and re-added', async () => {
+      instrumentation = new ReplayInstrumentation();
+      const faro = initializeFaro(
+        mockConfig({
+          instrumentations: [instrumentation],
+          batching: { enabled: false },
+        })
+      );
+
+      try {
+        faro.api.setSession({ id: 'session-a', attributes: { isSampled: 'true' } });
+        await Promise.resolve();
+        expect(mockRecord).toHaveBeenCalledTimes(1);
+
+        faro.instrumentations.remove(instrumentation);
+        faro.instrumentations.add(instrumentation);
+        expect(mockRecord).toHaveBeenCalledTimes(2);
+
+        faro.api.setSession({ id: 'session-b', attributes: { isSampled: 'true' } });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockRecord).toHaveBeenCalledTimes(3);
+      } finally {
+        faro.instrumentations.remove(instrumentation);
+      }
+    });
+
+    it('should continue recording identity when the instance is replaced in the same document', () => {
+      window.sessionStorage.clear();
+      const firstInstrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent());
+      const recordingId = replayAttributes()[0]!['recording_id'];
+
+      firstInstrumentation.destroy();
+      mockPushEvent.mockClear();
+      instrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+
+      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
+    });
+
+    it('should continue recording identity across a same-document replacement when localStorage writes fail', () => {
+      window.sessionStorage.clear();
+      const originalSetItem = Storage.prototype.setItem;
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (this === window.localStorage) {
+          throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+        }
+        originalSetItem.call(this, key, value);
+      });
+
+      const firstInstrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+      emitCallback(incrementalEvent());
+      const recordingId = replayAttributes()[0]!['recording_id'];
+      firstInstrumentation.destroy();
+      mockPushEvent.mockClear();
+
+      instrumentation = initSampled({}, 'session-a');
+      emitCallback(metaEvent());
+
+      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
+      expect(window.localStorage.length).toBe(0);
+    });
+
+    it.each([
+      { handoff: 'active', pointerWrites: 'available' },
+      { handoff: 'clean', pointerWrites: 'available' },
+      { handoff: 'clean', pointerWrites: 'blocked' },
+      { handoff: 'clean', pointerWrites: 'recover' },
+    ])(
+      'should abandon a foreign $handoff checkpoint across replacement (pointer writes: $pointerWrites)',
+      ({ handoff, pointerWrites }) => {
+        instrumentation = initSampled({}, 'session-a');
+        const ownerNamespace = instrumentation['recordingOwnerNamespace'];
+        emitCallback(metaEvent());
+        emitCallback(incrementalEvent());
+        emitCallback(metaEvent());
+        emitCallback(fullSnapshotEvent());
+        const recordingId = replayAttributes()[0]!['recording_id'];
+        const key = `${replayRecordingCheckpointKeyPrefix}${ownerNamespace}:${recordingId}`;
+        const foreignClaim = {
+          ...JSON.parse(window.localStorage.getItem(key)!),
+          documentId: 'other-document',
+          handoff,
+          nextSeq: 1,
+          gen: 0,
+        };
+        window.localStorage.setItem(key, JSON.stringify(foreignClaim));
+        let blockPointerWrites = pointerWrites !== 'available';
+        if (blockPointerWrites) {
+          const originalSetItem = Storage.prototype.setItem;
+          jest.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+            if (blockPointerWrites && this === window.sessionStorage) {
+              throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+            }
+            originalSetItem.call(this, key, value);
+          });
+        }
+        mockPushEvent.mockClear();
+
+        window.dispatchEvent(
+          new StorageEvent('storage', { key, newValue: JSON.stringify(foreignClaim), storageArea: window.localStorage })
+        );
+        emitCallback(metaEvent());
+        const recoveryRecordingId = replayAttributes()[0]!['recording_id'];
+        expect(recoveryRecordingId).not.toBe(recordingId);
+        expect(replayAttributes()).toEqual([
+          expect.objectContaining({ recording_id: recoveryRecordingId, gen: '0', seq: '0' }),
+        ]);
+        expect(lifecycleAttributes('faro.session_recording.started')).toEqual([
+          expect.objectContaining({ recording_id: recoveryRecordingId }),
+        ]);
+        expect(JSON.parse(window.localStorage.getItem(key)!)).toEqual(foreignClaim);
+
+        instrumentation.destroy();
+        blockPointerWrites = pointerWrites === 'blocked';
+        mockPushEvent.mockClear();
+        instrumentation = initSampled({}, 'session-a');
+        emitCallback(metaEvent());
+        expect(replayAttributes()).toEqual([
+          expect.objectContaining({ recording_id: recoveryRecordingId, gen: '1', seq: '1' }),
+        ]);
+        window.dispatchEvent(new Event('pagehide'));
+        if (!blockPointerWrites) {
+          // Navigation has no same-document handoff: it must use the repaired pointer.
+          instrumentation.destroy();
+          mockPushEvent.mockClear();
+          instrumentation = initSampled({}, 'session-a');
+          emitCallback(metaEvent());
+          expect(replayAttributes()).toEqual([
+            expect.objectContaining({ recording_id: recoveryRecordingId, gen: '2', seq: '2' }),
+          ]);
+        }
+        expect(JSON.parse(window.localStorage.getItem(key)!)).toEqual(foreignClaim);
+      }
+    );
+
+    it.each([
+      ['a removal of its checkpoint', (key: string) => ({ key, newValue: null })],
+      ['another recording checkpoint', (key: string) => ({ key: `${key}-other`, newValue: '{"documentId":"x"}' })],
+      ['a write under its own document', (key: string) => ({ key, newValue: window.localStorage.getItem(key) })],
+    ])('should keep recording on a storage event for %s', (_scenario, makeEvent) => {
+      window.sessionStorage.clear();
+      instrumentation = initSampled({}, 'session-a');
+      const ownerNamespace = instrumentation['recordingOwnerNamespace'];
+      emitCallback(metaEvent());
+      const recordingId = replayAttributes()[0]!['recording_id'];
+      const key = `${replayRecordingCheckpointKeyPrefix}${ownerNamespace}:${recordingId}`;
+      mockPushEvent.mockClear();
+
+      window.dispatchEvent(new StorageEvent('storage', { ...makeEvent(key), storageArea: window.localStorage }));
+      emitCallback(incrementalEvent());
+
+      expect(lifecycleAttributes('faro.session_recording.started')).toEqual([]);
+      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '0', seq: '1' })]);
+    });
+  });
+
   describe('destroy', () => {
     it('should stop recording and clean up when destroyed', () => {
       const stopFn = jest.fn();
@@ -859,34 +1778,27 @@ describe('ReplayInstrumentation', () => {
       jest.useRealTimers();
     });
 
-    function initSampledInstrumentation(options: ReplayInstrumentationOptions = {}): ReplayInstrumentation {
-      const inst = new ReplayInstrumentation(options);
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
-      inst['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      inst['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-      inst.initialize();
-      return inst;
-    }
-
     it('should pause recording after inactivity threshold elapses', () => {
       const stopFn = jest.fn();
       mockRecord.mockReturnValue(stopFn);
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
       expect(instrumentation['isPaused']).toBe(false);
 
       jest.advanceTimersByTime(5_000);
 
       expect(stopFn).toHaveBeenCalled();
       expect(instrumentation['isPaused']).toBe(true);
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.paused', {});
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.paused', {
+        recording_id: expect.any(String),
+      });
     });
 
     it('should resume recording with a fresh checkpoint when user interacts after pause', () => {
       const stopFn = jest.fn();
       mockRecord.mockReturnValue(stopFn);
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
 
       jest.advanceTimersByTime(5_000);
       expect(instrumentation['isPaused']).toBe(true);
@@ -897,14 +1809,16 @@ describe('ReplayInstrumentation', () => {
 
       expect(instrumentation['isPaused']).toBe(false);
       expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.resumed', {});
+      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.resumed', {
+        recording_id: expect.any(String),
+      });
     });
 
     it('should not pause when inactivityThresholdMs is 0', () => {
       const stopFn = jest.fn();
       mockRecord.mockReturnValue(stopFn);
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 0 });
+      instrumentation = initSampled({ inactivityThresholdMs: 0 });
 
       jest.advanceTimersByTime(120_000);
 
@@ -916,7 +1830,7 @@ describe('ReplayInstrumentation', () => {
       const stopFn = jest.fn();
       mockRecord.mockReturnValue(stopFn);
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: undefined });
+      instrumentation = initSampled({ inactivityThresholdMs: undefined });
 
       jest.advanceTimersByTime(120_000);
 
@@ -927,7 +1841,7 @@ describe('ReplayInstrumentation', () => {
     it('should remove DOM listeners on stopRecording', () => {
       const removeSpy = jest.spyOn(document, 'removeEventListener');
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
       instrumentation.destroy();
 
       const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
@@ -943,7 +1857,7 @@ describe('ReplayInstrumentation', () => {
       mockRecord.mockReturnValue(stopFn);
       const removeSpy = jest.spyOn(document, 'removeEventListener');
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
 
       jest.advanceTimersByTime(5_000);
       expect(instrumentation['isPaused']).toBe(true);
@@ -961,7 +1875,7 @@ describe('ReplayInstrumentation', () => {
       const stopFn = jest.fn();
       mockRecord.mockReturnValue(stopFn);
 
-      instrumentation = initSampledInstrumentation({ inactivityThresholdMs: 5_000 });
+      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
 
       jest.advanceTimersByTime(4_000);
       document.dispatchEvent(new Event('keydown'));
@@ -983,7 +1897,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 1 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -996,7 +1910,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 0 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -1010,7 +1924,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.2 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -1024,7 +1938,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.1 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -1039,13 +1953,13 @@ describe('ReplayInstrumentation', () => {
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
 
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.2 });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
       instrumentation.initialize();
       const firstDecision = instrumentation['isRecording'];
 
       const instrumentation2 = new ReplayInstrumentation({ samplingRate: 0.2 });
-      instrumentation2['api'] = { getSession: mockGetSession } as any;
+      instrumentation2['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation2['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
       instrumentation2.initialize();
       const secondDecision = instrumentation2['isRecording'];
@@ -1058,7 +1972,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: -0.5 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
@@ -1073,7 +1987,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 1.5 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
@@ -1094,7 +2008,7 @@ describe('ReplayInstrumentation', () => {
 
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.5 });
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -1110,7 +2024,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 0 });
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'false' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
@@ -1167,7 +2081,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 1 });
 
       mockGetSession.mockReturnValue({ id: undefined, attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession } as any;
+      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
       instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -1,14 +1,54 @@
-import { BaseInstrumentation, clampSamplingRate, VERSION } from '@grafana/faro-core';
+import { BaseInstrumentation, clampSamplingRate, genShortID, VERSION } from '@grafana/faro-core';
 import { record, type recordOptions } from '@grafana/rrweb';
 import { EventType, type eventWithTime } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn, defaultReplayInstrumentationOptions } from './const';
+import { createMemoryStorage, type ReplayRecordingState, ReplayRecordingStateStore } from './recordingState';
 import type { ReplayInstrumentationOptions } from './types';
 
 const faroSessionReplayEventName = 'faro.session_recording.event';
 const faroSessionReplayStartedEventName = 'faro.session_recording.started';
 const faroSessionReplayPausedEventName = 'faro.session_recording.paused';
 const faroSessionReplayResumedEventName = 'faro.session_recording.resumed';
+
+// When localStorage cannot be accessed or written, checkpoints live only as long as this
+// Document: same-document replacement still continues, cross-Document navigation starts a
+// recovery recording.
+let documentLocalCheckpointStorage: Storage | undefined;
+const sharedStorageProbeKey = 'com.grafana.faro.replay.probe';
+
+interface ActiveRecordingHandoff {
+  sessionId: string;
+  recordingId: string;
+}
+
+interface RecordingOwnerState {
+  handoff?: ActiveRecordingHandoff;
+  abandonedRecordingIds: Set<string>;
+}
+
+const recordingOwners = new WeakMap<Document, Map<string, RecordingOwnerState>>();
+
+function getRecordingOwnerState(namespace: string): RecordingOwnerState {
+  let owners = recordingOwners.get(document);
+  if (!owners) {
+    owners = new Map();
+    recordingOwners.set(document, owners);
+  }
+  let owner = owners.get(namespace);
+  if (!owner) {
+    owner = { abandonedRecordingIds: new Set() };
+    owners.set(namespace, owner);
+  }
+  return owner;
+}
+
+function takeActiveRecordingHandoff(namespace: string): ActiveRecordingHandoff | undefined {
+  const owner = getRecordingOwnerState(namespace);
+  const handoff = owner.handoff;
+  delete owner.handoff;
+  return handoff;
+}
 
 type RrwebEmit = (event: eventWithTime) => void;
 
@@ -35,8 +75,11 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
   private boundOnUserInteraction: (() => void) | null = null;
 
-  // Session ownership of the active recorder attempt.
-  private recordingSessionId: string | null = null;
+  private recordingState: ReplayRecordingState | undefined;
+  private pageHidden = false;
+  private recordingStateStore: ReplayRecordingStateStore | undefined;
+  private recordingOwnerNamespace!: string;
+
   // record() may notify listeners before returning its stop function.
   private isStarting: boolean = false;
   // Coalesce re-entrant session changes into one deferred start.
@@ -49,6 +92,50 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   private readonly metasListener = (): void => {
     this.checkAndUpdateRecording(true);
+  };
+
+  private readonly pageHideListener = (): void => {
+    if (this.destroyed) {
+      return;
+    }
+    this.pageHidden = true;
+    if (!this.recordingState) {
+      return;
+    }
+    this.stopRecording();
+    this.recordingStateStore?.seal(this.recordingState);
+  };
+
+  private readonly pageShowListener = (event: PageTransitionEvent): void => {
+    if (this.destroyed || !event.persisted || !this.pageHidden) {
+      return;
+    }
+    this.pageHidden = false;
+    this.recordingState = undefined;
+    this.checkAndUpdateRecording(false);
+  };
+
+  // A competing claim can arrive after that Document has already sealed its checkpoint.
+  // Revoke this identity before restarting, rather than adopting its now-clean counters.
+  private readonly storageListener = (event: StorageEvent): void => {
+    if (this.destroyed || this.pageHidden || !this.recordingState) {
+      return;
+    }
+    if (
+      !this.recordingStateStore?.hasLostOwnership(
+        this.recordingState.recordingId,
+        event.key,
+        event.newValue,
+        event.storageArea
+      )
+    ) {
+      return;
+    }
+    this.logDebug('Recording checkpoint was claimed by another document, starting a recovery recording');
+    this.recordingStateStore.abandon(this.recordingState.recordingId);
+    this.stopRecording();
+    this.recordingState = undefined;
+    this.checkAndUpdateRecording(false);
   };
 
   constructor(options: ReplayInstrumentationOptions = {}) {
@@ -64,6 +151,23 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   initialize(): void {
     this.destroyed = false;
+    this.pageHidden = false;
+    // Owner identity excludes deployment versions so navigation can cross releases.
+    this.recordingOwnerNamespace = JSON.stringify([
+      this.config.globalObjectKey,
+      this.config.app?.name ?? '',
+      this.config.app?.namespace ?? '',
+      this.config.app?.environment ?? '',
+    ]);
+    this.recordingStateStore = new ReplayRecordingStateStore({
+      tabStorage: this.getSessionStorage(),
+      sharedStorage: this.getSharedCheckpointStorage(),
+      ownerNamespace: this.recordingOwnerNamespace,
+      documentId: genShortID(),
+      generateRecordingId: genShortID,
+      abandonedRecordingIds: getRecordingOwnerState(this.recordingOwnerNamespace).abandonedRecordingIds,
+    });
+    this.recordingStateStore.removeLegacyState();
     this.lifecycle++;
     // A listener already being notified can still queue work after destroy().
     this.pendingStart = false;
@@ -71,11 +175,45 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     // Listen for session changes. Starts triggered from the listener are deferred out
     // of the call stack (see scheduleStartRecording).
     this.metas.addListener(this.metasListener);
+    window.addEventListener('pagehide', this.pageHideListener, { capture: true });
+    window.addEventListener('pageshow', this.pageShowListener, { capture: true });
+    window.addEventListener('storage', this.storageListener);
 
     this.checkAndUpdateRecording(false);
   }
 
+  private getSessionStorage(): Storage | undefined {
+    try {
+      return typeof window === 'undefined' ? undefined : window.sessionStorage;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private getSharedCheckpointStorage(): Storage | undefined {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        const storage = window.localStorage;
+        // Access can succeed while writes fail, for example once the origin's quota is
+        // full. Probe once so a broken storage degrades to the Document-local fallback
+        // instead of failing every checkpoint.
+        storage.setItem(sharedStorageProbeKey, '1');
+        storage.removeItem(sharedStorageProbeKey);
+        return storage;
+      }
+    } catch {
+      // Fall through to the Document-local fallback.
+    }
+
+    documentLocalCheckpointStorage ??= createMemoryStorage();
+    return documentLocalCheckpointStorage;
+  }
+
   private checkAndUpdateRecording(deferStart: boolean): void {
+    if (this.pageHidden) {
+      return;
+    }
+
     // A notification can arrive synchronously while rrweb's record() is still executing,
     // before the stop function is installed. Reconcile once the current call stack has
     // finished so the start attempt can finish setting up its state.
@@ -114,7 +252,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     }
 
     if (this.isRecording) {
-      if (this.recordingSessionId === sessionId) {
+      if (this.recordingState?.sessionId === sessionId) {
         return;
       }
 
@@ -242,21 +380,22 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   // Passive: capture reconciliation must happen before validating the attempt.
   private isRecordingSessionEligible(): boolean {
-    if (this.destroyed || this.recordingSessionId === null) {
+    if (this.destroyed || this.pageHidden || !this.recordingState) {
       return false;
     }
 
     const session = this.api.getSession();
     return (
-      session?.id === this.recordingSessionId &&
+      session?.id === this.recordingState.sessionId &&
       session.attributes?.['isSampled'] === 'true' &&
-      this.shouldReplaySample(this.recordingSessionId)
+      this.shouldReplaySample(this.recordingState.sessionId)
     );
   }
 
   // rrweb can emit snapshots synchronously before returning its stop function.
   // Publish only after startup succeeds and the attempt remains eligible.
   private startRrweb(lifecycleEventName: string): boolean {
+    const state = this.recordingState!;
     const bufferedEvents: eventWithTime[] = [];
     const attempt: { phase: 'buffering' | 'active' | 'discarded' } = { phase: 'buffering' };
     const revision = this.attemptRevision;
@@ -311,7 +450,9 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       discardAttempt();
       stop!();
     };
-    const isCurrentAttempt = (): boolean => isValid() && this.isRecording && this.stopFn === stopAttempt;
+    const recordingId = state.recordingId;
+    const isCurrentAttempt = (): boolean =>
+      isValid() && this.isRecording && this.stopFn === stopAttempt && this.recordingState === state;
 
     this.stopFn = stopAttempt;
     this.isRecording = true;
@@ -319,7 +460,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
     // Telemetry failure does not undo a successfully installed recorder.
     try {
-      this.api.pushEvent(lifecycleEventName, {});
+      this.api.pushEvent(lifecycleEventName, { recording_id: recordingId });
     } catch (err) {
       this.logWarn(`Failed to push ${lifecycleEventName} event`, err);
     }
@@ -374,17 +515,22 @@ export class ReplayInstrumentation extends BaseInstrumentation {
         }
 
         const eligibleSessionId = this.currentEligibleSessionId();
-        if (this.destroyed || eligibleSessionId === null || eligibleSessionId !== sessionId) {
+        if (this.destroyed || this.pageHidden || eligibleSessionId === null || eligibleSessionId !== sessionId) {
           this.logDebug('Session changed during reconciliation, deferring recording start');
           return;
         }
 
-        this.recordingSessionId = sessionId;
+        if (this.recordingState?.sessionId !== sessionId) {
+          const handoff = takeActiveRecordingHandoff(this.recordingOwnerNamespace);
+          this.recordingState = this.recordingStateStore!.claim(
+            sessionId,
+            handoff?.sessionId === sessionId ? handoff.recordingId : undefined
+          );
+        }
 
         if (!this.startRrweb(faroSessionReplayStartedEventName)) {
           // Not marked as recording, so a later session notification can retry.
           this.logWarn('Failed to start session replay: rrweb did not start');
-          this.recordingSessionId = null;
           return;
         }
 
@@ -397,10 +543,6 @@ export class ReplayInstrumentation extends BaseInstrumentation {
         this.setupInactivityTracking();
       });
     } catch (err) {
-      // A failed attempt must not retain a session reservation.
-      if (!this.isRecording) {
-        this.recordingSessionId = null;
-      }
       this.logWarn('Failed to start session replay', err);
     }
   }
@@ -426,7 +568,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
           return;
         }
 
-        this.api.pushEvent(faroSessionReplayPausedEventName, {});
+        this.api.pushEvent(faroSessionReplayPausedEventName, { recording_id: this.recordingState!.recordingId });
       });
     } catch (err) {
       this.logWarn('Failed to push session replay paused event', err);
@@ -550,9 +692,10 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   }
 
   private handleEvent(event: eventWithTime, isCurrentAttempt: () => boolean): void {
+    const state = this.recordingState;
     try {
       this.metas.capture(() => {
-        if (!isCurrentAttempt()) {
+        if (!state || !isCurrentAttempt()) {
           return;
         }
 
@@ -574,12 +717,24 @@ export class ReplayInstrumentation extends BaseInstrumentation {
           return;
         }
 
+        if (processedEvent.type === EventType.Meta) {
+          state.gen++;
+        }
+        // Reserve after acceptance but before serialization: a failed event leaves
+        // a detectable gap, without moving its snapshot back to the previous gen.
+        // Capture gen alongside seq: serialization runs user code (toJSON) that may
+        // re-enter with a later Meta and advance state.gen before we read it.
+        const seq = state.nextSeq++;
+        const gen = Math.max(state.gen, 0);
         const serializedEvent = JSON.stringify(processedEvent);
         if (!isCurrentAttempt()) {
           return;
         }
         this.api.pushEvent(faroSessionReplayEventName, {
           event: serializedEvent,
+          recording_id: state.recordingId,
+          gen: String(gen),
+          seq: String(seq),
         });
       });
     } catch (err) {
@@ -591,7 +746,16 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     this.destroyed = true;
     this.pendingStart = false;
     this.metas.removeListener?.(this.metasListener);
+    window.removeEventListener('pagehide', this.pageHideListener, { capture: true });
+    window.removeEventListener('pageshow', this.pageShowListener, { capture: true });
+    window.removeEventListener('storage', this.storageListener);
     this.stopRecording();
-    this.recordingSessionId = null;
+    const state = this.recordingState;
+    if (state) {
+      if (this.recordingStateStore?.checkpoint(state)) {
+        getRecordingOwnerState(this.recordingOwnerNamespace).handoff = state;
+      }
+      this.recordingState = undefined;
+    }
   }
 }

--- a/experimental/instrumentation-replay/src/recordingState.test.ts
+++ b/experimental/instrumentation-replay/src/recordingState.test.ts
@@ -1,0 +1,529 @@
+import {
+  createMemoryStorage,
+  legacyReplayRecordingStorageKeyPrefix,
+  MAX_RECORDING_CHECKPOINT_AGE_MS,
+  MAX_RETAINED_RECORDING_CHECKPOINTS,
+  replayRecordingCheckpointKeyPrefix,
+  replayRecordingPointerKeyPrefix,
+  ReplayRecordingStateStore,
+} from './recordingState';
+
+describe('ReplayRecordingStateStore', () => {
+  const owner = '["faro","app","","production"]';
+  const pointerKey = `${replayRecordingPointerKeyPrefix}${owner}`;
+  const checkpointKey = (recordingId: string) => `${replayRecordingCheckpointKeyPrefix}${owner}:${recordingId}`;
+  const checkpointKeys = (storage: Storage) =>
+    Array.from({ length: storage.length }, (_, index) => storage.key(index)!).filter((key) =>
+      key.startsWith(`${replayRecordingCheckpointKeyPrefix}${owner}:`)
+    );
+
+  function makeStore(
+    tabStorage: Storage | undefined,
+    sharedStorage: Storage | undefined,
+    documentId: string,
+    recoveryRecordingId: string,
+    now?: () => number
+  ): ReplayRecordingStateStore {
+    return new ReplayRecordingStateStore({
+      tabStorage,
+      sharedStorage,
+      ownerNamespace: owner,
+      documentId,
+      generateRecordingId: () => recoveryRecordingId,
+      now,
+    });
+  }
+
+  // A browser derives a new tab by copying the whole sessionStorage area.
+  function cloneTab(tabStorage: Storage): Storage {
+    const copy: Record<string, string> = {};
+    for (let index = 0; index < tabStorage.length; index++) {
+      const key = tabStorage.key(index)!;
+      copy[key] = tabStorage.getItem(key)!;
+    }
+    return createMemoryStorage(copy);
+  }
+
+  function readCheckpoint(shared: Storage, recordingId: string) {
+    return JSON.parse(shared.getItem(checkpointKey(recordingId))!);
+  }
+
+  describe('single tab', () => {
+    it('continues the recording the tab points at when its checkpoint is clean', () => {
+      const tab = createMemoryStorage();
+      const shared = createMemoryStorage();
+      const first = makeStore(tab, shared, 'doc-1', 'recording-a', () => 1_000);
+      const state = first.claim('session-a');
+      expect(state).toEqual({ sessionId: 'session-a', recordingId: 'recording-a', nextSeq: 0, gen: -1 });
+      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recording-a' });
+      expect(first.seal({ ...state, nextSeq: 42, gen: 3 })).toBe(true);
+      expect(readCheckpoint(shared, 'recording-a')).toEqual({
+        sessionId: 'session-a',
+        nextSeq: 42,
+        gen: 3,
+        handoff: 'clean',
+        documentId: 'doc-1',
+        updatedAt: 1_000,
+      });
+
+      const next = makeStore(tab, shared, 'doc-2', 'unused', () => 2_000);
+      expect(next.claim('session-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recording-a',
+        nextSeq: 42,
+        gen: 3,
+      });
+      expect(readCheckpoint(shared, 'recording-a')).toEqual(
+        expect.objectContaining({ handoff: 'active', documentId: 'doc-2', updatedAt: 2_000 })
+      );
+    });
+
+    it('continues an active checkpoint only with the explicit in-memory handoff for that recording', () => {
+      const tab = createMemoryStorage();
+      const shared = createMemoryStorage();
+      const state = makeStore(tab, shared, 'doc-1', 'recording-a').claim('session-a');
+      expect(makeStore(tab, shared, 'doc-1', 'recording-a').checkpoint({ ...state, nextSeq: 5, gen: 0 })).toBe(true);
+
+      const withoutHandoff = makeStore(tab, shared, 'doc-2', 'recovery-1');
+      expect(withoutHandoff.claim('session-a').recordingId).toBe('recovery-1');
+
+      const shared2 = createMemoryStorage();
+      const tab2 = createMemoryStorage();
+      const owned = makeStore(tab2, shared2, 'doc-1', 'recording-a').claim('session-a');
+      makeStore(tab2, shared2, 'doc-1', 'recording-a').checkpoint({ ...owned, nextSeq: 5, gen: 0 });
+      const replacement = makeStore(tab2, shared2, 'doc-2', 'recovery-2');
+      expect(replacement.claim('session-a', 'recording-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recording-a',
+        nextSeq: 5,
+        gen: 0,
+      });
+      expect(replacement.claim('session-a', 'other-recording').recordingId).toBe('recovery-2');
+    });
+
+    it('seals and checkpoints exact counters only while the document owns the active entry', () => {
+      const tab = createMemoryStorage();
+      const shared = createMemoryStorage();
+      const ownerStore = makeStore(tab, shared, 'owner-document', 'recording-a');
+      const state = ownerStore.claim('session-a');
+
+      expect(ownerStore.checkpoint({ ...state, nextSeq: 58, gen: 2 })).toBe(true);
+      expect(readCheckpoint(shared, 'recording-a')).toEqual(
+        expect.objectContaining({ nextSeq: 58, gen: 2, handoff: 'active' })
+      );
+
+      const stale = makeStore(tab, shared, 'stale-document', 'unused');
+      expect(stale.seal({ ...state, nextSeq: 100, gen: 3 })).toBe(false);
+      expect(stale.checkpoint({ ...state, nextSeq: 100, gen: 3 })).toBe(false);
+      expect(ownerStore.seal({ ...state, sessionId: 'session-b', nextSeq: 100, gen: 3 })).toBe(false);
+
+      expect(ownerStore.seal({ ...state, nextSeq: 60, gen: 2 })).toBe(true);
+      expect(readCheckpoint(shared, 'recording-a')).toEqual(expect.objectContaining({ nextSeq: 60, handoff: 'clean' }));
+      // A sealed entry is no longer owned by anyone.
+      expect(ownerStore.checkpoint({ ...state, nextSeq: 61, gen: 2 })).toBe(false);
+    });
+
+    it('rewrites the pointer to the recovery recording', () => {
+      const tab = createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'gone' }) });
+      const shared = createMemoryStorage();
+      expect(makeStore(tab, shared, 'doc-1', 'recovery').claim('session-a').recordingId).toBe('recovery');
+      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recovery' });
+      expect(readCheckpoint(shared, 'recovery')).toEqual(
+        expect.objectContaining({ handoff: 'active', documentId: 'doc-1' })
+      );
+    });
+  });
+
+  describe('cloned tabs', () => {
+    function dormantOriginal() {
+      const tab = createMemoryStorage();
+      const shared = createMemoryStorage();
+      const store = makeStore(tab, shared, 'doc-a1', 'recording-a');
+      const state = store.claim('session-a');
+      expect(store.seal({ ...state, nextSeq: 42, gen: 3 })).toBe(true);
+      return { tab, shared, clone: cloneTab(tab) };
+    }
+
+    it('lets the clone continue when it claims first and makes the original recover', () => {
+      const { tab, shared, clone } = dormantOriginal();
+
+      const cloneClaim = makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a');
+      const originalClaim = makeStore(tab, shared, 'doc-a2', 'recovery-original').claim('session-a');
+
+      expect(cloneClaim).toEqual({ sessionId: 'session-a', recordingId: 'recording-a', nextSeq: 42, gen: 3 });
+      expect(originalClaim).toEqual({ sessionId: 'session-a', recordingId: 'recovery-original', nextSeq: 0, gen: -1 });
+      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recovery-original' });
+      expect(JSON.parse(clone.getItem(pointerKey)!)).toEqual({ recordingId: 'recording-a' });
+    });
+
+    it('makes the clone recover when the original claims first', () => {
+      const { tab, shared, clone } = dormantOriginal();
+
+      const originalClaim = makeStore(tab, shared, 'doc-a2', 'recovery-original').claim('session-a');
+      const cloneClaim = makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a');
+
+      expect(originalClaim.recordingId).toBe('recording-a');
+      expect(cloneClaim).toEqual({ sessionId: 'session-a', recordingId: 'recovery-clone', nextSeq: 0, gen: -1 });
+    });
+
+    it('makes the clone recover after the winner navigated and reclaimed in between', () => {
+      const { tab, shared, clone } = dormantOriginal();
+
+      const second = makeStore(tab, shared, 'doc-a2', 'unused');
+      const state = second.claim('session-a');
+      expect(second.seal({ ...state, nextSeq: 50, gen: 4 })).toBe(true);
+      const third = makeStore(tab, shared, 'doc-a3', 'unused');
+      expect(third.claim('session-a')).toEqual(expect.objectContaining({ recordingId: 'recording-a', nextSeq: 50 }));
+
+      expect(makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a').recordingId).toBe(
+        'recovery-clone'
+      );
+    });
+
+    it('makes the clone recover when it claims while the winner is dormant again, without stale counters', () => {
+      const { tab, shared, clone } = dormantOriginal();
+
+      const second = makeStore(tab, shared, 'doc-a2', 'unused');
+      const state = second.claim('session-a');
+      expect(second.seal({ ...state, nextSeq: 50, gen: 4 })).toBe(true);
+
+      // The clone wins the dormant checkpoint, but from its latest sealed counters, never
+      // from the copied ones.
+      expect(makeStore(clone, shared, 'doc-c1', 'unused').claim('session-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recording-a',
+        nextSeq: 50,
+        gen: 4,
+      });
+      expect(makeStore(tab, shared, 'doc-a3', 'recovery-original').claim('session-a').recordingId).toBe(
+        'recovery-original'
+      );
+    });
+
+    it('lets both claimants of one replication race detect the other write and nothing else', () => {
+      const { tab, shared, clone } = dormantOriginal();
+      // Each renderer process reads its own replica of localStorage during the race window.
+      const replicaOriginal = cloneTab(shared);
+      const replicaClone = cloneTab(shared);
+      const original = makeStore(tab, replicaOriginal, 'doc-a2', 'recovery-original');
+      const cloned = makeStore(clone, replicaClone, 'doc-c1', 'recovery-clone');
+
+      const originalClaim = original.claim('session-a');
+      const cloneClaim = cloned.claim('session-a');
+      expect(cloneClaim).toEqual(originalClaim);
+
+      // The browser then delivers each write to the other Document as a storage event.
+      const key = checkpointKey('recording-a');
+      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)).toBe(true);
+      expect(cloned.hasLostOwnership('recording-a', key, replicaOriginal.getItem(key), null)).toBe(true);
+
+      // Own writes, other recordings, removals, malformed values, and other areas are not evidence.
+      expect(original.hasLostOwnership('recording-a', key, replicaOriginal.getItem(key), null)).toBe(false);
+      expect(
+        original.hasLostOwnership('recording-a', checkpointKey('recording-b'), replicaClone.getItem(key), null)
+      ).toBe(false);
+      expect(original.hasLostOwnership('recording-a', key, null, null)).toBe(false);
+      expect(original.hasLostOwnership('recording-a', key, 'not json', null)).toBe(false);
+      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), createMemoryStorage())).toBe(
+        false
+      );
+      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), replicaOriginal)).toBe(true);
+      expect(
+        makeStore(tab, undefined, 'doc-x', 'x').hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)
+      ).toBe(false);
+
+      // A sealed entry under the other Document is equally foreign.
+      expect(cloned.seal({ ...cloneClaim, nextSeq: 50, gen: 4 })).toBe(true);
+      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)).toBe(true);
+    });
+
+    it('gives both tabs continuity again after a split', () => {
+      const { tab, shared, clone } = dormantOriginal();
+
+      const cloneStore = makeStore(clone, shared, 'doc-c1', 'unused');
+      const cloneState = cloneStore.claim('session-a');
+      const originalStore = makeStore(tab, shared, 'doc-a2', 'recovery-original');
+      const originalState = originalStore.claim('session-a');
+
+      expect(cloneStore.seal({ ...cloneState, nextSeq: 45, gen: 4 })).toBe(true);
+      expect(originalStore.seal({ ...originalState, nextSeq: 7, gen: 0 })).toBe(true);
+
+      expect(makeStore(clone, shared, 'doc-c2', 'unused').claim('session-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recording-a',
+        nextSeq: 45,
+        gen: 4,
+      });
+      expect(makeStore(tab, shared, 'doc-a3', 'unused').claim('session-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recovery-original',
+        nextSeq: 7,
+        gen: 0,
+      });
+    });
+  });
+
+  describe('fail closed', () => {
+    const validCheckpoint = JSON.stringify({
+      sessionId: 'session-a',
+      nextSeq: 42,
+      gen: 3,
+      handoff: 'clean',
+      documentId: 'old-document',
+      updatedAt: 1_000,
+    });
+
+    it.each<[string, () => { tab: Storage | undefined; shared: Storage | undefined }]>([
+      [
+        'a missing pointer',
+        () => ({
+          tab: createMemoryStorage(),
+          shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }),
+        }),
+      ],
+      [
+        'a malformed pointer',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: '{"recordingId":42}' }),
+          shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }),
+        }),
+      ],
+      [
+        'a pointer to a missing checkpoint',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: createMemoryStorage(),
+        }),
+      ],
+      [
+        'a malformed checkpoint',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: createMemoryStorage({
+            [checkpointKey('recording-a')]: '{"sessionId":"session-a","handoff":"clean"}',
+          }),
+        }),
+      ],
+      [
+        'a checkpoint without updatedAt',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: createMemoryStorage({
+            [checkpointKey('recording-a')]: JSON.stringify({ ...JSON.parse(validCheckpoint), updatedAt: undefined }),
+          }),
+        }),
+      ],
+      [
+        'a checkpoint of another session',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: createMemoryStorage({
+            [checkpointKey('recording-a')]: JSON.stringify({ ...JSON.parse(validCheckpoint), sessionId: 'session-b' }),
+          }),
+        }),
+      ],
+      [
+        'unreadable shared storage',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: {
+            ...createMemoryStorage(),
+            getItem: () => {
+              throw new DOMException('Storage is not readable', 'SecurityError');
+            },
+          } as Storage,
+        }),
+      ],
+      [
+        'unwritable shared storage',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: {
+            ...createMemoryStorage(),
+            getItem: () => validCheckpoint,
+            setItem: () => {
+              throw new DOMException('Storage is not writable', 'SecurityError');
+            },
+          } as Storage,
+        }),
+      ],
+      [
+        'no tab storage',
+        () => ({ tab: undefined, shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }) }),
+      ],
+      [
+        'no shared storage',
+        () => ({
+          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
+          shared: undefined,
+        }),
+      ],
+    ])('mints a recovery recording for %s', (_scenario, setup) => {
+      const { tab, shared } = setup();
+      expect(makeStore(tab, shared, 'new-document', 'recovery').claim('session-a')).toEqual({
+        sessionId: 'session-a',
+        recordingId: 'recovery',
+        nextSeq: 0,
+        gen: -1,
+      });
+    });
+
+    it('does not adopt a legacy checkpoint and removes it', () => {
+      const legacyKey = `${legacyReplayRecordingStorageKeyPrefix}${owner}`;
+      const tab = createMemoryStorage({
+        [legacyKey]: JSON.stringify({
+          sessionId: 'session-a',
+          recordingId: 'legacy-recording',
+          nextSeq: 42,
+          gen: 3,
+          handoff: 'clean',
+          documentId: 'old-document',
+        }),
+        'unrelated-key': 'kept',
+      });
+      const store = makeStore(tab, createMemoryStorage(), 'doc-1', 'recovery');
+      store.removeLegacyState();
+
+      expect(tab.getItem(legacyKey)).toBeNull();
+      expect(tab.getItem('unrelated-key')).toBe('kept');
+      expect(store.claim('session-a').recordingId).toBe('recovery');
+    });
+  });
+
+  describe('pruning', () => {
+    function seedCheckpoints(shared: Storage, count: number, at: (index: number) => number) {
+      for (let index = 0; index < count; index++) {
+        makeStore(createMemoryStorage(), shared, `doc-${index}`, `recording-${index}`, () => at(index)).claim(
+          'session-a'
+        );
+      }
+    }
+
+    it('removes checkpoints older than the age bound but never the claiming tab entry', () => {
+      const shared = createMemoryStorage();
+      const base = 1_000_000;
+      seedCheckpoints(shared, 3, () => base);
+      const tab = createMemoryStorage();
+      const dormant = makeStore(tab, shared, 'doc-old', 'recording-old', () => base);
+      expect(dormant.seal({ ...dormant.claim('session-a'), nextSeq: 9, gen: 1 })).toBe(true);
+
+      const later = base + MAX_RECORDING_CHECKPOINT_AGE_MS + 1;
+      const claim = makeStore(tab, shared, 'doc-new', 'unused', () => later).claim('session-a');
+
+      expect(claim).toEqual(expect.objectContaining({ recordingId: 'recording-old', nextSeq: 9 }));
+      expect(checkpointKeys(shared)).toEqual([checkpointKey('recording-old')]);
+    });
+
+    it.each([5_000, 500])('keeps the claiming entry and newest active checkpoints when claimed at %i', (now) => {
+      const shared = createMemoryStorage();
+      const total = MAX_RETAINED_RECORDING_CHECKPOINTS + 5;
+      seedCheckpoints(shared, total, (index) => 1_000 + index);
+
+      const claim = makeStore(createMemoryStorage(), shared, 'doc-new', 'recording-new', () => now).claim('session-a');
+
+      expect(claim.recordingId).toBe('recording-new');
+      const keys = checkpointKeys(shared);
+      expect(keys).toHaveLength(MAX_RETAINED_RECORDING_CHECKPOINTS);
+      expect(keys).toContain(checkpointKey('recording-new'));
+      for (let index = 0; index < total; index++) {
+        expect(keys.includes(checkpointKey(`recording-${index}`))).toBe(
+          index >= total - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1)
+        );
+      }
+    });
+
+    it('preserves navigation continuity while other tabs repeatedly record and close', () => {
+      const tab = createMemoryStorage();
+      const shared = createMemoryStorage();
+      let now = 1_000;
+      const active = makeStore(tab, shared, 'doc-active', 'recording-active', () => now);
+      const state = active.claim('session-a');
+      const total = MAX_RETAINED_RECORDING_CHECKPOINTS + 5;
+
+      for (let index = 0; index < total; index++) {
+        now++;
+        const other = makeStore(createMemoryStorage(), shared, `doc-${index}`, `recording-${index}`, () => now);
+        expect(other.seal(other.claim('session-a'))).toBe(true);
+        expect(checkpointKeys(shared)).toHaveLength(Math.min(index + 2, MAX_RETAINED_RECORDING_CHECKPOINTS));
+      }
+
+      const keys = checkpointKeys(shared);
+      expect(keys).toContain(checkpointKey('recording-active'));
+      for (let index = 0; index < total; index++) {
+        expect(keys.includes(checkpointKey(`recording-${index}`))).toBe(
+          index >= total - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1)
+        );
+      }
+
+      now++;
+      const finalState = { ...state, nextSeq: 42, gen: 3 };
+      expect(active.seal(finalState)).toBe(true);
+      const nextPage = makeStore(tab, shared, 'doc-next', 'recovery', () => now + 1);
+      expect(nextPage.claim('session-a')).toEqual(finalState);
+    });
+
+    it('evicts clean checkpoints oldest first before falling back to the oldest active checkpoint', () => {
+      const shared = createMemoryStorage();
+      const activeCount = MAX_RETAINED_RECORDING_CHECKPOINTS - 2;
+      seedCheckpoints(shared, activeCount, (index) => 1_000 + index);
+      for (let index = 0; index < 2; index++) {
+        const clean = makeStore(
+          createMemoryStorage(),
+          shared,
+          `doc-clean-${index}`,
+          `clean-${index}`,
+          () => 2_000 + index
+        );
+        expect(clean.seal(clean.claim('session-a'))).toBe(true);
+      }
+
+      for (let index = 0; index < 3; index++) {
+        makeStore(createMemoryStorage(), shared, `doc-new-${index}`, `new-${index}`, () => 3_000 + index).claim(
+          'session-a'
+        );
+
+        const keys = checkpointKeys(shared);
+        expect(keys).toHaveLength(MAX_RETAINED_RECORDING_CHECKPOINTS);
+        expect(keys).not.toContain(checkpointKey('clean-0'));
+        expect(keys.includes(checkpointKey('clean-1'))).toBe(index === 0);
+        expect(keys.includes(checkpointKey('recording-0'))).toBe(index < 2);
+        for (let activeIndex = 1; activeIndex < activeCount; activeIndex++) {
+          expect(keys).toContain(checkpointKey(`recording-${activeIndex}`));
+        }
+        for (let newIndex = 0; newIndex <= index; newIndex++) {
+          expect(keys).toContain(checkpointKey(`new-${newIndex}`));
+        }
+      }
+    });
+
+    it('removes malformed entries under the owner prefix and leaves other keys alone', () => {
+      const shared = createMemoryStorage({
+        [checkpointKey('broken')]: 'not json',
+        [`${replayRecordingCheckpointKeyPrefix}["other-owner"]:recording`]: 'not json',
+        'com.grafana.faro.session': 'kept',
+      });
+
+      makeStore(createMemoryStorage(), shared, 'doc-1', 'recording-a', () => 1_000).claim('session-a');
+
+      expect(shared.getItem(checkpointKey('broken'))).toBeNull();
+      expect(shared.getItem(`${replayRecordingCheckpointKeyPrefix}["other-owner"]:recording`)).toBe('not json');
+      expect(shared.getItem('com.grafana.faro.session')).toBe('kept');
+    });
+
+    it('makes a pruned dormant tab recover instead of continuing', () => {
+      const shared = createMemoryStorage();
+      const base = 1_000_000;
+      const tab = createMemoryStorage();
+      const dormant = makeStore(tab, shared, 'doc-old', 'recording-old', () => base);
+      expect(dormant.seal({ ...dormant.claim('session-a'), nextSeq: 9, gen: 1 })).toBe(true);
+
+      const later = base + MAX_RECORDING_CHECKPOINT_AGE_MS + 1;
+      makeStore(createMemoryStorage(), shared, 'doc-other', 'recording-other', () => later).claim('session-a');
+      expect(shared.getItem(checkpointKey('recording-old'))).toBeNull();
+
+      expect(makeStore(tab, shared, 'doc-new', 'recovery', () => later + 1).claim('session-a').recordingId).toBe(
+        'recovery'
+      );
+    });
+  });
+});

--- a/experimental/instrumentation-replay/src/recordingState.ts
+++ b/experimental/instrumentation-replay/src/recordingState.ts
@@ -1,0 +1,337 @@
+export interface ReplayRecordingState {
+  sessionId: string;
+  recordingId: string;
+  nextSeq: number;
+  gen: number;
+}
+
+interface PersistedReplayRecordingState extends Omit<ReplayRecordingState, 'recordingId'> {
+  handoff: 'active' | 'clean';
+  documentId: string;
+  updatedAt: number;
+}
+
+interface PersistedRecordingPointer {
+  recordingId: string;
+}
+
+export interface ReplayRecordingStateStoreOptions {
+  // Tab-scoped storage (sessionStorage) holding only a pointer to the current recording.
+  // A browser may copy it into a derived tab; that is harmless because it carries no counters.
+  tabStorage: Storage | undefined;
+  // Origin-shared storage (localStorage) holding one checkpoint per recording. Every tab that
+  // references a recording reads and writes the same entry, so ownership is unambiguous.
+  sharedStorage: Storage | undefined;
+  ownerNamespace: string;
+  documentId: string;
+  generateRecordingId: () => string;
+  now?: () => number;
+  // Shared by replacement stores for the same owner in one Document.
+  abandonedRecordingIds?: Set<string>;
+}
+
+export const replayRecordingPointerKeyPrefix = 'com.grafana.faro.replay.tab:';
+export const replayRecordingCheckpointKeyPrefix = 'com.grafana.faro.replay.rec:';
+// Pre-v3 builds kept a copyable checkpoint under this key. It is removed, never adopted.
+export const legacyReplayRecordingStorageKeyPrefix = 'com.grafana.faro.replay:';
+
+// Pruning only costs continuity, for a dormant tab or for a live tab beyond the bounds whose
+// entry is refreshed only at Document boundaries; it can never enable a collision.
+export const MAX_RETAINED_RECORDING_CHECKPOINTS: number = 16;
+export const MAX_RECORDING_CHECKPOINT_AGE_MS: number = 24 * 60 * 60 * 1000;
+
+export function createMemoryStorage(initial: Record<string, string> = {}): Storage {
+  const entries = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return entries.size;
+    },
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, String(value)),
+    removeItem: (key: string) => void entries.delete(key),
+    clear: () => entries.clear(),
+  };
+}
+
+export class ReplayRecordingStateStore {
+  private readonly tabStorage: Storage | undefined;
+  private readonly sharedStorage: Storage | undefined;
+  private readonly documentId: string;
+  private readonly generateRecordingId: () => string;
+  private readonly now: () => number;
+  private readonly pointerKey: string;
+  private readonly checkpointKeyPrefix: string;
+  private readonly legacyKey: string;
+  private readonly abandonedRecordingIds: Set<string>;
+
+  constructor(options: ReplayRecordingStateStoreOptions) {
+    this.tabStorage = options.tabStorage;
+    this.sharedStorage = options.sharedStorage;
+    this.documentId = options.documentId;
+    this.generateRecordingId = options.generateRecordingId;
+    this.now = options.now ?? (() => Date.now());
+    this.pointerKey = `${replayRecordingPointerKeyPrefix}${options.ownerNamespace}`;
+    this.checkpointKeyPrefix = `${replayRecordingCheckpointKeyPrefix}${options.ownerNamespace}:`;
+    this.legacyKey = `${legacyReplayRecordingStorageKeyPrefix}${options.ownerNamespace}`;
+    this.abandonedRecordingIds = options.abandonedRecordingIds ?? new Set();
+  }
+
+  // Prefer the one-time same-document handoff over a possibly stale tab pointer.
+  // Continue only a clean checkpoint or the explicitly handed-off active checkpoint.
+  // Missing, invalid, or abandoned state fails closed into a recovery recording.
+  claim(sessionId: string, activeHandoffRecordingId?: string): ReplayRecordingState {
+    const recordingId = activeHandoffRecordingId ?? this.readPointer();
+    if (recordingId !== undefined && !this.abandonedRecordingIds.has(recordingId)) {
+      const persisted = this.readCheckpoint(recordingId);
+      if (
+        persisted?.sessionId === sessionId &&
+        (persisted.handoff === 'clean' || (persisted.handoff === 'active' && recordingId === activeHandoffRecordingId))
+      ) {
+        const continuedState: ReplayRecordingState = {
+          sessionId,
+          recordingId,
+          nextSeq: persisted.nextSeq,
+          gen: persisted.gen,
+        };
+        if (this.writeCheckpoint(continuedState, 'active')) {
+          if (activeHandoffRecordingId !== undefined) {
+            this.writePointer(recordingId);
+          }
+          this.prune(recordingId);
+          return continuedState;
+        }
+      }
+    }
+
+    const recoveryState: ReplayRecordingState = {
+      sessionId,
+      recordingId: this.generateRecordingId(),
+      nextSeq: 0,
+      gen: -1,
+    };
+    this.writeCheckpoint(recoveryState, 'active');
+    // A claimant that lost points at its own recording from now on and stops touching the
+    // winner's entry, so both tabs regain continuity after a split.
+    this.writePointer(recoveryState.recordingId);
+    this.prune(recoveryState.recordingId);
+    return recoveryState;
+  }
+
+  // Revocation must survive failed pointer writes and later clean checkpoints.
+  abandon(recordingId: string): void {
+    this.abandonedRecordingIds.add(recordingId);
+  }
+
+  checkpoint(state: ReplayRecordingState): boolean {
+    return this.transition(state, 'active');
+  }
+
+  // Whether a `storage` event from another Document shows that this recording's entry now
+  // belongs to a different Document. Two claimants can both read a clean checkpoint inside the
+  // browser's cross-process replication window; the browser then delivers the other claimant's
+  // write as a `storage` event, which is the positive evidence this Document lost the race.
+  // A removed entry is not evidence of a claimant, so it only costs continuity later.
+  hasLostOwnership(
+    recordingId: string,
+    key: string | null,
+    newValue: string | null,
+    storageArea: Storage | null
+  ): boolean {
+    if (!this.sharedStorage || key !== this.checkpointKey(recordingId)) {
+      return false;
+    }
+
+    if (storageArea !== null && storageArea !== this.sharedStorage) {
+      return false;
+    }
+
+    const persisted = this.parseCheckpoint(newValue);
+    return persisted !== undefined && persisted.documentId !== this.documentId;
+  }
+
+  seal(state: ReplayRecordingState): boolean {
+    return this.transition(state, 'clean');
+  }
+
+  removeLegacyState(): void {
+    try {
+      this.tabStorage?.removeItem(this.legacyKey);
+    } catch {
+      // Best effort: the legacy key is never read, so leaving it behind is harmless.
+    }
+  }
+
+  private transition(state: ReplayRecordingState, handoff: PersistedReplayRecordingState['handoff']): boolean {
+    const persisted = this.readCheckpoint(state.recordingId);
+    if (
+      persisted?.handoff !== 'active' ||
+      persisted.documentId !== this.documentId ||
+      persisted.sessionId !== state.sessionId
+    ) {
+      return false;
+    }
+
+    return this.writeCheckpoint(state, handoff);
+  }
+
+  // Remove other recordings' checkpoints past the age bound, then evict the oldest clean
+  // checkpoints before active ones to meet the cap.
+  // The claiming tab's own entry is exempt. Malformed entries under our prefix can never be
+  // claimed, so they are removed as well.
+  private prune(exemptRecordingId: string): void {
+    const storage = this.sharedStorage;
+    if (!storage) {
+      return;
+    }
+
+    try {
+      const exemptKey = this.checkpointKey(exemptRecordingId);
+      const candidates: string[] = [];
+      for (let index = 0; index < storage.length; index++) {
+        const key = storage.key(index);
+        if (key === null || key === exemptKey || !key.startsWith(this.checkpointKeyPrefix)) {
+          continue;
+        }
+        candidates.push(key);
+      }
+
+      const now = this.now();
+      const retained: Array<{
+        key: string;
+        updatedAt: number;
+        handoff: PersistedReplayRecordingState['handoff'];
+      }> = [];
+      for (const key of candidates) {
+        const state = this.parseCheckpoint(storage.getItem(key));
+        if (state === undefined || now - state.updatedAt > MAX_RECORDING_CHECKPOINT_AGE_MS) {
+          storage.removeItem(key);
+        } else {
+          retained.push({ key, updatedAt: state.updatedAt, handoff: state.handoff });
+        }
+      }
+
+      retained.sort((a, b) => {
+        if (a.handoff !== b.handoff) {
+          return a.handoff === 'clean' ? -1 : 1;
+        }
+        return a.updatedAt - b.updatedAt;
+      });
+      const excess = Math.max(0, retained.length - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1));
+      for (const stale of retained.slice(0, excess)) {
+        storage.removeItem(stale.key);
+      }
+    } catch {
+      // Pruning is best effort and must never affect the claim that triggered it.
+    }
+  }
+
+  private checkpointKey(recordingId: string): string {
+    return `${this.checkpointKeyPrefix}${recordingId}`;
+  }
+
+  private readPointer(): string | undefined {
+    if (!this.tabStorage) {
+      return undefined;
+    }
+
+    try {
+      const serialized = this.tabStorage.getItem(this.pointerKey);
+      if (!serialized) {
+        return undefined;
+      }
+
+      const value: unknown = JSON.parse(serialized);
+      return this.isPointer(value) ? value.recordingId : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writePointer(recordingId: string): void {
+    if (!this.tabStorage) {
+      return;
+    }
+
+    try {
+      const pointer: PersistedRecordingPointer = { recordingId };
+      this.tabStorage.setItem(this.pointerKey, JSON.stringify(pointer));
+    } catch {
+      // The in-memory recording remains usable even if its pointer cannot be persisted.
+    }
+  }
+
+  private readCheckpoint(recordingId: string): PersistedReplayRecordingState | undefined {
+    if (!this.sharedStorage) {
+      return undefined;
+    }
+
+    try {
+      return this.parseCheckpoint(this.sharedStorage.getItem(this.checkpointKey(recordingId)));
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseCheckpoint(serialized: string | null): PersistedReplayRecordingState | undefined {
+    if (!serialized) {
+      return undefined;
+    }
+
+    try {
+      const value: unknown = JSON.parse(serialized);
+      return this.isPersistedState(value) ? value : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writeCheckpoint(state: ReplayRecordingState, handoff: PersistedReplayRecordingState['handoff']): boolean {
+    if (!this.sharedStorage) {
+      return false;
+    }
+
+    try {
+      const persisted: PersistedReplayRecordingState = {
+        sessionId: state.sessionId,
+        nextSeq: state.nextSeq,
+        gen: state.gen,
+        handoff,
+        documentId: this.documentId,
+        updatedAt: this.now(),
+      };
+      this.sharedStorage.setItem(this.checkpointKey(state.recordingId), JSON.stringify(persisted));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private isPointer(value: unknown): value is PersistedRecordingPointer {
+    return (
+      value != null &&
+      typeof value === 'object' &&
+      typeof (value as Partial<PersistedRecordingPointer>).recordingId === 'string' &&
+      (value as PersistedRecordingPointer).recordingId.length > 0
+    );
+  }
+
+  private isPersistedState(value: unknown): value is PersistedReplayRecordingState {
+    if (value == null || typeof value !== 'object') {
+      return false;
+    }
+
+    const state = value as Partial<PersistedReplayRecordingState>;
+    return (
+      typeof state.sessionId === 'string' &&
+      Number.isSafeInteger(state.nextSeq) &&
+      state.nextSeq! >= 0 &&
+      Number.isSafeInteger(state.gen) &&
+      state.gen! >= -1 &&
+      (state.handoff === 'active' || state.handoff === 'clean') &&
+      typeof state.documentId === 'string' &&
+      Number.isSafeInteger(state.updatedAt) &&
+      state.updatedAt! >= 0
+    );
+  }
+}

--- a/experimental/instrumentation-replay/src/session.integration.test.ts
+++ b/experimental/instrumentation-replay/src/session.integration.test.ts
@@ -1,0 +1,173 @@
+import { initializeFaro, type TransportBody } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { makeCoreConfig } from '../../../packages/web-sdk/src/config/makeCoreConfig';
+import { SessionInstrumentation } from '../../../packages/web-sdk/src/instrumentations/session/instrumentation';
+import {
+  SESSION_EXPIRATION_TIME,
+  SESSION_INACTIVITY_TIME,
+  STORAGE_KEY,
+} from '../../../packages/web-sdk/src/instrumentations/session/sessionManager';
+import { FetchTransport } from '../../../packages/web-sdk/src/transports/fetch-v2/transport';
+
+import { ReplayInstrumentation } from './instrumentation';
+
+describe.each([true, false])('Replay through fetch-v2 with persistent=%s', (persistent) => {
+  const originalFetch = globalThis.fetch;
+  let replay: ReplayInstrumentation;
+  let requests: Array<{ sessionId: string; body: TransportBody }>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    requests = [];
+    globalThis.fetch = jest.fn(async (_url, init) => {
+      requests.push({
+        sessionId: (init!.headers as Record<string, string>)['x-faro-session-id']!,
+        body: JSON.parse(init!.body as string),
+      });
+      return { status: 202, headers: { get: () => null }, text: async () => '' } as unknown as Response;
+    });
+  });
+
+  afterEach(() => {
+    replay?.destroy();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    globalThis.fetch = originalFetch;
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  function start(inactivityThresholdMs: number) {
+    replay = new ReplayInstrumentation({ recordAfter: 'DOMContentLoaded', inactivityThresholdMs });
+    return initializeFaro(
+      makeCoreConfig(
+        mockConfig({
+          batching: {},
+          instrumentations: [new SessionInstrumentation(), replay],
+          sessionTracking: { enabled: true, persistent, samplingRate: 1 },
+          transports: [new FetchTransport({ url: 'https://collector.test/collect', requestTimeoutMs: 0 })],
+        })
+      )!
+    );
+  }
+
+  async function flush() {
+    await jest.advanceTimersByTimeAsync(250);
+  }
+
+  function recordings() {
+    return requests.flatMap(({ body }) =>
+      (body.events ?? [])
+        .filter((event) => event.name === 'faro.session_recording.event')
+        .map((event) => ({ sessionId: body.meta.session?.id, attributes: event.attributes! }))
+    );
+  }
+
+  function expectConsistentOwnership() {
+    expect(requests.every(({ sessionId, body }) => sessionId === body.meta.session?.id)).toBe(true);
+    const owners = new Map<string, string | undefined>();
+    for (const { sessionId, attributes } of recordings()) {
+      const recordingId = attributes['recording_id']!;
+      if (owners.has(recordingId)) {
+        expect(sessionId).toBe(owners.get(recordingId));
+      } else {
+        owners.set(recordingId, sessionId);
+      }
+    }
+    expect(owners.size).toBe(2);
+  }
+
+  it('starts a new recording before resuming an expired session', async () => {
+    const faro = start(1000);
+    const sessionA = faro.api.getSession()?.id;
+    await flush();
+    const recordingA = recordings()[0]!.attributes['recording_id'];
+    await jest.advanceTimersByTimeAsync(1000);
+    await flush();
+    jest.setSystemTime(Date.now() + SESSION_INACTIVITY_TIME + 1);
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+
+    const sessionB = faro.api.getSession()?.id;
+    expect(sessionB).not.toBe(sessionA);
+    expect(
+      recordings()
+        .filter((event) => event.sessionId === sessionB)
+        .map((event) => event.attributes['seq'])
+    ).toEqual(['0', '1']);
+    expect(
+      recordings()
+        .filter((event) => event.sessionId === sessionB)
+        .every((event) => event.attributes['recording_id'] !== recordingA)
+    ).toBe(true);
+    expectConsistentOwnership();
+  });
+
+  it('does not move queued incremental events at a lifetime boundary', async () => {
+    const faro = start(0);
+    await flush();
+    const sessionA = faro.api.getSession()?.id;
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 11 }));
+    const storage = persistent ? window.localStorage : window.sessionStorage;
+    const stored = JSON.parse(storage.getItem(STORAGE_KEY)!);
+    jest.setSystemTime(stored.started + SESSION_EXPIRATION_TIME + 1);
+    stored.lastActivity = Date.now();
+    storage.setItem(STORAGE_KEY, JSON.stringify(stored));
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 22 }));
+    await flush();
+
+    expect(faro.api.getSession()?.id).not.toBe(sessionA);
+    const before = recordings().find((event) => JSON.parse(event.attributes['event']!).data?.x === 11);
+    expect(before?.sessionId).toBe(sessionA);
+    expectConsistentOwnership();
+  });
+
+  it('ignores a delayed session-invalid response for a rotated-away session and keeps the new recording', async () => {
+    // Hold the first request so the collector can answer it after the session has rotated.
+    let held: { sessionId: string; resolve: (response: Response) => void } | undefined;
+    globalThis.fetch = jest.fn((_url, init) => {
+      const sessionId = (init!.headers as Record<string, string>)['x-faro-session-id']!;
+      requests.push({ sessionId, body: JSON.parse(init!.body as string) });
+      if (!held) {
+        return new Promise<Response>((resolve) => (held = { sessionId, resolve }));
+      }
+      return Promise.resolve({
+        status: 202,
+        headers: { get: () => null },
+        text: async () => '',
+      } as unknown as Response);
+    });
+
+    const faro = start(1000);
+    const sessionA = faro.api.getSession()!.id;
+    await flush();
+    expect(held?.sessionId).toBe(sessionA);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    jest.setSystemTime(Date.now() + SESSION_INACTIVITY_TIME + 1);
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    const sessionB = faro.api.getSession()!.id;
+    expect(sessionB).not.toBe(sessionA);
+    const recordingB = recordings().find((event) => event.sessionId === sessionB)!.attributes['recording_id'];
+
+    held!.resolve({
+      status: 202,
+      headers: { get: (name: string) => (name === 'X-Faro-Session-Status' ? 'invalid' : null) },
+      text: async () => '',
+    } as unknown as Response);
+    await flush();
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 5 }));
+    await flush();
+
+    expect(faro.api.getSession()!.id).toBe(sessionB);
+    const underB = recordings().filter((event) => event.sessionId === sessionB);
+    expect(underB.length).toBeGreaterThan(2);
+    expect(underB.every((event) => event.attributes['recording_id'] === recordingB)).toBe(true);
+    expect(underB.map((event) => event.attributes['seq'])).toEqual(underB.map((_, index) => String(index)));
+    expectConsistentOwnership();
+  });
+});


### PR DESCRIPTION
**Stack 4/5:** #2259 → #2261 → #2260 → #2256 → #2264.

Merge in this order into `main`, retargeting each child after its parent merges and retaining parent branches until restacked. Release the complete stack together, after collector CORS support for `Idempotency-Key` is deployed.

Replay events lacked the identity needed to distinguish concurrent recordings or detect missing events. This adds recording identity and preserves it across safe navigation and same-document handoffs, while recovering with a new identity when ownership is uncertain.

## Changes

- Add `recording_id`, checkpoint generation `gen`, and recording-wide `seq` to replay events; lifecycle markers carry `recording_id`. Reserve counters after Replay's `beforeSend` accepts an event and before serialization, so serialization failures and later global filtering leave detectable gaps.
- Store shared checkpoints in `localStorage` and a per-tab pointer in `sessionStorage`, scoped by global key and app name/namespace/environment. Deployment version changes retain continuity.
- Continue only a clean checkpoint for the same session or an explicit same-document handoff. Seal on `pagehide`, reclaim on BFCache restore, and create a new recording after session rotation or unsafe ownership.
- On a competing storage claim, abandon the identity before restarting. Abandonment survives instrumentation replacement and failed pointer writes; successful handoffs repair stale pointers without overwriting another document's checkpoint.
- Prune malformed and older-than-24-hour checkpoints at claim time, then enforce a 16-checkpoint cap by evicting clean entries before active ones, oldest first. Exempt the claimed recording. Storage failure falls back to document-local continuity; events do not write storage individually.
- Add an experimental changelog entry. Recording-identity documentation is still missing from the README.

## Compatibility and limits

Attributes are additive; the serialized rrweb event is unchanged. Older producers lack identity, so consumers must handle legacy events. Instances sharing the same global key and app identity share a tab pointer, including same-origin frames.

Simultaneous claims can briefly overlap until cross-process `storage` notifications arrive. Pruning can sacrifice continuity for long-lived tabs; recovery starts a new recording. Receiver deduplication is outside this PR.

## Validation

CI passes at `b695fc93` (checked 2026-09-11), including Node tests and browser smoke tests. Coverage includes sequence gaps and reentrant serialization, cloned tabs, ownership loss, failed pointer writes, replacement, pruning, namespace isolation, navigation/BFCache, and real-session/Fetch integration across expiry and delayed invalidation.

Closes #2242. Refs #2241, #2254, #2255.
