### PR TITLE
chore: assign replay instrumentation to session-replay team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 * @grafana/frontend-o11y
+
+/experimental/instrumentation-replay/ @grafana/session-replay


### PR DESCRIPTION
## Why

Route replay instrumentation ownership and review requests to @grafana/session-replay.

## What

Add `/experimental/instrumentation-replay/ @grafana/session-replay` after the catch-all CODEOWNERS rule. This overrides @grafana/frontend-o11y for this directory; ownership elsewhere is unchanged.

Branched directly from origin/main. CODEOWNERS-only change; no runtime tests required.