### PR TITLE
fix(replay): discard invalidated recorder attempts

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Fix (`@grafana/faro-instrumentation-replay`): Pause inactive recordings even when metadata
+  capture fails, and contain errors when publishing the paused lifecycle event (#2260).
+
 ## 2.4.0
 
 - Feature (`@grafana/faro-transport-otlp-http`): OTLP HTTP transport now supports async dynamic header values.

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Next
 
-- Fix (`@grafana/faro-instrumentation-replay`): Pause inactive recordings even when metadata
-  capture fails, and contain errors when publishing the paused lifecycle event (#2260).
-
 ## 2.4.0
 
 - Feature (`@grafana/faro-transport-otlp-http`): OTLP HTTP transport now supports async dynamic header values.

--- a/experimental/instrumentation-replay/README.md
+++ b/experimental/instrumentation-replay/README.md
@@ -119,6 +119,12 @@ initializeFaro({
 | ------------ | -------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
 | `beforeSend` | `(event: eventWithTime) => eventWithTime \| null \| undefined` | `undefined` | Transform or filter events before they are sent. Return `null` or `undefined` to skip sending |
 
+Replay reconciles session state before starting, pausing, resuming, or accepting recorder events.
+Synchronous capture keeps that decision consistent through event submission. If `beforeSend` or
+rrweb callbacks such as `maskInputFn` change the session, revoke sampling, or destroy Replay,
+the invalidated attempt's pending events are discarded. Startup publishes nothing until rrweb
+returns a stop function and the attempt remains eligible.
+
 ## Privacy and Security
 
 This instrumentation records user interactions on your website. Make sure to:

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -66,6 +66,69 @@ describe('Replay callback and startup safety', () => {
     return events().filter((item) => item.payload.name === 'faro.session_recording.event');
   }
 
+  it('pauses despite a capture listener failure and resumes after the listener recovers', () => {
+    start({ inactivityThresholdMs: 5_000 });
+    const failedCapture = () => {
+      throw new Error('capture failed');
+    };
+    faro.metas.addCaptureListener(failedCapture);
+
+    expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(events().map((item) => item.payload.name)).toEqual(['faro.session_recording.started']);
+
+    faro.metas.removeCaptureListener(failedCapture);
+    emit(changeEvent());
+    expect(recordings()).toEqual([]);
+    document.dispatchEvent(new Event('pointerdown'));
+
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(events().map((item) => item.payload.name)).toEqual([
+      'faro.session_recording.started',
+      'faro.session_recording.resumed',
+    ]);
+  });
+
+  it('stays paused when publishing the paused event fails', () => {
+    start({ inactivityThresholdMs: 5_000 });
+    const pushEvent = jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(() => {
+      throw new Error('publication failed');
+    });
+
+    try {
+      expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
+      expect(stop).toHaveBeenCalledTimes(1);
+      emit(changeEvent());
+      expect(recordings()).toEqual([]);
+      document.dispatchEvent(new Event('pointerdown'));
+      expect(mockRecord).toHaveBeenCalledTimes(2);
+      expect(events().map((item) => item.payload.name)).toEqual([
+        'faro.session_recording.started',
+        'faro.session_recording.resumed',
+      ]);
+    } finally {
+      pushEvent.mockRestore();
+    }
+  });
+
+  it.each(['rotate', 'clear'])('does not publish a paused event after capture changes the session: %s', (action) => {
+    start({ inactivityThresholdMs: 5_000 });
+    const changeSession = () => {
+      faro.metas.removeCaptureListener(changeSession);
+      if (action === 'rotate') {
+        setSession('B');
+      } else {
+        faro.api.setSession(undefined);
+      }
+    };
+    faro.metas.addCaptureListener(changeSession);
+
+    jest.advanceTimersByTime(5_000);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(events().filter((item) => item.payload.name === 'faro.session_recording.paused')).toEqual([]);
+  });
+
   it.each(['no-stop', 'throw'])('discards synchronous startup events when record fails: %s', (failure) => {
     mockRecord.mockImplementation((options) => {
       options.emit(metaEvent());

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -43,6 +43,7 @@ describe('Replay callback and startup safety', () => {
 
   afterEach(() => {
     replay?.destroy();
+    jest.restoreAllMocks();
     document.body.replaceChildren();
     window.sessionStorage.clear();
     jest.clearAllTimers();
@@ -139,6 +140,104 @@ describe('Replay callback and startup safety', () => {
     });
     start();
     expect(events()).toEqual([]);
+  });
+
+  it.each(['start', 'resume'])('logs stop failures when an attempt is invalidated during %s', async (phase) => {
+    replay = new ReplayInstrumentation({ inactivityThresholdMs: 5_000 });
+    const logWarn = jest.spyOn(replay, 'logWarn');
+    if (phase === 'resume') {
+      faro.instrumentations.add(replay);
+      jest.advanceTimersByTime(5_000);
+    }
+    const previousEvents = [...events()];
+    const stopError = new Error('stop failed');
+    const stopInvalidated = jest.fn(() => {
+      throw stopError;
+    });
+    mockRecord.mockImplementationOnce((options) => {
+      emit = options.emit;
+      emit(metaEvent());
+      setSession('B');
+      return stopInvalidated;
+    });
+
+    expect(() => {
+      if (phase === 'resume') {
+        document.dispatchEvent(new Event('pointerdown'));
+      } else {
+        faro.instrumentations.add(replay);
+      }
+    }).not.toThrow();
+
+    expect(stopInvalidated).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledWith('Failed to stop session replay', stopError);
+    expect(logWarn).not.toHaveBeenCalledWith(`Failed to ${phase} session replay`, stopError);
+    expect(events()).toEqual(previousEvents);
+    const staleEmit = emit;
+    staleEmit(changeEvent());
+    expect(recordings()).toEqual([]);
+
+    await Promise.resolve();
+
+    expect(mockRecord).toHaveBeenCalledTimes(phase === 'resume' ? 3 : 2);
+    staleEmit(changeEvent());
+    expect(recordings()).toEqual([]);
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['B']);
+  });
+
+  it('does not retry a failed reinitialization from a previous lifecycle', async () => {
+    start();
+    setSession('B');
+    faro.instrumentations.remove(replay);
+    mockRecord.mockReturnValueOnce(undefined);
+    faro.instrumentations.add(replay);
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+
+    await Promise.resolve();
+
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    setSession('B');
+    await Promise.resolve();
+    expect(mockRecord).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves coalescing of new starts when a previous lifecycle callback runs', async () => {
+    start();
+    setSession('B');
+    faro.instrumentations.remove(replay);
+    faro.instrumentations.add(replay);
+
+    // Notify between the old callback and the new one; this must not queue a second retry.
+    const notification = Promise.resolve().then(() => setSession('D'));
+    setSession('C');
+    mockRecord.mockReturnValueOnce(undefined);
+    await notification;
+    await Promise.resolve();
+
+    expect(mockRecord).toHaveBeenCalledTimes(3);
+    expect(stop).toHaveBeenCalledTimes(2);
+  });
+
+  it('can restart after a removed listener queues work during destruction', async () => {
+    faro.metas.addListener((meta) => {
+      if (meta.session?.id === 'B') {
+        faro.instrumentations.remove(replay);
+      }
+    });
+    start();
+    // Core still invokes the removed replay listener in this notification's iteration.
+    setSession('B');
+    faro.instrumentations.add(replay);
+    await Promise.resolve();
+
+    setSession('C');
+    await Promise.resolve();
+
+    expect(mockRecord).toHaveBeenCalledTimes(3);
+    expect(stop).toHaveBeenCalledTimes(2);
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['C']);
   });
 
   it('publishes the lifecycle marker before buffered events and then accepts live events', () => {

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -262,6 +262,33 @@ describe('Replay callback and startup safety', () => {
     expect(recordings()).toHaveLength(1);
   });
 
+  it.each(['A', 'B'])('preserves a recorder reinitialized during resume for session %s', async (sessionId) => {
+    start({ inactivityThresholdMs: 5_000 });
+    jest.advanceTimersByTime(5_000);
+    const reinitialize = () => {
+      faro.metas.removeCaptureListener(reinitialize);
+      faro.instrumentations.remove(replay);
+      setSession(sessionId);
+      faro.instrumentations.add(replay);
+    };
+    faro.metas.addCaptureListener(reinitialize);
+
+    document.dispatchEvent(new Event('pointerdown'));
+    await Promise.resolve();
+
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(events().filter((item) => item.payload.name === 'faro.session_recording.resumed')).toEqual([]);
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual([sessionId]);
+
+    faro.instrumentations.remove(replay);
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    emit(changeEvent());
+    expect(recordings()).toHaveLength(1);
+  });
+
   it('publishes the lifecycle marker before buffered events and then accepts live events', () => {
     mockRecord.mockImplementation((options) => {
       emit = options.emit;

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -240,6 +240,28 @@ describe('Replay callback and startup safety', () => {
     expect(recordings().map((item) => item.meta.session?.id)).toEqual(['C']);
   });
 
+  it('does not leak a recorder when a capture listener reinitializes replay', () => {
+    const reinitialize = () => {
+      faro.metas.removeCaptureListener(reinitialize);
+      faro.instrumentations.remove(replay);
+      faro.instrumentations.add(replay);
+    };
+    faro.metas.addCaptureListener(reinitialize);
+
+    start();
+
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
+
+    faro.instrumentations.remove(replay);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    emit(changeEvent());
+    expect(recordings()).toHaveLength(1);
+  });
+
   it('publishes the lifecycle marker before buffered events and then accepts live events', () => {
     mockRecord.mockImplementation((options) => {
       emit = options.emit;

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -1,0 +1,228 @@
+import { type EventEvent, type Faro, initializeFaro, type TransportItem } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+import { EventType, type eventWithTime } from '@grafana/rrweb-types';
+
+import { ReplayInstrumentation } from './instrumentation';
+import type { ReplayInstrumentationOptions } from './types';
+
+jest.mock('@grafana/rrweb', () => ({ record: jest.fn() }));
+
+const metaEvent = (): eventWithTime => ({
+  type: EventType.Meta,
+  data: { href: 'https://example.com/', width: 1, height: 1 },
+  timestamp: Date.now(),
+});
+const changeEvent = (): eventWithTime => ({
+  type: EventType.Custom,
+  data: { tag: 'change', payload: null },
+  timestamp: Date.now(),
+});
+
+describe('Replay callback and startup safety', () => {
+  let faro: Faro;
+  let replay: ReplayInstrumentation;
+  let transport: MockTransport;
+  let mockRecord: jest.Mock;
+  let emit: (event: eventWithTime) => void;
+  let stop: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.sessionStorage.clear();
+    mockRecord = require('@grafana/rrweb').record;
+    mockRecord.mockReset();
+    stop = jest.fn();
+    mockRecord.mockImplementation((options) => {
+      emit = options.emit;
+      return stop;
+    });
+    transport = new MockTransport();
+    faro = initializeFaro(mockConfig({ transports: [transport] }));
+    setSession('A');
+  });
+
+  afterEach(() => {
+    replay?.destroy();
+    document.body.replaceChildren();
+    window.sessionStorage.clear();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  function setSession(id: string, sampled = true) {
+    faro.api.setSession({ id, attributes: { isSampled: String(sampled) } });
+  }
+
+  function start(options: ReplayInstrumentationOptions = {}) {
+    replay = new ReplayInstrumentation({ recordAfter: 'DOMContentLoaded', ...options });
+    faro.instrumentations.add(replay);
+  }
+
+  function events() {
+    return transport.items as Array<TransportItem<EventEvent>>;
+  }
+
+  function recordings() {
+    return events().filter((item) => item.payload.name === 'faro.session_recording.event');
+  }
+
+  it.each(['no-stop', 'throw'])('discards synchronous startup events when record fails: %s', (failure) => {
+    mockRecord.mockImplementation((options) => {
+      options.emit(metaEvent());
+      if (failure === 'throw') {
+        throw new Error('recorder failed');
+      }
+      return undefined;
+    });
+    start();
+    expect(events()).toEqual([]);
+  });
+
+  it('publishes the lifecycle marker before buffered events and then accepts live events', () => {
+    mockRecord.mockImplementation((options) => {
+      emit = options.emit;
+      emit(metaEvent());
+      emit(changeEvent());
+      return stop;
+    });
+    start();
+    emit({ ...changeEvent(), timestamp: Date.now() + 1 });
+    expect(events().map((item) => item.payload.name)).toEqual([
+      'faro.session_recording.started',
+      'faro.session_recording.event',
+      'faro.session_recording.event',
+      'faro.session_recording.event',
+    ]);
+  });
+
+  it.each(['rotate', 'unsample', 'away-back', 'destroy'])(
+    'discards real rrweb startup invalidated by maskInputFn: %s',
+    async (action) => {
+      const input = document.createElement('input');
+      input.value = 'private';
+      document.body.appendChild(input);
+      const realRecord = jest.requireActual('@grafana/rrweb').record;
+      mockRecord.mockImplementation((options) => {
+        const stopRecorder = realRecord(options);
+        return () => {
+          stop();
+          stopRecorder?.();
+        };
+      });
+      let invalidated = false;
+      start({
+        maskInputFn: () => {
+          if (!invalidated) {
+            invalidated = true;
+            if (action === 'destroy') {
+              replay.destroy();
+            } else if (action === 'unsample') {
+              setSession('A', false);
+            } else {
+              setSession('B');
+              if (action === 'away-back') {
+                setSession('A');
+              }
+            }
+          }
+          return '******';
+        },
+      });
+      expect(invalidated).toBe(true);
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(events()).toEqual([]);
+      await Promise.resolve();
+      if (action === 'rotate' || action === 'away-back') {
+        expect(events()[0]?.payload.name).toBe('faro.session_recording.started');
+        expect(recordings().map((item) => JSON.parse(item.payload.attributes!['event']!).type)).toEqual([
+          EventType.Meta,
+          EventType.FullSnapshot,
+        ]);
+        expect(recordings().every((item) => item.meta.session?.id === (action === 'rotate' ? 'B' : 'A'))).toBe(true);
+      } else {
+        expect(events()).toEqual([]);
+      }
+    }
+  );
+
+  it.each(['rotate', 'unsample', 'destroy'])('discards an event invalidated inside beforeSend: %s', (action) => {
+    start({
+      beforeSend: (event) => {
+        if (action === 'destroy') {
+          replay.destroy();
+        } else {
+          setSession(action === 'rotate' ? 'B' : 'A', action !== 'unsample');
+        }
+        return event;
+      },
+    });
+    emit(changeEvent());
+    expect(recordings()).toEqual([]);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reconcile again between accepting an event and submitting it', () => {
+    let expired = false;
+    faro.metas.addCaptureListener(() => {
+      if (expired) {
+        setSession('B');
+      }
+    });
+    start({
+      beforeSend: (event) => {
+        expired = true;
+        return event;
+      },
+    });
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
+    expect(faro.api.getSession()?.id).toBe('B');
+  });
+
+  it('discards serialization callbacks that invalidate the current attempt', () => {
+    start();
+    const event = {
+      ...changeEvent(),
+      toJSON: () => {
+        setSession('B');
+        return changeEvent();
+      },
+    };
+    emit(event);
+    expect(recordings()).toEqual([]);
+  });
+
+  it('rejects a stale rrweb callback after rotating away and back to the same session', async () => {
+    start();
+    const staleEmit = emit;
+    setSession('B');
+    setSession('A');
+    await Promise.resolve();
+    staleEmit(changeEvent());
+    expect(recordings()).toEqual([]);
+    emit(changeEvent());
+    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
+  });
+
+  it('reconciles a paused session before choosing resume versus a new recorder', async () => {
+    let expired = false;
+    faro.metas.addCaptureListener(() => {
+      if (expired) {
+        setSession('B');
+      }
+    });
+    start({ inactivityThresholdMs: 1000 });
+    jest.advanceTimersByTime(1000);
+    expired = true;
+    document.dispatchEvent(new Event('pointerdown'));
+    await Promise.resolve();
+    expect(events().filter((item) => item.payload.name === 'faro.session_recording.resumed')).toEqual([]);
+    expect(
+      events()
+        .filter((item) => item.payload.name === 'faro.session_recording.started')
+        .map((item) => item.meta.session?.id)
+    ).toEqual(['A', 'B']);
+  });
+});

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -1126,27 +1126,41 @@ describe('ReplayInstrumentation', () => {
       const numSamples = seeds.length * samplesPerSeed;
       const buckets = new Array(numBuckets).fill(0);
       const maxAllowedChiSquared = 21.67;
+      const originalCrypto = globalThis.crypto;
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: {},
+      });
       const randomSpy = jest.spyOn(Math, 'random');
 
-      const inst = new ReplayInstrumentation();
-      for (const seed of seeds) {
-        randomSpy.mockImplementation(createSeededRandom(seed));
+      try {
+        const inst = new ReplayInstrumentation();
+        for (const seed of seeds) {
+          randomSpy.mockImplementation(createSeededRandom(seed));
 
-        for (let i = 0; i < samplesPerSeed; i++) {
-          const hash = inst['hashSessionId'](genShortID());
-          const bucket = Math.min(Math.floor(hash * numBuckets), numBuckets - 1);
-          buckets[bucket]++;
+          for (let i = 0; i < samplesPerSeed; i++) {
+            const hash = inst['hashSessionId'](genShortID());
+            const bucket = Math.min(Math.floor(hash * numBuckets), numBuckets - 1);
+            buckets[bucket]++;
+          }
         }
+
+        // Seed Math.random with several fixed seeds so the real genShortID() exercises a broader,
+        // deterministic corpus. This uses chi-squared as a regression score, not as a p-value-based test.
+        const expected = numSamples / numBuckets;
+        const chiSquared = buckets.reduce((sum, observed) => {
+          return sum + (observed - expected) ** 2 / expected;
+        }, 0);
+
+        expect(randomSpy).toHaveBeenCalled();
+        expect(chiSquared).toBeLessThan(maxAllowedChiSquared);
+      } finally {
+        randomSpy.mockRestore();
+        Object.defineProperty(globalThis, 'crypto', {
+          configurable: true,
+          value: originalCrypto,
+        });
       }
-
-      // Seed Math.random with several fixed seeds so the real genShortID() exercises a broader,
-      // deterministic corpus. This uses chi-squared as a regression score, not as a p-value-based test.
-      const expected = numSamples / numBuckets;
-      const chiSquared = buckets.reduce((sum, observed) => {
-        return sum + (observed - expected) ** 2 / expected;
-      }, 0);
-
-      expect(chiSquared).toBeLessThan(maxAllowedChiSquared);
     });
 
     it('should not start recording when session ID is null', () => {

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -48,6 +48,7 @@ describe('ReplayInstrumentation', () => {
   let mockGetSession: jest.Mock;
   let mockAddListener: jest.Mock;
   let mockPushEvent: jest.Mock;
+  let mockCapture: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -58,6 +59,7 @@ describe('ReplayInstrumentation', () => {
     mockGetSession = jest.fn();
     mockAddListener = jest.fn();
     mockPushEvent = jest.fn();
+    mockCapture = jest.fn((callback?: () => void) => callback?.());
   });
 
   afterEach(() => {
@@ -190,7 +192,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -208,7 +210,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -237,7 +239,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -256,7 +258,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'false' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -275,7 +277,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -313,7 +315,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -345,7 +347,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -360,7 +362,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'false' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -380,7 +382,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
 
@@ -408,7 +410,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -431,7 +433,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -455,7 +457,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -476,7 +478,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -494,7 +496,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -518,7 +520,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -542,7 +544,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -568,7 +570,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -600,7 +602,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -627,7 +629,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -651,7 +653,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -675,7 +677,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -699,7 +701,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -722,7 +724,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -738,7 +740,7 @@ describe('ReplayInstrumentation', () => {
       expect(parsed.data.href).toBe('file:///android_asset/www/index.html');
     });
 
-    it('should keep Meta event href sanitized when batched after a non-replay event', () => {
+    it('should keep Meta event href sanitized when batched after a non-replay event', async () => {
       jest.useFakeTimers();
       try {
         const transport = new BatchedBodyTransport();
@@ -757,6 +759,9 @@ describe('ReplayInstrumentation', () => {
         );
 
         api.setSession({ id: 'test-session', attributes: { isSampled: 'true' } });
+        // Session-triggered (re)starts are deferred out of the metas-listener call
+        // stack; flush that microtask before relying on the recorder being active.
+        await Promise.resolve();
         jest.advanceTimersByTime(1);
         transport.sentBodies = [];
 
@@ -801,7 +806,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
       instrumentation.initialize();
@@ -824,7 +829,7 @@ describe('ReplayInstrumentation', () => {
         attributes: { isSampled: 'true' },
       });
       instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -858,7 +863,7 @@ describe('ReplayInstrumentation', () => {
       const inst = new ReplayInstrumentation(options);
       mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
       inst['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      inst['metas'] = { addListener: mockAddListener } as any;
+      inst['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
       inst.initialize();
       return inst;
     }
@@ -979,7 +984,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -992,7 +997,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -1006,7 +1011,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -1020,7 +1025,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -1035,13 +1040,13 @@ describe('ReplayInstrumentation', () => {
 
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.2 });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
       instrumentation.initialize();
       const firstDecision = instrumentation['isRecording'];
 
       const instrumentation2 = new ReplayInstrumentation({ samplingRate: 0.2 });
       instrumentation2['api'] = { getSession: mockGetSession } as any;
-      instrumentation2['metas'] = { addListener: mockAddListener } as any;
+      instrumentation2['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
       instrumentation2.initialize();
       const secondDecision = instrumentation2['isRecording'];
       instrumentation2.destroy();
@@ -1054,7 +1059,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
 
@@ -1069,7 +1074,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
 
@@ -1090,7 +1095,7 @@ describe('ReplayInstrumentation', () => {
       instrumentation = new ReplayInstrumentation({ samplingRate: 0.5 });
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
       expect(instrumentation['isRecording']).toBe(true);
@@ -1106,7 +1111,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'false' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 
@@ -1149,7 +1154,7 @@ describe('ReplayInstrumentation', () => {
 
       mockGetSession.mockReturnValue({ id: undefined, attributes: { isSampled: 'true' } });
       instrumentation['api'] = { getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener } as any;
+      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
 
       instrumentation.initialize();
 

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -42,6 +42,8 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   // Coalesce re-entrant session changes into one deferred start.
   private pendingStart: boolean = false;
   private destroyed: boolean = false;
+  // Deferred starts belong to the lifecycle that scheduled them.
+  private lifecycle = 0;
   // Prevent an invalidated attempt from reviving if the same session returns.
   private attemptRevision = 0;
 
@@ -62,6 +64,9 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   initialize(): void {
     this.destroyed = false;
+    this.lifecycle++;
+    // A listener already being notified can still queue work after destroy().
+    this.pendingStart = false;
 
     // Listen for session changes. Starts triggered from the listener are deferred out
     // of the call stack (see scheduleStartRecording).
@@ -134,8 +139,12 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
     this.pendingStart = true;
+    const lifecycle = this.lifecycle;
 
     void Promise.resolve().then(() => {
+      if (lifecycle !== this.lifecycle) {
+        return;
+      }
       this.pendingStart = false;
       if (this.destroyed) {
         return;
@@ -289,9 +298,12 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       discardAttempt();
       try {
         stop();
+      } catch (err) {
+        this.logWarn('Failed to stop session replay', err);
       } finally {
         this.stopRecording();
       }
+      this.logDebug('Recorder start attempt invalidated');
       return false;
     }
 
@@ -567,6 +579,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   destroy(): void {
     this.destroyed = true;
+    this.pendingStart = false;
     this.metas.removeListener?.(this.metasListener);
     this.stopRecording();
     this.recordingSessionId = null;

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -393,21 +393,27 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
 
-    this.metas.capture(() => {
-      if (!this.isRecording || this.isPaused) {
-        return;
-      }
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
 
-      if (this.inactivityTimer !== null) {
-        clearTimeout(this.inactivityTimer);
-        this.inactivityTimer = null;
-      }
+    // Metadata reconciliation must not prevent the local inactivity pause.
+    this.stopRrweb();
+    this.isPaused = true;
+    this.logDebug('Session replay paused due to inactivity');
 
-      this.stopRrweb();
-      this.isPaused = true;
-      this.logDebug('Session replay paused due to inactivity');
-      this.api.pushEvent(faroSessionReplayPausedEventName, {});
-    });
+    try {
+      this.metas.capture(() => {
+        if (!this.isRecording || !this.isPaused || !this.isRecordingSessionEligible()) {
+          return;
+        }
+
+        this.api.pushEvent(faroSessionReplayPausedEventName, {});
+      });
+    } catch (err) {
+      this.logWarn('Failed to push session replay paused event', err);
+    }
   }
 
   private resumeRecording(): void {

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -440,6 +440,11 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
     try {
       this.metas.capture(() => {
+        // A capture listener may have installed a fresh recorder.
+        if (this.isRecording && !this.isPaused) {
+          return;
+        }
+
         if (!this.isRecording || !this.isPaused || !this.isRecordingSessionEligible()) {
           this.logDebug('Recording session no longer eligible, stopping instead of resuming');
           this.stopRecording();

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -10,6 +10,8 @@ const faroSessionReplayStartedEventName = 'faro.session_recording.started';
 const faroSessionReplayPausedEventName = 'faro.session_recording.paused';
 const faroSessionReplayResumedEventName = 'faro.session_recording.resumed';
 
+type RrwebEmit = (event: eventWithTime) => void;
+
 // DOM events that signal a human is present.  Aligned with rrweb's
 // IncrementalSource 1-5 (MouseMove, MouseInteraction, Scroll,
 // ViewportResize, Input).  We use pointer* instead of mouse*/touch*
@@ -33,6 +35,20 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
   private boundOnUserInteraction: (() => void) | null = null;
 
+  // Session ownership of the active recorder attempt.
+  private recordingSessionId: string | null = null;
+  // record() may notify listeners before returning its stop function.
+  private isStarting: boolean = false;
+  // Coalesce re-entrant session changes into one deferred start.
+  private pendingStart: boolean = false;
+  private destroyed: boolean = false;
+  // Prevent an invalidated attempt from reviving if the same session returns.
+  private attemptRevision = 0;
+
+  private readonly metasListener = (): void => {
+    this.checkAndUpdateRecording(true);
+  };
+
   constructor(options: ReplayInstrumentationOptions = {}) {
     super();
 
@@ -45,23 +61,46 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   }
 
   initialize(): void {
-    // Check if current session is sampled before starting recording
-    this.checkAndUpdateRecording();
+    this.destroyed = false;
 
-    // Listen for session changes
-    this.metas.addListener(() => {
-      this.checkAndUpdateRecording();
-    });
+    // Listen for session changes. Starts triggered from the listener are deferred out
+    // of the call stack (see scheduleStartRecording).
+    this.metas.addListener(this.metasListener);
+
+    this.checkAndUpdateRecording(false);
   }
 
-  private checkAndUpdateRecording(): void {
-    const session = this.api.getSession();
-    const isSampled = session?.attributes?.['isSampled'] === 'true';
-    const sessionId = session?.id ?? null;
+  private checkAndUpdateRecording(deferStart: boolean): void {
+    // A notification can arrive synchronously while rrweb's record() is still executing,
+    // before the stop function is installed. Reconcile once the current call stack has
+    // finished so the start attempt can finish setting up its state.
+    if (this.isStarting) {
+      const session = this.api.getSession();
+      if (session !== undefined && !this.isRecordingSessionEligible()) {
+        this.attemptRevision++;
+      }
+      this.scheduleStartRecording();
+      return;
+    }
 
-    if (!isSampled || sessionId === null) {
+    const session = this.api.getSession();
+
+    // Core's setSession removes and re-adds the session meta, notifying listeners on
+    // each step, so mid-rotation the listener transiently observes NO session meta at
+    // all. Acting on that transient notification would stop and restart recording on
+    // every setSession call; the follow-up notification carries the session to act on.
+    // A deliberate session clear (resetSession / setSession(undefined)) is different:
+    // it re-adds a session meta WITHOUT an id, which must stop recording below.
+    if (session === undefined) {
+      this.logDebug('No session meta present, awaiting the next session meta notification');
+      return;
+    }
+
+    const sessionId = this.currentEligibleSessionId();
+
+    if (sessionId === null) {
       if (this.isRecording) {
-        this.logDebug('Session is not sampled, stopping recording');
+        this.logDebug('Session is not eligible for replay (unsampled or missing id), stopping recording');
         this.stopRecording();
       } else {
         this.logDebug('Session is not sampled, recording not started');
@@ -69,19 +108,58 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
 
-    // Globally sampled — apply replay sub-sampling using a deterministic hash of the
-    // session ID so the decision is stable across page reloads within the same session.
-    const replaySampled = this.shouldReplaySample(sessionId);
+    if (this.isRecording) {
+      if (this.recordingSessionId === sessionId) {
+        return;
+      }
 
-    if (replaySampled && !this.isRecording) {
-      this.logDebug('Session is sampled for replay, starting recording');
-      this.startRecording();
-    } else if (!replaySampled && this.isRecording) {
-      this.logDebug('Session is not sampled for replay, stopping recording');
+      // The session rotated while recording: a recording belongs to exactly one
+      // session, so end this one now (stopping pushes no events, making it safe inside
+      // the listener call stack) and start the new session's recording deferred.
+      this.logDebug('Session changed, restarting recording for the new session');
       this.stopRecording();
-    } else if (!replaySampled) {
-      this.logDebug('Session is not sampled for replay, recording not started');
     }
+
+    if (deferStart) {
+      this.scheduleStartRecording();
+    } else {
+      this.startRecording(sessionId);
+    }
+  }
+
+  // Defer starts out of re-entrant metadata callbacks and transport hooks.
+  // Re-evaluate the latest session when the coalesced start executes.
+  private scheduleStartRecording(): void {
+    if (this.pendingStart) {
+      return;
+    }
+    this.pendingStart = true;
+
+    void Promise.resolve().then(() => {
+      this.pendingStart = false;
+      if (this.destroyed) {
+        return;
+      }
+
+      this.checkAndUpdateRecording(false);
+    });
+  }
+
+  // Passive eligibility check; capture reconciliation is explicit at the caller.
+  private currentEligibleSessionId(): string | null {
+    const session = this.api.getSession();
+    if (session === undefined) {
+      return null;
+    }
+
+    const sessionId = session.id ?? null;
+    const isSampled = session.attributes?.['isSampled'] === 'true';
+
+    if (sessionId === null || !isSampled || !this.shouldReplaySample(sessionId)) {
+      return null;
+    }
+
+    return sessionId;
   }
 
   private shouldReplaySample(sessionId: string): boolean {
@@ -121,20 +199,15 @@ export class ReplayInstrumentation extends BaseInstrumentation {
 
   private stopRecording(): void {
     this.teardownInactivityTracking();
-    if (this.stopFn) {
-      this.stopFn();
-      this.stopFn = null;
-    }
+    this.stopRrweb();
     this.isRecording = false;
     this.isPaused = false;
     this.logDebug('Session replay stopped');
   }
 
-  private buildRecordOptions(): recordOptions<eventWithTime> {
+  private buildRecordOptions(emit: RrwebEmit): recordOptions<eventWithTime> {
     return {
-      emit: (event: eventWithTime, isCheckout?: boolean): void => {
-        this.handleEvent(event, isCheckout);
-      },
+      emit,
       checkoutEveryNms: 300_000, // 5 minutes
       recordCrossOriginIframes: this.options.recordCrossOriginIframes,
       maskAllInputs: this.options.maskAllInputs,
@@ -158,33 +231,159 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     };
   }
 
-  private startRrweb(): boolean {
-    const stop = record(this.buildRecordOptions());
-    if (stop) {
-      this.stopFn = stop;
-      return true;
+  // Passive: capture reconciliation must happen before validating the attempt.
+  private isRecordingSessionEligible(): boolean {
+    if (this.destroyed || this.recordingSessionId === null) {
+      return false;
     }
-    return false;
+
+    const session = this.api.getSession();
+    return (
+      session?.id === this.recordingSessionId &&
+      session.attributes?.['isSampled'] === 'true' &&
+      this.shouldReplaySample(this.recordingSessionId)
+    );
+  }
+
+  // rrweb can emit snapshots synchronously before returning its stop function.
+  // Publish only after startup succeeds and the attempt remains eligible.
+  private startRrweb(lifecycleEventName: string): boolean {
+    const bufferedEvents: eventWithTime[] = [];
+    const attempt: { phase: 'buffering' | 'active' | 'discarded' } = { phase: 'buffering' };
+    const revision = this.attemptRevision;
+    const isValid = (): boolean =>
+      attempt.phase !== 'discarded' && revision === this.attemptRevision && this.isRecordingSessionEligible();
+    const wasRecording = this.isRecording;
+    const wasPaused = this.isPaused;
+    const discardAttempt = (): void => {
+      attempt.phase = 'discarded';
+      bufferedEvents.length = 0;
+    };
+
+    this.isStarting = true;
+    let stop: (() => void) | undefined;
+    try {
+      stop = record(
+        this.buildRecordOptions((event) => {
+          if (attempt.phase === 'buffering') {
+            bufferedEvents.push(event);
+          } else if (attempt.phase === 'active') {
+            this.handleEvent(event, isCurrentAttempt);
+          }
+        })
+      );
+    } catch (err) {
+      discardAttempt();
+      throw err;
+    } finally {
+      this.isStarting = false;
+    }
+
+    if (!stop) {
+      discardAttempt();
+      return false;
+    }
+
+    if (!isValid()) {
+      // Stop before publishing anything from an invalidated startup.
+      discardAttempt();
+      try {
+        stop();
+      } finally {
+        this.stopRecording();
+      }
+      return false;
+    }
+
+    const stopAttempt = (): void => {
+      discardAttempt();
+      stop!();
+    };
+    const isCurrentAttempt = (): boolean => isValid() && this.isRecording && this.stopFn === stopAttempt;
+
+    this.stopFn = stopAttempt;
+    this.isRecording = true;
+    this.isPaused = false;
+
+    // Telemetry failure does not undo a successfully installed recorder.
+    try {
+      this.api.pushEvent(lifecycleEventName, {});
+    } catch (err) {
+      this.logWarn(`Failed to push ${lifecycleEventName} event`, err);
+    }
+
+    try {
+      for (const event of bufferedEvents) {
+        if (!isCurrentAttempt()) {
+          discardAttempt();
+          return true;
+        }
+        this.handleEvent(event, isCurrentAttempt);
+      }
+
+      if (!isCurrentAttempt()) {
+        discardAttempt();
+        return true;
+      }
+
+      bufferedEvents.length = 0;
+      attempt.phase = 'active';
+      return true;
+    } catch (err) {
+      if (this.stopFn === stopAttempt) {
+        this.stopRrweb();
+        this.isRecording = wasRecording;
+        this.isPaused = wasPaused;
+      }
+      throw err;
+    }
   }
 
   private stopRrweb(): void {
-    if (this.stopFn) {
-      this.stopFn();
-      this.stopFn = null;
+    this.attemptRevision++;
+    const stop = this.stopFn;
+    this.stopFn = null;
+
+    if (stop) {
+      try {
+        stop();
+      } catch (err) {
+        this.logWarn('Failed to stop session replay', err);
+      }
     }
   }
 
-  private startRecording(): void {
+  private startRecording(sessionId: string): void {
     try {
-      this.startRrweb();
+      this.metas.capture(() => {
+        const eligibleSessionId = this.currentEligibleSessionId();
+        if (this.destroyed || eligibleSessionId === null || eligibleSessionId !== sessionId) {
+          this.logDebug('Session changed during reconciliation, deferring recording start');
+          return;
+        }
 
-      this.isRecording = true;
-      this.isPaused = false;
-      this.logDebug('Session replay started');
-      this.api.pushEvent(faroSessionReplayStartedEventName, {});
+        this.recordingSessionId = sessionId;
 
-      this.setupInactivityTracking();
+        if (!this.startRrweb(faroSessionReplayStartedEventName)) {
+          // Not marked as recording, so a later session notification can retry.
+          this.logWarn('Failed to start session replay: rrweb did not start');
+          this.recordingSessionId = null;
+          return;
+        }
+
+        if (!this.isRecording) {
+          return;
+        }
+
+        this.logDebug('Session replay started');
+
+        this.setupInactivityTracking();
+      });
     } catch (err) {
+      // A failed attempt must not retain a session reservation.
+      if (!this.isRecording) {
+        this.recordingSessionId = null;
+      }
       this.logWarn('Failed to start session replay', err);
     }
   }
@@ -194,15 +393,21 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
 
-    if (this.inactivityTimer !== null) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
+    this.metas.capture(() => {
+      if (!this.isRecording || this.isPaused) {
+        return;
+      }
 
-    this.stopRrweb();
-    this.isPaused = true;
-    this.logDebug('Session replay paused due to inactivity');
-    this.api.pushEvent(faroSessionReplayPausedEventName, {});
+      if (this.inactivityTimer !== null) {
+        clearTimeout(this.inactivityTimer);
+        this.inactivityTimer = null;
+      }
+
+      this.stopRrweb();
+      this.isPaused = true;
+      this.logDebug('Session replay paused due to inactivity');
+      this.api.pushEvent(faroSessionReplayPausedEventName, {});
+    });
   }
 
   private resumeRecording(): void {
@@ -211,19 +416,37 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     }
 
     try {
-      this.startRrweb();
+      this.metas.capture(() => {
+        if (!this.isRecording || !this.isPaused || !this.isRecordingSessionEligible()) {
+          this.logDebug('Recording session no longer eligible, stopping instead of resuming');
+          this.stopRecording();
+          return;
+        }
 
-      this.isPaused = false;
-      this.logDebug('Session replay resumed after user interaction');
-      this.api.pushEvent(faroSessionReplayResumedEventName, {});
+        if (!this.startRrweb(faroSessionReplayResumedEventName)) {
+          // Stays paused, so the next user interaction can retry the resume.
+          this.logWarn('Failed to resume session replay: rrweb did not start');
+          return;
+        }
 
-      this.resetInactivityTimer();
+        if (!this.isRecording || this.isPaused) {
+          return;
+        }
+
+        this.logDebug('Session replay resumed after user interaction');
+
+        this.resetInactivityTimer();
+      });
     } catch (err) {
       this.logWarn('Failed to resume session replay', err);
     }
   }
 
   private setupInactivityTracking(): void {
+    // Defensive: a re-entrant stop/start cycle must never leak a previous closure's
+    // document listeners.
+    this.teardownInactivityTracking();
+
     const threshold = this.options.inactivityThresholdMs;
     if (!threshold || threshold <= 0) {
       return;
@@ -264,9 +487,7 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       return;
     }
 
-    if (this.inactivityTimer !== null) {
-      clearTimeout(this.inactivityTimer);
-    }
+    clearTimeout(this.inactivityTimer ?? undefined);
 
     this.inactivityTimer = setTimeout(() => {
       this.pauseRecording();
@@ -300,22 +521,38 @@ export class ReplayInstrumentation extends BaseInstrumentation {
     }
   }
 
-  private handleEvent(event: eventWithTime, _isCheckout?: boolean): void {
+  private handleEvent(event: eventWithTime, isCurrentAttempt: () => boolean): void {
     try {
-      this.sanitizeMetaHref(event);
-
-      // Apply beforeSend transformation if provided
-      let processedEvent: eventWithTime | null | undefined = event;
-      if (this.options.beforeSend) {
-        processedEvent = this.options.beforeSend(event);
-        if (processedEvent === null || processedEvent === undefined) {
+      this.metas.capture(() => {
+        if (!isCurrentAttempt()) {
           return;
         }
-        this.sanitizeMetaHref(processedEvent);
-      }
 
-      this.api.pushEvent(faroSessionReplayEventName, {
-        event: JSON.stringify(processedEvent),
+        this.sanitizeMetaHref(event);
+
+        // Apply beforeSend transformation if provided
+        let processedEvent: eventWithTime | null | undefined = event;
+        if (this.options.beforeSend) {
+          processedEvent = this.options.beforeSend(event);
+          if (processedEvent === null || processedEvent === undefined) {
+            return;
+          }
+          this.sanitizeMetaHref(processedEvent);
+        }
+
+        // beforeSend is user code and may itself synchronously rotate the session or
+        // otherwise invalidate this attempt; re-validate after it runs, not just before.
+        if (!isCurrentAttempt()) {
+          return;
+        }
+
+        const serializedEvent = JSON.stringify(processedEvent);
+        if (!isCurrentAttempt()) {
+          return;
+        }
+        this.api.pushEvent(faroSessionReplayEventName, {
+          event: serializedEvent,
+        });
       });
     } catch (err) {
       this.logWarn(`Failed to push ${faroSessionReplayEventName} event`, err);
@@ -323,6 +560,9 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   }
 
   destroy(): void {
+    this.destroyed = true;
+    this.metas.removeListener?.(this.metasListener);
     this.stopRecording();
+    this.recordingSessionId = null;
   }
 }

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -368,6 +368,11 @@ export class ReplayInstrumentation extends BaseInstrumentation {
   private startRecording(sessionId: string): void {
     try {
       this.metas.capture(() => {
+        // A capture listener may have reinitialized and started this instrumentation.
+        if (this.isRecording) {
+          return;
+        }
+
         const eligibleSessionId = this.currentEligibleSessionId();
         if (this.destroyed || eligibleSessionId === null || eligibleSessionId !== sessionId) {
           this.logDebug('Session changed during reconciliation, deferring recording start');


### PR DESCRIPTION
**Stack 3/5:** #2259 → #2261 → #2260 → #2256 → #2264.

Merge in this order into `main`, retargeting each child after its parent merges and retaining parent branches until restacked. Release the complete stack together, after collector CORS support for `Idempotency-Key` is deployed.

rrweb can emit events and invoke application callbacks before `record()` returns. Those events could escape a failed startup or be published after a callback changed the session, revoked sampling, or destroyed Replay.

## Changes

- Buffer startup events until rrweb returns a stop function and the attempt is still eligible. Publish `started`/`resumed` before buffered events and discard invalidated attempts.
- Reconcile start, pause, resume, and event submission through metadata capture; recheck attempt validity after user callbacks and serialization.
- Ignore transient missing-session notifications and eligible same-session updates. Stop on rotation and coalesce the replacement start into one microtask.
- Scope deferred starts to their initialize/destroy lifecycle. Reentrant capture cannot install a duplicate recorder or stop a fresh recorder installed during resume.
- Catch and log stop failures. Inactivity pause still stops rrweb when metadata capture or lifecycle-event publication fails; later interaction can retry resume.
- Use seeded randomness in the sampling distribution test.

## Compatibility

Session-triggered restarts now happen one microtask later. This layer uses #2261's capture API; #2264 switches Replay to the compatibility helper. Recording identity fields are added in #2256.

## Validation

CI passes at `a96126d2` (checked 2026-09-11), including Node tests and browser smoke tests. Real-core/rrweb regressions cover startup failure, callback invalidation, lifecycle-marker ordering, stale callbacks, pause failures, expired-session resume, and destroy/reinitialize during capture.

Refs #2241, #2242, #2254. A release-note entry for these safety changes is still needed; #2256's changelog entry covers recording identity.
