### PR TITLE
feat(session): guard capture and dispose session resources

### DIFF
--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -147,6 +147,22 @@ Custom instrumentations can continue submitting fresh items with `transports.exe
 `metas.value`; the transport entry point reconciles these before queueing. Previously captured
 metadata keeps its ownership, including for delayed user actions and Replay.
 
+The built-in metadata implementation replaces session metadata atomically. Each replacement,
+including a clear, sends one notification; a session manager may normalize it with another
+replacement. A nested `setSession()` takes precedence, and each listener receives the current
+value. Clearing metadata does not disable session tracking.
+
+Telemetry submitted by a session ID generator or sampler before the replacement commits is
+discarded with a diagnostic. It does not consume deduplication state, refresh activity, or enter
+transport hooks. Submissions from listeners after the replacement commits are allowed.
+Reconciliation or metadata-assembly failures remain attached to the active capture cycle even
+when a nested public API catches the error. The next independent capture can retry.
+
+Removing session instrumentation disposes its manager, visibility and metadata listeners,
+capture listener, and before-send hook. Stored session state remains available for replacement
+instrumentation. Removed callbacks cannot continue session updates if disposal happens during
+a listener or application callback.
+
 Properties
 
 - `id` - the name of the browser
@@ -196,6 +212,8 @@ Methods and properties:
 
 - `add()` - adds a new meta
 - `remove()` - removes a specific meta
+- `replace(previous, replacement)` - atomically removes the previous item and appends its replacement
+- `beginSessionUpdate()` - rejects captures until a session replacement commits; returns a cancellation function
 - `addListener()` - adds a new listener
 - `removeListener()` - removes a specific listener
 - `capture(callback?)` - runs capture listeners and returns metadata assembled before the optional
@@ -205,6 +223,7 @@ Methods and properties:
 - `removeCaptureListener()` - unregisters a capture callback
 - `value` - reads current metadata without notifying capture listeners or refreshing session activity
 
-Capture methods are optional on the public `Metas` interface so existing extension implementations
-and mocks remain valid. `captureMetas(metas, callback?)`, exported by core and the Web SDK,
+Capture, replacement, and session preparation methods are optional on the public `Metas` interface
+so existing extension implementations and mocks remain valid. `captureMetas(metas, callback?)`,
+exported by core and the Web SDK,
 provides capture with a fallback for implementations that only expose the older interface.

--- a/docs/sources/developer/persistent-session-concurrency.md
+++ b/docs/sources/developer/persistent-session-concurrency.md
@@ -1,0 +1,117 @@
+# Persistent-session concurrency
+
+Investigation date: 2026-09-11. Follow-up to [#2267](https://github.com/grafana/faro-web-sdk/issues/2267).
+
+Retain synchronous, best-effort persistent-session reconciliation. Concurrent renewal is reproducible in native Chromium,
+but the observed tabs converged through ordinary capture, with an extra session and Replay recording in some runs. These
+results justify documenting the limitation and retaining a browser regression, without introducing a storage mutex.
+
+## Supported behavior
+
+A tab adopts a valid stored session when its next eligible reconciliation observes it. Collector invalidation is rejected
+when the request session differs from the observed memory or storage session. These checks do not make the shared
+read/check/write sequence atomic. There is no guarantee of one replacement across tabs, immediate synchronization, or a
+fixed convergence time or rotation count. See the [session updater][session-utils] and [response guard][transport].
+
+The HTML standard explicitly leaves interactions between agent clusters unspecified and advises assuming no locking.
+Storage notifications are queued tasks. Another `getItem()` is not an atomic conditional write or a documented freshness
+barrier. See [Web Storage concurrency][storage] and [notification delivery][storage-events].
+
+## Native browser evidence
+
+The control used commit [`002103d`][baseline], containing the completed
+[#2259](https://github.com/grafana/faro-web-sdk/pull/2259) →
+[#2261](https://github.com/grafana/faro-web-sdk/pull/2261) →
+[#2260](https://github.com/grafana/faro-web-sdk/pull/2260) →
+[#2256](https://github.com/grafana/faro-web-sdk/pull/2256) →
+[#2264](https://github.com/grafana/faro-web-sdk/pull/2264) chain, before the Web Locks lifecycle refactor.
+Sources were extracted into an isolated directory and bundled with the installed Rolldown 1.2.3, resolving Faro core to
+that same checkout. Versions: Faro 2.11.0, `@grafana/rrweb` 2.0.0-grafana.2, Playwright 1.62.1,
+full headless Chromium **151.0.7922.34**, Linux.
+
+Each of 25 trials created two independent pages in one browser context on the same loopback HTTP origin. Both initialized
+Session and Replay instrumentations, persistent session A, sampling 1, disabled batching, and disabled Replay inactivity.
+The collector held one A request per tab, then answered both with `202` and `X-Faro-Session-Status: invalid` in the same
+server turn. A custom generator returned distinct tab-labelled IDs immediately. Native storage reads were unchanged;
+write/remove wrappers only logged and forwarded operations. Callbacks, metadata, Replay events, and tab checkpoint
+pointers were recorded. This deliberately concentrates responses and adds tracing overhead; it does not measure production
+incidence. No mocked read sequence, artificial generator delay, synthetic storage event, or storage lock was used.
+
+| Observation                                                  | Result in these 25 trials                                                   |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Replacement sessions generated                               | Two in 14 trials; one in 11                                                 |
+| Extra rotations relative to one replacement                  | One in 14 trials; zero in 11                                                |
+| In-memory divergence after responses                         | 25/25, including the tab still holding A when its response was rejected     |
+| Convergence while otherwise idle                             | None at the subsequent idle observation                                     |
+| Ordinary capture after the reconciliation interval           | Both tabs adopted the same stored session in 25/25                          |
+| Observed transition-to-adoption interval                     | Approximately 1.403–1.410 seconds, determined by the harness schedule       |
+| `onSessionChange`                                            | Once per generated replacement; no additional callback on adoption          |
+| New Replay starts across both tabs, excluding initialization | Three with two replacements; two with one replacement                       |
+| Recording/session identity in 128 observed rrweb events      | No recording crossed sessions; no repeated `(recording_id, gen, seq)` tuple |
+
+Representative two-replacement trace, relative to the first request submission:
+
+| Time                            | Tab A                                              | Tab B                                                                   |
+| ------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| 3.7 ms                          | Generates A-1 after observing native stored A      |                                                                         |
+| 4.6 ms                          | Installs A-1; callback A → A-1                     |                                                                         |
+| 4.7–5.8 ms                      |                                                    | Observes native stored A, generates B-1, installs B-1; callback A → B-1 |
+| 6.3–7.6 ms                      | Starts a recording under A-1                       | Starts a recording under B-1                                            |
+| After responses and during idle | Memory A-1, stored B-1                             | Memory B-1, stored B-1                                                  |
+| 1414.6 ms                       | Next capture adopts B-1 without a session callback | Retains B-1                                                             |
+| 1415.7 ms                       | Starts another recording under B-1                 | Retains its B-1 recording                                               |
+
+The losing tab's checkpoint pointer followed its additional recording. The extra start included a fresh Meta and full
+snapshot under a fresh recording ID; it did not reuse the prior recording's counters. This agrees with the control's
+[session-change restart][replay] and [checkpoint selection][checkpoints]. These are observations of the old checkpoint
+implementation, not validation of the replacement Web Locks lifecycle or crash recovery.
+
+## Shared-record writers
+
+All SDK mutations of the shared `com.grafana.faro.session` localStorage record reach the [persistent manager][manager].
+Reviewing only invalidation would miss other ways a stale read can overwrite a competing tab. The following risks are
+source-derived, not additional browser reproductions.
+
+| Path                                                           | Operation and concurrent-write risk                                                                                                                    |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Initialization][initialization]                               | Persists a new or resumed session derived from an earlier read; can overwrite another tab's renewal.                                                   |
+| [Persistence expiry during initialization][initialization]     | Removes the record based on the previously read activity time; can remove a newer record written between read and removal.                             |
+| [Capture, visibility, or public session update][session-utils] | Reads validity, optionally refreshes activity, and either adopts or unconditionally stores a generated replacement.                                    |
+| [Collector invalidation][transport]                            | Checks request identity against memory and storage, then invokes forced renewal; competing writes can occur between those operations.                  |
+| [Accepted activity][session-utils]                             | Checks matching ID and validity before writing an activity copy; can overwrite a renewal occurring after its read.                                     |
+| [Metadata synchronization][session-utils]                      | Normalizes changed ID, attributes, or overrides and stores the resulting session. A metadata notification in a lagging tab can reinstate its older ID. |
+
+The [manager][manager] reconciles on capture and visible-document activity, with the
+[one-second storage interval][constants]; it does not adopt sessions directly from `storage` events. Passive metadata reads
+and elapsed idle time therefore do not establish convergence. Adoption is sufficient for the tested quiescent shared
+record; continued competing writes, metadata changes, clock changes, suspension, and older already-open SDK versions can
+extend divergence. A fixed bound has not been established.
+
+## Retained regression and remaining uncertainty
+
+[The native smoke regression](../../../e2e/smoke/tests/session-concurrency.spec.ts) initializes both SDK instrumentations,
+releases two real transport responses together, and verifies later captured session identity, silent adoption, and
+recording/session binding. It accepts either renewal ordering and attaches observations rather than requiring the race to
+occur. It passed three repeated runs against isolated control bundles.
+
+After building the current packages, rerun it with:
+
+```bash
+yarn workspace @grafana/faro-smoke-harness e2e session-concurrency --repeat-each=3
+```
+
+The controlled Chromium results establish a practical race and extra Replay snapshots. They do not establish production
+frequency, a maximum number of rotations, behavior in other engines, or that every stale writer is harmless. Keep these
+limits explicit. If real traffic shows material session fragmentation, investigate all writers together before proposing
+an asynchronous synchronization protocol; recording leases alone do not serialize persistent-session mutation.
+
+[baseline]: https://github.com/grafana/faro-web-sdk/tree/002103dfc64c736a588126cd6580825e22aa2e26
+[session-utils]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+[transport]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/packages/web-sdk/src/transports/fetch/transport.ts
+[manager]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+[initialization]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+[constants]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/packages/web-sdk/src/instrumentations/session/sessionManager/sessionConstants.ts
+[replay]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/experimental/instrumentation-replay/src/instrumentation.ts
+[checkpoints]: https://github.com/grafana/faro-web-sdk/blob/002103dfc64c736a588126cd6580825e22aa2e26/experimental/instrumentation-replay/src/recordingState.ts
+[storage]: https://html.spec.whatwg.org/multipage/webstorage.html#introduction-16
+[storage-events]: https://html.spec.whatwg.org/multipage/webstorage.html#storage-broadcast

--- a/e2e/smoke/tests/session-concurrency.spec.ts
+++ b/e2e/smoke/tests/session-concurrency.spec.ts
@@ -1,0 +1,172 @@
+import { expect, type Page, type Route, test } from '@playwright/test';
+
+import type { Faro, TransportBody } from '@grafana/faro-core';
+
+interface SessionObservation {
+  callbacks: Array<{ previous: string | undefined; next: string | undefined }>;
+  events: Array<{ name: string; session: string | undefined; recording: string | undefined }>;
+}
+
+declare global {
+  interface Window {
+    GrafanaFaroWebSdk: typeof import('@grafana/faro-web-sdk');
+    GrafanaFaroInstrumentationReplay: typeof import('@grafana/faro-instrumentation-replay');
+    sessionObservation: SessionObservation;
+    faro: Faro;
+  }
+}
+
+async function observe(page: Page) {
+  return page.evaluate(() => {
+    const target = window;
+    return {
+      ...target.sessionObservation,
+      memory: target.faro.api.getSession()?.id,
+      stored: JSON.parse(window.localStorage.getItem('com.grafana.faro.session') ?? 'null')?.sessionId as
+        string | undefined,
+    };
+  });
+}
+
+test('concurrent persistent-session invalidations converge on subsequent capture', async ({ browser }) => {
+  const context = await browser.newContext();
+  const pending: Route[] = [];
+  const invalidated: TransportBody[] = [];
+  try {
+    await context.route('**/session-concurrency', (route) =>
+      route.fulfill({ contentType: 'text/html', body: '<!doctype html><title>Session concurrency</title>' })
+    );
+    await context.route('**/collect-concurrency', async (route) => {
+      const body = route.request().postDataJSON() as TransportBody;
+      if (body.events?.some((event) => event.name === 'concurrent-renewal')) {
+        invalidated.push(body);
+        pending.push(route);
+        return;
+      }
+      await route.fulfill({ status: 201, body: '{}' });
+    });
+
+    const pages: Page[] = [];
+    for (let tab = 0; tab < 2; tab++) {
+      const page = await context.newPage();
+      await page.goto('/session-concurrency');
+      await page.addScriptTag({ url: '/bundles/faro-web-sdk.iife.js' });
+      await page.addScriptTag({ url: '/bundles/faro-instrumentation-replay.iife.js' });
+      await page.evaluate(() => {
+        const target = window;
+        const { initializeFaro, SessionInstrumentation } = target.GrafanaFaroWebSdk;
+        const { ReplayInstrumentation } = target.GrafanaFaroInstrumentationReplay;
+        const observation: SessionObservation = { callbacks: [], events: [] };
+        target.sessionObservation = observation;
+        initializeFaro({
+          url: '/collect-concurrency',
+          app: { name: 'session-concurrency' },
+          batching: { enabled: false },
+          instrumentations: [
+            new SessionInstrumentation(),
+            new ReplayInstrumentation({ samplingRate: 1, inactivityThresholdMs: 0 }),
+          ],
+          sessionTracking: {
+            enabled: true,
+            persistent: true,
+            session: { id: 'session-A' },
+            samplingRate: 1,
+            onSessionChange: (previous, next) => {
+              observation.callbacks.push({ previous: previous?.id, next: next.id });
+            },
+          },
+          beforeSend: (item) => {
+            if (item.type === 'event') {
+              const event = item.payload as NonNullable<TransportBody['events']>[number];
+              observation.events.push({
+                name: event.name,
+                session: item.meta.session?.id,
+                recording: event.attributes?.['recording_id'],
+              });
+            }
+            return item;
+          },
+        });
+      });
+      await expect
+        .poll(async () => (await observe(page)).events.some((event) => event.name === 'faro.session_recording.started'))
+        .toBe(true);
+      expect((await observe(page)).memory).toBe('session-A');
+      pages.push(page);
+    }
+
+    // Await the real transport sends so both response handlers finish before
+    // measuring. Only collector responses are controlled; storage is native.
+    const sends = pages.map((page) =>
+      page.evaluate(async () => {
+        const target = window;
+        await target.faro.transports.transports[0]!.send([
+          {
+            type: target.GrafanaFaroWebSdk.TransportItemType.EVENT,
+            meta: target.faro.metas.value,
+            payload: { name: 'concurrent-renewal', timestamp: new Date().toISOString() },
+          },
+        ]);
+      })
+    );
+    await expect.poll(() => pending.length).toBe(2);
+    expect(invalidated.map((body) => body.meta.session?.id)).toEqual(['session-A', 'session-A']);
+    await Promise.all(
+      pending.map((route) =>
+        route.fulfill({ status: 202, headers: { 'X-Faro-Session-Status': 'invalid' }, body: '{}' })
+      )
+    );
+    await Promise.all(sends);
+    await expect
+      .poll(async () => new Set(await Promise.all(pages.map(async (page) => (await observe(page)).stored))).size)
+      .toBe(1);
+    const afterInvalidation = await Promise.all(pages.map(observe));
+    const settledSession = afterInvalidation[0]!.stored;
+    expect(settledSession).toBeTruthy();
+    expect(settledSession).not.toBe('session-A');
+
+    // Reconciliation is driven by capture/visibility and throttled to one
+    // second. Elapsing that interval alone does not promise convergence.
+    await pages[0]!.waitForTimeout(1_100);
+    await Promise.all(pages.map((page) => page.evaluate(() => window.faro.api.pushEvent('after-renewal'))));
+    await expect
+      .poll(async () =>
+        Promise.all(
+          pages.map(
+            async (page) => (await observe(page)).events.find((event) => event.name === 'after-renewal')?.session
+          )
+        )
+      )
+      .toEqual([settledSession, settledSession]);
+    await expect
+      .poll(async () =>
+        Promise.all(
+          pages.map(
+            async (page) =>
+              (await observe(page)).events.filter((event) => event.name === 'faro.session_recording.started').at(-1)
+                ?.session
+          )
+        )
+      )
+      .toEqual([settledSession, settledSession]);
+
+    const afterCapture = await Promise.all(pages.map(observe));
+    expect(afterCapture.map((state) => state.callbacks)).toEqual(afterInvalidation.map((state) => state.callbacks));
+    for (const state of afterCapture) {
+      expect(state.memory).toBe(settledSession);
+      expect(state.stored).toBe(settledSession);
+      for (const recording of new Set(state.events.map((event) => event.recording).filter(Boolean))) {
+        const sessions = new Set(
+          state.events.filter((event) => event.recording === recording).map((event) => event.session)
+        );
+        expect(sessions.size, 'a recording must retain one captured session').toBe(1);
+      }
+    }
+    await test.info().attach('session-concurrency', {
+      contentType: 'application/json',
+      body: JSON.stringify({ browser: browser.version(), afterInvalidation, afterCapture }, null, 2),
+    });
+  } finally {
+    await context.close();
+  }
+});

--- a/e2e/smoke/tests/session-divergence.spec.ts
+++ b/e2e/smoke/tests/session-divergence.spec.ts
@@ -10,18 +10,12 @@ import { expect, test } from './fixtures';
 // session, a background tab must adopt the new id rather than keep emitting the
 // expired one. Asserts: after Tab A rotates, Tab B's next emit carries the rotated id.
 //
-// Non-obvious mechanics (don't "simplify" away):
-//  - ?session=persistent runs session signals only, so nothing rotates on its own.
-//  - We force expiry by ageing the stored session (not by waiting out the real
-//    lifetime cap), then drain the ~2s updateSession throttle (leading+trailing)
-//    so Tab A's next send rotates synchronously and Tab B can't self-rotate first.
-//  - Each send uses a different signal type: faro won't re-send a duplicate, and
-//    rotation/adoption only happens on an actual send (updateSession in beforeSend).
-//  - The rotation-triggering batch is re-stamped to the new session in beforeSend,
-//    so Tab B's first post-rotation send already carries the rotated id.
+// Force expiry by ageing the stored session, then let the one-second
+// reconciliation interval elapse. The next accepted capture rotates or adopts
+// the session before assigning ownership to the triggering signal.
 
 const URL = '/?session=persistent';
-const THROTTLE_LAPSE_MS = 2_500; // > the ~2s updateSession throttle settle (leading+trailing)
+const RECONCILIATION_LAPSE_MS = 2_500;
 
 const EVENT_BTN = '[data-cy="btn-push-event"]';
 const LOG_BTN = '[data-cy="btn-push-log"]';
@@ -61,7 +55,7 @@ async function expireStoredSession(page: Page): Promise<void> {
 }
 
 // Bring the tab to the front, click a signal button, and wait until the
-// resulting /collect payload is captured (so beforeSend/updateSession has run).
+// resulting /collect payload is captured (so session reconciliation has run).
 // Returns the session id that payload carried — i.e. the tab's in-memory id.
 async function clickAndCapture(page: Page, sink: string[], button: string): Promise<string> {
   const before = sink.length;
@@ -89,9 +83,8 @@ test('a background tab converges to the rotated session instead of emitting the 
     await tabB.locator(EVENT_BTN).waitFor();
     expect(await clickAndCapture(tabB, bIds, EVENT_BTN), 'Tab B resumes S0 from shared localStorage').toBe(s0);
 
-    // --- expire the shared session, then let the updateSession throttle lapse so
-    //     the next send rotates synchronously (neither tab emits in between) ---
-    await tabA.waitForTimeout(THROTTLE_LAPSE_MS);
+    // Let reconciliation run again, then expire the shared session.
+    await tabA.waitForTimeout(RECONCILIATION_LAPSE_MS);
     await expireStoredSession(tabA);
 
     // --- Tab A emits first (log = a fresh signal) -> rotates to A1 in storage ---
@@ -100,10 +93,9 @@ test('a background tab converges to the rotated session instead of emitting the 
     expect(a1, 'Tab A rotates to a new session when the stored one is expired').not.toBe(s0);
     expect(await storageSessionId(tabB), 'shared storage now holds A1 for both tabs').toBe(a1);
 
-    // The rotation-triggering batch is re-stamped to the new session in beforeSend,
-    // so Tab B's first post-rotation send already carries A1 — immediate
-    // convergence, no one-batch boundary smear. A missing adoption (stale S0) or a
-    // self-rotation (some other id) would surface here as a value other than A1.
+    // Tab B reconciles before capturing its signal, so its first post-rotation
+    // send carries A1. Missing adoption or another rotation would produce a
+    // different session ID.
     const bConverged = await clickAndCapture(tabB, bIds, LOG_BTN);
     expect(bConverged, 'background tab converges to the shared session, not the expired one').toBe(a1);
   } finally {

--- a/packages/core/src/api/apiTestHelpers.ts
+++ b/packages/core/src/api/apiTestHelpers.ts
@@ -6,6 +6,8 @@ import type { UserActionsAPI } from './userActions/types';
 export const mockMetas: {
   add: jest.Mock;
   remove: jest.Mock;
+  replace: jest.Mock;
+  beginSessionUpdate: jest.Mock;
   addListener: jest.Mock;
   removeListener: jest.Mock;
   capture: () => {};
@@ -15,6 +17,8 @@ export const mockMetas: {
 } = {
   add: jest.fn(),
   remove: jest.fn(),
+  replace: jest.fn(),
+  beginSessionUpdate: jest.fn(() => () => {}),
   addListener: jest.fn(),
   removeListener: jest.fn(),
   capture: () => mockMetas.value,

--- a/packages/core/src/api/meta/initialize.ts
+++ b/packages/core/src/api/meta/initialize.ts
@@ -49,10 +49,7 @@ export function initializeMetaAPI({
         }
       : {};
 
-    if (metaSession) {
-      metas.remove(metaSession);
-    }
-
+    const previousSession = metaSession;
     metaSession = {
       session: {
         // if session is undefined, session manager force creates a new session
@@ -61,7 +58,15 @@ export function initializeMetaAPI({
       },
     };
 
-    metas.add(metaSession);
+    if (metas.replace) {
+      metas.replace(previousSession, metaSession);
+    } else {
+      // Compatibility with metadata implementations predating atomic replacement.
+      if (previousSession) {
+        metas.remove(previousSession);
+      }
+      metas.add(metaSession);
+    }
   };
 
   const getSession: MetaAPI['getSession'] = () => metas.value.session;

--- a/packages/core/src/api/meta/initilialize.test.ts
+++ b/packages/core/src/api/meta/initilialize.test.ts
@@ -57,6 +57,34 @@ describe('Meta API', () => {
   });
 
   describe('setSession', () => {
+    it('replaces and clears a session atomically, with the latest nested value delivered to every listener', () => {
+      const { api, metas } = initializeFaro(mockConfig());
+      api.setSession({ id: 'initial' });
+      const otherMeta = { user: { id: 'user' }, session: { id: 'configured' } };
+      metas.add(otherMeta);
+      const first: Array<string | undefined> = [];
+      const later: Array<string | undefined> = [];
+      metas.addListener((meta) => {
+        first.push(meta.session?.id);
+        if (meta.session?.id === 'outer') {
+          api.setSession({ id: 'nested' });
+        }
+      });
+      metas.addListener((meta) => later.push(meta.session?.id));
+
+      api.setSession({ id: 'outer' });
+
+      expect(first).toEqual(['outer', 'nested']);
+      expect(later).toEqual(['nested', 'nested']);
+      expect(api.getSession()?.id).toBe('nested');
+      expect(metas.value.user).toEqual({ id: 'user' });
+
+      api.resetSession();
+      expect(first).toEqual(['outer', 'nested', undefined]);
+      expect(later).toEqual(['nested', 'nested', undefined]);
+      expect(api.getSession()).toEqual({});
+    });
+
     it('adds overrides to the session meta if provided via the setView() function call', () => {
       const initialSession = { id: 'my-session' };
 

--- a/packages/core/src/instrumentations/initialize.test.ts
+++ b/packages/core/src/instrumentations/initialize.test.ts
@@ -1,0 +1,82 @@
+import { initializeFaro } from '../initialize';
+import { mockConfig } from '../testUtils';
+
+import { BaseInstrumentation } from './base';
+
+class TestInstrumentation extends BaseInstrumentation {
+  readonly version = '1';
+  initialize = jest.fn();
+  destroy = jest.fn();
+
+  constructor(readonly name: string) {
+    super();
+  }
+}
+
+it('removes the selected instrumentation even when other registrations follow it', () => {
+  const first = new TestInstrumentation('first');
+  const later = new TestInstrumentation('later');
+  const sdk = initializeFaro(mockConfig({ instrumentations: [first, later] }));
+
+  sdk.instrumentations.remove(first);
+
+  expect(first.destroy).toHaveBeenCalledTimes(1);
+  expect(later.destroy).not.toHaveBeenCalled();
+  expect(sdk.instrumentations.instrumentations).toEqual([later]);
+});
+
+it('unwinds a failed registration so it can be replaced', () => {
+  const failing = new TestInstrumentation('same');
+  failing.initialize.mockImplementation(() => {
+    throw new Error('initialization failed');
+  });
+  const sdk = initializeFaro(mockConfig());
+  expect(() => sdk.instrumentations.add(failing)).toThrow('initialization failed');
+  expect(failing.destroy).toHaveBeenCalledTimes(1);
+  const replacement = new TestInstrumentation('same');
+  sdk.instrumentations.add(replacement);
+  expect(sdk.instrumentations.instrumentations).toEqual([replacement]);
+});
+
+it('revokes registration before cleanup so a replacement added from cleanup survives', () => {
+  const first = new TestInstrumentation('same');
+  const replacement = new TestInstrumentation('same');
+  const sdk = initializeFaro(mockConfig({ instrumentations: [first] }));
+  first.destroy.mockImplementation(() => sdk.instrumentations.add(replacement));
+
+  sdk.instrumentations.remove(first);
+
+  expect(sdk.instrumentations.instrumentations).toEqual([replacement]);
+  expect(replacement.initialize).toHaveBeenCalledTimes(1);
+  expect(replacement.destroy).not.toHaveBeenCalled();
+});
+
+it('does not remove a replacement registered while removing several instrumentations', () => {
+  const first = new TestInstrumentation('first');
+  const later = new TestInstrumentation('later');
+  const replacement = new TestInstrumentation('later');
+  const sdk = initializeFaro(mockConfig({ instrumentations: [first, later] }));
+  first.destroy.mockImplementation(() => {
+    sdk.instrumentations.remove(later);
+    sdk.instrumentations.add(replacement);
+  });
+
+  sdk.instrumentations.remove(first, later);
+
+  expect(sdk.instrumentations.instrumentations).toEqual([replacement]);
+  expect(later.destroy).toHaveBeenCalledTimes(1);
+  expect(replacement.destroy).not.toHaveBeenCalled();
+});
+
+it('does not tear down a reinitialized instance when its older initialization fails', () => {
+  const instrumentation = new TestInstrumentation('same');
+  const sdk = initializeFaro(mockConfig());
+  instrumentation.initialize.mockImplementationOnce(() => {
+    sdk.instrumentations.remove(instrumentation);
+    sdk.instrumentations.add(instrumentation);
+    throw new Error('older initialization failed');
+  });
+  expect(() => sdk.instrumentations.add(instrumentation)).toThrow('older initialization failed');
+  expect(sdk.instrumentations.instrumentations).toEqual([instrumentation]);
+  expect(instrumentation.destroy).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/instrumentations/initialize.ts
+++ b/packages/core/src/instrumentations/initialize.ts
@@ -17,7 +17,7 @@ export function initializeInstrumentations(
 ): Instrumentations {
   internalLogger.debug('Initializing instrumentations');
 
-  const instrumentations: Instrumentation[] = [];
+  const registrations: Array<{ instrumentation: Instrumentation }> = [];
 
   const add: Instrumentations['add'] = (...newInstrumentations) => {
     internalLogger.debug('Adding instrumentations');
@@ -25,9 +25,7 @@ export function initializeInstrumentations(
     newInstrumentations.forEach((newInstrumentation) => {
       internalLogger.debug(`Adding "${newInstrumentation.name}" instrumentation`);
 
-      const exists = instrumentations.some(
-        (existingInstrumentation) => existingInstrumentation.name === newInstrumentation.name
-      );
+      const exists = registrations.some(({ instrumentation }) => instrumentation.name === newInstrumentation.name);
 
       if (exists) {
         internalLogger.warn(`Instrumentation ${newInstrumentation.name} is already added`);
@@ -42,45 +40,59 @@ export function initializeInstrumentations(
       newInstrumentation.transports = transports;
       newInstrumentation.api = api;
 
-      instrumentations.push(newInstrumentation);
-
-      newInstrumentation.initialize();
+      const registration = { instrumentation: newInstrumentation };
+      registrations.push(registration);
+      try {
+        newInstrumentation.initialize();
+      } catch (error) {
+        const index = registrations.indexOf(registration);
+        if (index !== -1) {
+          registrations.splice(index, 1);
+          try {
+            newInstrumentation.destroy?.();
+          } catch (cleanupError) {
+            internalLogger.warn('Failed to clean up instrumentation after initialization failure', cleanupError);
+          }
+        }
+        throw error;
+      }
     });
   };
 
   const remove: Instrumentations['remove'] = (...instrumentationsToRemove) => {
     internalLogger.debug('Removing instrumentations');
 
-    instrumentationsToRemove.forEach((instrumentationToRemove) => {
+    const selected = instrumentationsToRemove.map((instrumentationToRemove) => {
       internalLogger.debug(`Removing "${instrumentationToRemove.name}" instrumentation`);
 
-      const existingInstrumentationIndex = instrumentations.reduce<number | null>(
-        (acc, existingInstrumentation, existingTransportIndex) => {
-          if (acc === null && existingInstrumentation.name === instrumentationToRemove.name) {
-            return existingTransportIndex;
-          }
-
-          return null;
-        },
-        null
+      const registration = registrations.find(
+        ({ instrumentation }) => instrumentation.name === instrumentationToRemove.name
       );
 
-      if (existingInstrumentationIndex === null) {
+      if (!registration) {
         internalLogger.warn(`Instrumentation "${instrumentationToRemove.name}" is not added`);
+      }
 
+      return registration;
+    });
+
+    selected.forEach((registration) => {
+      if (!registration) {
         return;
       }
 
-      instrumentations[existingInstrumentationIndex]!.destroy?.();
-
-      instrumentations.splice(existingInstrumentationIndex, 1);
+      const index = registrations.indexOf(registration);
+      if (index !== -1) {
+        registrations.splice(index, 1);
+        registration.instrumentation.destroy?.();
+      }
     });
   };
 
   return {
     add,
     get instrumentations() {
-      return [...instrumentations];
+      return registrations.map(({ instrumentation }) => instrumentation);
     },
     remove,
   };

--- a/packages/core/src/metas/capture.ts
+++ b/packages/core/src/metas/capture.ts
@@ -12,12 +12,13 @@ export function isMetaCaptured(meta: Meta): boolean {
 }
 
 /** Capture metadata, including with extension implementations predating capture listeners. */
-export function captureMetas(metas: Metas, callback?: () => void): Meta {
+export function captureMetas(metas: Pick<Metas, 'capture' | 'value'>, callback?: () => void): Meta {
   if (metas.capture) {
-    return markMetaCaptured(metas.capture(callback));
+    const meta = metas.capture(callback);
+    return isMetaCaptured(meta) ? meta : markMetaCaptured({ ...meta });
   }
 
-  const meta = markMetaCaptured(metas.value);
+  const meta = markMetaCaptured({ ...metas.value });
   callback?.();
   return meta;
 }

--- a/packages/core/src/metas/initialize.test.ts
+++ b/packages/core/src/metas/initialize.test.ts
@@ -22,6 +22,22 @@ describe('metas', () => {
     expect(metas.value.session?.id).toBe('after');
   });
 
+  it.each([false, true])(
+    'snapshots a reused legacy metadata object without marking it captured (capture=%s)',
+    (customCapture) => {
+      const live = { session: { id: 'first' } };
+      const metas = { value: live, capture: customCapture ? () => live : undefined };
+      const first = captureMetas(metas);
+      live.session = { id: 'second' };
+      const second = captureMetas(metas);
+
+      expect(first).not.toBe(live);
+      expect(second).not.toBe(live);
+      expect(first.session?.id).toBe('first');
+      expect(second.session?.id).toBe('second');
+    }
+  );
+
   it('sets app.gitHash from global object on initialization', () => {
     (global as any).__faroGitHash_test = 'abc123def456abc123def456abc123def456abc1';
 
@@ -151,6 +167,70 @@ describe('metas', () => {
     metas.removeCaptureListener!(fail);
     metas.addCaptureListener!(() => api.setSession({ id: 'recovered' }));
     expect(metas.capture!().session?.id).toBe('recovered');
+  });
+
+  it('retains a reconciliation failure swallowed by nested telemetry until the outer capture exits', () => {
+    const transport = new MockTransport();
+    const { api, metas } = initializeFaro(mockConfig({ transports: [transport], dedupe: true }));
+    const fail = () => {
+      throw new Error('nested failure');
+    };
+    const remaining = jest.fn();
+    metas.addCaptureListener!(() => api.pushEvent('nested'));
+    metas.addCaptureListener!(fail);
+    metas.addCaptureListener!(remaining);
+
+    api.pushEvent('outer');
+
+    expect(transport.items).toEqual([]);
+    expect(remaining).not.toHaveBeenCalled();
+
+    metas.removeCaptureListener!(fail);
+    api.pushEvent('outer');
+    expect(transport.items.map((item) => (item.payload as { name: string }).name)).toEqual(['nested', 'outer']);
+    expect(remaining).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains metadata assembly failure after a nested public API catches it', () => {
+    const transport = new MockTransport();
+    const { api, metas } = initializeFaro(mockConfig({ transports: [transport] }));
+    let fail = true;
+    metas.add(() => {
+      if (fail) {
+        fail = false;
+        throw new Error('metadata assembly failed');
+      }
+      return {};
+    });
+    metas.addCaptureListener!(() => api.pushEvent('nested'));
+
+    expect(() => metas.capture!(() => api.pushEvent('outer'))).toThrow('metadata assembly failed');
+    expect(transport.items).toEqual([]);
+
+    api.pushEvent('recovered');
+    expect(transport.items.map((item) => (item.payload as { name: string }).name)).toEqual(['nested', 'recovered']);
+  });
+
+  it('does not deliver a metadata listener when assembly triggers a caught capture failure', () => {
+    const { api, metas } = initializeFaro(mockConfig());
+    let submit = true;
+    metas.add(() => {
+      if (submit) {
+        submit = false;
+        api.pushEvent('nested');
+      }
+      return {};
+    });
+    const delivered = jest.fn();
+    metas.addListener(delivered);
+    metas.addCaptureListener!(() => api.setSession({ id: 'replacement' }));
+    metas.addCaptureListener!(() => {
+      throw new Error('capture failed');
+    });
+
+    api.pushEvent('outer');
+
+    expect(delivered).not.toHaveBeenCalled();
   });
 
   it('resets the capture cycle after a pending listener throws during nested capture', () => {

--- a/packages/core/src/metas/initialize.ts
+++ b/packages/core/src/metas/initialize.ts
@@ -14,18 +14,32 @@ export function initializeMetas(
   let items: MetaItem[] = [];
   let listeners: MetasListener[] = [];
   let captureListeners: Array<() => void> = [];
-  let pendingCaptureListeners: Array<() => void> | undefined;
-  let nextCaptureListener = 0;
-  let captureListenerCount = 0;
+  const sessionPreparations = new Set<object>();
+  let activeCapture: { listeners: Array<() => void>; next: number; failure?: { error: unknown } } | undefined;
 
-  const getValue = () => items.reduce<Meta>((acc, item) => Object.assign(acc, isFunction(item) ? item() : item), {});
+  const getValue = (): Meta => {
+    try {
+      return items.reduce<Meta>((acc, item) => Object.assign(acc, isFunction(item) ? item() : item), {});
+    } catch (error) {
+      if (activeCapture) {
+        activeCapture.failure ??= { error };
+      }
+      throw error;
+    }
+  };
 
   const notifyListeners = () => {
-    if (listeners.length) {
+    // A listener can replace metadata. Later deliveries must see that replacement.
+    listeners.forEach((listener) => {
+      if (activeCapture?.failure) {
+        throw activeCapture.failure.error;
+      }
       const value = getValue();
-
-      listeners.forEach((listener) => listener(value));
-    }
+      if (activeCapture?.failure) {
+        throw activeCapture.failure.error;
+      }
+      listener(value);
+    });
   };
 
   const add: Metas['add'] = (...newItems) => {
@@ -56,28 +70,45 @@ export function initializeMetas(
     listeners = listeners.filter((currentListener) => currentListener !== listener);
   };
 
+  const assertCaptureAllowed = () => {
+    if (sessionPreparations.size > 0) {
+      const error = new Error('Telemetry submitted during session preparation was discarded');
+      internalLogger.warn(error.message);
+      throw error;
+    }
+    if (activeCapture?.failure) {
+      throw activeCapture.failure.error;
+    }
+  };
+
   const capture: NonNullable<Metas['capture']> = (callback) => {
+    assertCaptureAllowed();
     // Nested telemetry drains pending reconciliation but never reruns active or
     // completed listeners, including when a capture callback submits events.
-    const nested = pendingCaptureListeners !== undefined;
-    const cycleListeners = pendingCaptureListeners ?? captureListeners;
-    if (!nested) {
-      // Preserve forEach's array and length semantics if listeners are changed.
-      pendingCaptureListeners = cycleListeners;
-      nextCaptureListener = 0;
-      captureListenerCount = cycleListeners.length;
-    }
+    const nested = activeCapture !== undefined;
+    const cycle = (activeCapture ??= { listeners: captureListeners.slice(), next: 0 });
+    const checkFailure = () => {
+      if (cycle.failure) {
+        throw cycle.failure.error;
+      }
+    };
     try {
-      while (nextCaptureListener < captureListenerCount) {
-        const listener = cycleListeners[nextCaptureListener++];
-        listener?.();
+      while (cycle.next < cycle.listeners.length) {
+        try {
+          cycle.listeners[cycle.next++]?.();
+        } catch (error) {
+          cycle.failure ??= { error };
+        }
+        checkFailure();
       }
       const value = markMetaCaptured(getValue());
+      checkFailure();
       callback?.();
+      checkFailure();
       return value;
     } finally {
       if (!nested) {
-        pendingCaptureListeners = undefined;
+        activeCapture = undefined;
       }
     }
   };
@@ -85,8 +116,24 @@ export function initializeMetas(
   return {
     add,
     remove,
+    replace: (previous, replacement) => {
+      items = items.filter((item) => item !== previous);
+      items.push(replacement);
+      if (!isFunction(replacement) && 'session' in replacement) {
+        sessionPreparations.clear();
+      }
+      notifyListeners();
+    },
+    beginSessionUpdate: () => {
+      const preparation = {};
+      sessionPreparations.add(preparation);
+      return () => {
+        sessionPreparations.delete(preparation);
+      };
+    },
     addListener,
     removeListener,
+    assertCaptureAllowed,
     capture,
     addCaptureListener: (listener) => {
       captureListeners.push(listener);

--- a/packages/core/src/metas/types.ts
+++ b/packages/core/src/metas/types.ts
@@ -7,6 +7,12 @@ export type MetasListener = (value: Meta) => void;
 export interface Metas {
   add: (...getters: MetaItem[]) => void;
   remove: (...getters: MetaItem[]) => void;
+  /** Replace an item atomically, giving the replacement precedence over existing metadata. */
+  replace?: (previous: MetaItem | undefined, replacement: MetaItem) => void;
+  /** Reject captures until a session replacement commits, or the preparation is cancelled. */
+  beginSessionUpdate?: () => () => void;
+  /** Check admission without reconciling or changing an already selected owner. */
+  assertCaptureAllowed?: () => void;
   addListener: (listener: MetasListener) => void;
   removeListener: (listener: MetasListener) => void;
   /** Reconcile before capture. Optional for compatibility with older extension implementations. */

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -139,7 +139,7 @@ export function initializeTransports(
         return;
       }
       const itemMeta = { ...item.meta };
-      if (itemMeta.session?.id === previousSessionId && meta.session?.id !== previousSessionId) {
+      if (previousSessionId && itemMeta.session?.id === previousSessionId && meta.session?.id !== previousSessionId) {
         if (meta.session === undefined) {
           delete itemMeta.session;
         } else {

--- a/packages/core/src/transports/transports.test.ts
+++ b/packages/core/src/transports/transports.test.ts
@@ -43,6 +43,17 @@ class MockTransport extends BaseTransport implements Transport {
 const sendMock = jest.spyOn(MockTransport.prototype, 'send');
 
 describe('transports', () => {
+  it('preserves a custom item without session ownership when reconciliation creates a session', () => {
+    const transport = new MockTransport();
+    const { api, metas, transports } = initializeFaro(mockConfig({ transports: [transport] }));
+    metas.addCaptureListener!(() => api.setSession({ id: 'new-session' }));
+
+    transports.execute(makeExceptionTransportItem('Error', 'before-session'));
+
+    expect(api.getSession()?.id).toBe('new-session');
+    expect(transport.sentItems[0]?.meta.session).toBeUndefined();
+  });
+
   describe('config.beforeSend', () => {
     it('will not send events that are rejected by beforeSend hook', () => {
       const transport = new MockTransport();

--- a/packages/web-sdk/src/instrumentations/session/capture.integration.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/capture.integration.test.ts
@@ -1,0 +1,285 @@
+import { EVENT_SESSION_EXTEND, type EventEvent, initializeFaro } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+
+import { SessionInstrumentation } from './instrumentation';
+import { SESSION_INACTIVITY_TIME, STORAGE_KEY } from './sessionManager';
+
+describe.each([true, false])('session capture with persistent=%s', (persistent) => {
+  const instrumentations: SessionInstrumentation[] = [];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    instrumentations.splice(0).forEach((instrumentation) => instrumentation.destroy());
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it.each([false, true])(
+    'keeps a nested session from override callbacks, with stored overrides=%s',
+    (storedOverrides) => {
+      const instrumentation = new SessionInstrumentation();
+      instrumentations.push(instrumentation);
+      const transport = new MockTransport();
+      const sdk = initializeFaro(
+        mockConfig({
+          transports: [transport],
+          instrumentations: [instrumentation],
+          sessionTracking: { enabled: true, persistent, samplingRate: 1 },
+        })
+      );
+      if (storedOverrides) {
+        sdk.api.setSession({ id: 'previous', overrides: { serviceName: 'stored-service' } });
+      }
+      let once = true;
+      sdk.api.setSession({
+        id: 'outer',
+        overrides: {
+          get serviceName() {
+            if (once) {
+              once = false;
+              sdk.api.setSession({ id: 'nested', attributes: { source: 'nested' } });
+            }
+            return 'outer-service';
+          },
+        },
+      });
+      expect(sdk.api.getSession()).toMatchObject({ id: 'nested', attributes: { source: 'nested', isSampled: 'true' } });
+      const storage = persistent ? window.localStorage : window.sessionStorage;
+      expect(JSON.parse(storage.getItem(STORAGE_KEY)!).sessionId).toBe('nested');
+      sdk.api.pushEvent('after-nested');
+      expect(transport.items.at(-1)!.meta.session?.id).toBe('nested');
+    }
+  );
+
+  it.each([
+    { initial: 'repeated', storageFailure: false },
+    { initial: 'repeated', storageFailure: true },
+    { initial: 'outer', storageFailure: false },
+  ])('finishes normalization when the sampler repeats the same semantic session: %j', ({ initial, storageFailure }) => {
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    const sdk = initializeFaro(
+      mockConfig({
+        instrumentations: [instrumentation],
+        sessionTracking: { enabled: true, persistent, samplingRate: 1 },
+      })
+    );
+    const storage = persistent ? window.localStorage : window.sessionStorage;
+    const previous = JSON.parse(storage.getItem(STORAGE_KEY)!).sessionId;
+    if (storageFailure) {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+    }
+    let calls = 0;
+    sdk.config.sessionTracking!.sampler = () => {
+      if (++calls > 3) {
+        throw new Error('normalization did not converge');
+      }
+      sdk.api.setSession({ id: 'repeated', attributes: { source: 'same' } });
+      return 1;
+    };
+    sdk.api.setSession({ id: initial, attributes: { source: 'same' } });
+    expect(sdk.api.getSession()).toMatchObject({ id: 'repeated', attributes: { source: 'same', isSampled: 'true' } });
+    expect(JSON.parse(storage.getItem(STORAGE_KEY)!).sessionId).toBe(storageFailure ? previous : 'repeated');
+  });
+
+  it.each(['generator', 'sampler'])(
+    'discards precommit telemetry from the %s without poisoning the outer capture',
+    (source) => {
+      const instrumentation = new SessionInstrumentation();
+      instrumentations.push(instrumentation);
+      const transport = new MockTransport();
+      const sdk = initializeFaro(
+        mockConfig({
+          transports: [transport],
+          instrumentations: [instrumentation],
+          dedupe: true,
+          sessionTracking: { enabled: true, persistent, samplingRate: 1 },
+        })
+      );
+      transport.items.length = 0;
+      const beforeSend = jest.fn((item) => item);
+      sdk.transports.addBeforeSendHooks(beforeSend);
+      const precommit = () => sdk.api.pushEvent('precommit');
+      if (source === 'generator') {
+        sdk.config.sessionTracking!.generateSessionId = () => {
+          precommit();
+          return 'replacement';
+        };
+      } else {
+        sdk.config.sessionTracking!.sampler = () => {
+          precommit();
+          return 1;
+        };
+      }
+      jest.advanceTimersByTime(SESSION_INACTIVITY_TIME + 1);
+
+      sdk.api.pushEvent('outer');
+
+      const sessionId = sdk.api.getSession()!.id;
+      expect(transport.items.map((item) => [(item.payload as EventEvent).name, item.meta.session?.id])).toEqual([
+        [EVENT_SESSION_EXTEND, sessionId],
+        ['outer', sessionId],
+      ]);
+      expect(beforeSend).toHaveBeenCalledTimes(2);
+
+      sdk.api.pushEvent('precommit');
+      expect((transport.items.at(-1)!.payload as EventEvent).name).toBe('precommit');
+    }
+  );
+
+  it('revokes callbacks already selected for metadata dispatch when the instrumentation is removed', () => {
+    const transport = new MockTransport();
+    const sdk = initializeFaro(mockConfig({ transports: [transport], sessionTracking: { enabled: true, persistent } }));
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    sdk.metas.addListener((meta) => {
+      if (meta.session?.id === 'after-removal') {
+        sdk.instrumentations.remove(instrumentation);
+      }
+    });
+    sdk.instrumentations.add(instrumentation);
+    transport.items.length = 0;
+    const storage = persistent ? window.localStorage : window.sessionStorage;
+    const beforeRemoval = storage.getItem(STORAGE_KEY);
+
+    sdk.api.setSession({ id: 'after-removal' });
+    jest.advanceTimersByTime(SESSION_INACTIVITY_TIME + 1);
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(storage.getItem(STORAGE_KEY)).toBe(beforeRemoval);
+    expect(transport.items).toEqual([]);
+    expect(sdk.api.getSession()).toEqual({ id: 'after-removal' });
+  });
+
+  it.each(['generator', 'sampler'])(
+    'retries an independent capture after the %s submits telemetry and throws',
+    (source) => {
+      const instrumentation = new SessionInstrumentation();
+      instrumentations.push(instrumentation);
+      const transport = new MockTransport();
+      const sdk = initializeFaro(
+        mockConfig({
+          transports: [transport],
+          instrumentations: [instrumentation],
+          dedupe: true,
+          sessionTracking: { enabled: true, persistent, samplingRate: 1 },
+        })
+      );
+      const sessionId = sdk.api.getSession()!.id;
+      const fail = () => {
+        sdk.api.pushEvent('precommit');
+        throw new Error('precommit failure');
+      };
+      if (source === 'generator') {
+        sdk.config.sessionTracking!.generateSessionId = fail;
+      } else {
+        sdk.config.sessionTracking!.sampler = fail;
+      }
+      transport.items.length = 0;
+      jest.advanceTimersByTime(SESSION_INACTIVITY_TIME + 1);
+      sdk.api.pushEvent('outer');
+      expect(transport.items).toEqual([]);
+      expect(sdk.api.getSession()!.id).toBe(sessionId);
+
+      delete sdk.config.sessionTracking!.generateSessionId;
+      delete sdk.config.sessionTracking!.sampler;
+      sdk.api.pushEvent('outer');
+      expect(sdk.api.getSession()!.id).not.toBe(sessionId);
+      expect(transport.items.map((item) => (item.payload as EventEvent).name)).toEqual([EVENT_SESSION_EXTEND, 'outer']);
+    }
+  );
+
+  it('does not write or notify after a sampler disposes its manager during reconciliation', () => {
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    const onSessionChange = jest.fn();
+    const sdk = initializeFaro(
+      mockConfig({
+        instrumentations: [instrumentation],
+        sessionTracking: { enabled: true, persistent, onSessionChange },
+      })
+    );
+    const storage = persistent ? window.localStorage : window.sessionStorage;
+    const beforeRemoval = storage.getItem(STORAGE_KEY);
+    sdk.config.sessionTracking!.sampler = () => {
+      sdk.instrumentations.remove(instrumentation);
+      return 1;
+    };
+    jest.advanceTimersByTime(SESSION_INACTIVITY_TIME + 1);
+    sdk.api.pushEvent('outer');
+
+    expect(storage.getItem(STORAGE_KEY)).toBe(beforeRemoval);
+    expect(onSessionChange).not.toHaveBeenCalled();
+  });
+
+  it('unwinds a partially initialized manager when session creation throws', () => {
+    const sdk = initializeFaro(mockConfig({ sessionTracking: { enabled: true, persistent } }));
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    sdk.config.sessionTracking!.sampler = () => {
+      throw new Error('startup failed');
+    };
+    expect(() => sdk.instrumentations.add(instrumentation)).toThrow('startup failed');
+    delete sdk.config.sessionTracking!.sampler;
+    sdk.api.setSession({ id: 'unmanaged' });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect((persistent ? window.localStorage : window.sessionStorage).getItem(STORAGE_KEY)).toBeNull();
+    expect(sdk.api.getSession()).toEqual({ id: 'unmanaged' });
+    expect(sdk.transports.getBeforeSendHooks()).toHaveLength(0);
+  });
+
+  it('normalizes once when the session store cannot accept writes', () => {
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    const sdk = initializeFaro(
+      mockConfig({
+        instrumentations: [instrumentation],
+        sessionTracking: { enabled: true, persistent },
+      })
+    );
+    const originalSetItem = Storage.prototype.setItem;
+    const writes = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === STORAGE_KEY) {
+        throw new Error('storage full');
+      }
+      originalSetItem.call(this, key, value);
+    });
+
+    expect(() => sdk.api.setSession({ id: 'replacement' })).not.toThrow();
+
+    expect(sdk.api.getSession()).toMatchObject({ id: 'replacement', attributes: { isSampled: 'true' } });
+    expect(writes.mock.calls.filter(([key]) => key === STORAGE_KEY)).toHaveLength(1);
+  });
+
+  it('normalizes a later nested replacement and retains its metadata in storage', () => {
+    const instrumentation = new SessionInstrumentation();
+    instrumentations.push(instrumentation);
+    const sdk = initializeFaro(
+      mockConfig({
+        instrumentations: [instrumentation],
+        sessionTracking: { enabled: true, persistent },
+      })
+    );
+    sdk.metas.addListener((meta) => {
+      if (meta.session?.id === 'outer' && meta.session.attributes?.['isSampled']) {
+        sdk.api.setSession({ id: 'nested', attributes: { owner: 'latest' } });
+      }
+    });
+
+    sdk.api.setSession({ id: 'outer' });
+
+    const expected = { id: 'nested', attributes: { owner: 'latest', isSampled: 'true' } };
+    expect(sdk.api.getSession()).toMatchObject(expected);
+    expect(
+      JSON.parse((persistent ? window.localStorage : window.sessionStorage).getItem(STORAGE_KEY)!).sessionMeta
+    ).toMatchObject(expected);
+  });
+});

--- a/packages/web-sdk/src/instrumentations/session/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/instrumentation.ts
@@ -18,40 +18,35 @@ import type { SessionManager } from './sessionManager/types';
 
 type LifecycleType = typeof EVENT_SESSION_RESUME | typeof EVENT_SESSION_START;
 
+interface SessionLifetime {
+  manager?: InstanceType<SessionManager>;
+  notifiedSession?: MetaSession;
+  disposers: Array<() => void>;
+}
+
 export class SessionInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-web-sdk:instrumentation-session';
   readonly version: string = VERSION;
 
-  // previously notified session, to ensure we don't send session start
-  // event twice for the same session
-  private notifiedSession: MetaSession | undefined;
+  private lifetime?: SessionLifetime;
 
-  // Reads the session manager's adoption flag (set once the manager exists).
-  private isAdoptingSession: () => boolean = () => false;
-  private captureListener: (() => void) | undefined;
-  private beforeSendHook: BeforeSendHook | undefined;
-  private sessionStartListener: ((meta: Meta) => void) | undefined;
-
-  private sendSessionStartEvent(meta: Meta): void {
+  private sendSessionStartEvent(meta: Meta, lifetime: SessionLifetime): void {
+    if (this.lifetime !== lifetime) {
+      return;
+    }
     const session = meta.session;
-
-    if (session && session.id !== this.notifiedSession?.id) {
+    const previousSession = lifetime.notifiedSession;
+    if (session && session.id !== previousSession?.id) {
+      lifetime.notifiedSession = session;
       // Adopting another tab's session: track it but emit nothing (the creating tab already did).
-      if (this.isAdoptingSession()) {
-        this.notifiedSession = session;
+      if (lifetime.manager?.isAdopting()) {
         return;
       }
-
-      if (this.notifiedSession && this.notifiedSession.id === session.attributes?.['previousSession']) {
-        this.api.pushEvent(EVENT_SESSION_EXTEND, {}, undefined, { skipDedupe: true });
-        this.notifiedSession = session;
-        return;
-      }
-
-      this.notifiedSession = session;
-      // no need to add attributes and session id, they are included as part of meta
-      // automatically
-      this.api.pushEvent(EVENT_SESSION_START, {}, undefined, { skipDedupe: true });
+      const event =
+        previousSession?.id === session.attributes?.['previousSession'] && previousSession
+          ? EVENT_SESSION_EXTEND
+          : EVENT_SESSION_START;
+      this.api.pushEvent(event, {}, undefined, { skipDedupe: true });
     }
   }
 
@@ -132,13 +127,20 @@ export class SessionInstrumentation extends BaseInstrumentation {
     return { initialSession, lifecycleType };
   }
 
-  private registerBeforeSendHook(recordActivity: (sessionId: string) => void) {
-    this.beforeSendHook = (item) => {
+  private registerBeforeSendHook(lifetime: SessionLifetime): void {
+    const transports = this.transports;
+    const beforeSendHook: BeforeSendHook = (item) => {
+      if (this.lifetime !== lifetime) {
+        return item;
+      }
       // config.beforeSend runs before this hook. Sampling and hooks added later
       // retain their existing order and do not undo session activity.
       const sessionId = item.meta.session?.id;
       if (sessionId && !this.transports.isPaused()) {
-        recordActivity(sessionId);
+        lifetime.manager?.recordActivity(sessionId);
+      }
+      if (this.lifetime !== lifetime) {
+        return item;
       }
       // Delivery filters using the captured session's sampling decision. It must
       // never rotate or reassign an item that already belongs to a session.
@@ -146,6 +148,9 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
       if (attributes && attributes?.['isSampled'] === 'true') {
         let newItem: TransportItem = JSON.parse(JSON.stringify(item));
+        if (this.lifetime !== lifetime) {
+          return item;
+        }
 
         const newAttributes = newItem.meta.session?.attributes;
         delete newAttributes?.['isSampled'];
@@ -159,61 +164,108 @@ export class SessionInstrumentation extends BaseInstrumentation {
 
       return null;
     };
-    this.transports?.addBeforeSendHooks(this.beforeSendHook);
+    this.register(
+      lifetime,
+      () => transports.addBeforeSendHooks(beforeSendHook),
+      () => transports.removeBeforeSendHooks(beforeSendHook)
+    );
   }
 
   initialize(): void {
-    this.logDebug('init session instrumentation');
-
-    const sessionTrackingConfig = this.config.sessionTracking;
-
-    if (sessionTrackingConfig?.enabled) {
-      const SessionManager = getSessionManagerByConfig(sessionTrackingConfig);
-
-      const sessionManager = new SessionManager();
-      this.isAdoptingSession = sessionManager.isAdopting;
-      this.registerBeforeSendHook(sessionManager.recordActivity);
-
-      const { initialSession, lifecycleType } = this.createInitialSession(SessionManager, sessionTrackingConfig);
-
-      SessionManager.storeUserSession(initialSession);
-
-      const initialSessionMeta = initialSession.sessionMeta;
-
-      this.notifiedSession = initialSessionMeta;
-      this.api.setSession(initialSessionMeta);
-      this.captureListener = () => {
-        if (!this.transports.isPaused()) {
-          sessionManager.updateSession({ refreshActivity: false });
-        }
-      };
-      this.metas.addCaptureListener?.(this.captureListener);
-
-      if (lifecycleType === EVENT_SESSION_START) {
-        this.api.pushEvent(EVENT_SESSION_START, {}, undefined, { skipDedupe: true });
-      }
-
-      if (lifecycleType === EVENT_SESSION_RESUME) {
-        this.api.pushEvent(EVENT_SESSION_RESUME, {}, undefined, { skipDedupe: true });
-      }
+    this.destroy();
+    if (this.lifetime) {
+      return;
     }
+    const lifetime: SessionLifetime = { disposers: [] };
+    this.lifetime = lifetime;
+    const isActive = () => this.lifetime === lifetime;
+    const metas = this.metas;
+    const sessionTrackingConfig = this.config.sessionTracking;
+    try {
+      if (sessionTrackingConfig?.enabled) {
+        const SessionManager = getSessionManagerByConfig(sessionTrackingConfig);
+        lifetime.manager = new SessionManager();
+        if (!isActive()) {
+          lifetime.manager.dispose();
+          return;
+        }
+        this.registerBeforeSendHook(lifetime);
 
-    this.sessionStartListener = this.sendSessionStartEvent.bind(this);
-    this.metas.addListener(this.sessionStartListener);
+        const endPreparation = this.metas.beginSessionUpdate?.();
+        let lifecycleType: LifecycleType;
+        try {
+          const initial = this.createInitialSession(SessionManager, sessionTrackingConfig);
+          if (!isActive()) {
+            return;
+          }
+          lifecycleType = initial.lifecycleType;
+          lifetime.manager.storeSession(initial.initialSession);
+          if (!isActive()) {
+            return;
+          }
+          lifetime.notifiedSession = initial.initialSession.sessionMeta;
+          this.api.setSession(initial.initialSession.sessionMeta);
+        } finally {
+          endPreparation?.();
+        }
+        if (!isActive()) {
+          return;
+        }
+        const captureListener = () => {
+          if (isActive() && !this.transports.isPaused()) {
+            lifetime.manager!.updateSession({ refreshActivity: false });
+          }
+        };
+        this.register(
+          lifetime,
+          () => metas.addCaptureListener?.(captureListener),
+          () => metas.removeCaptureListener?.(captureListener)
+        );
+
+        if (isActive()) {
+          this.api.pushEvent(lifecycleType, {}, undefined, { skipDedupe: true });
+        }
+      }
+      if (isActive()) {
+        const sessionStartListener = (meta: Meta) => this.sendSessionStartEvent(meta, lifetime);
+        this.register(
+          lifetime,
+          () => metas.addListener(sessionStartListener),
+          () => metas.removeListener(sessionStartListener)
+        );
+      }
+    } catch (error) {
+      if (isActive()) {
+        this.destroy();
+      }
+      throw error;
+    }
+  }
+
+  private register(lifetime: SessionLifetime, add: () => void, remove: () => void): void {
+    if (this.lifetime !== lifetime) {
+      return;
+    }
+    lifetime.disposers.push(remove);
+    add();
+    if (this.lifetime !== lifetime) {
+      remove();
+    }
   }
 
   destroy(): void {
-    if (this.captureListener) {
-      this.metas.removeCaptureListener?.(this.captureListener);
-      this.captureListener = undefined;
+    const lifetime = this.lifetime;
+    if (!lifetime) {
+      return;
     }
-    if (this.beforeSendHook) {
-      this.transports.removeBeforeSendHooks(this.beforeSendHook);
-      this.beforeSendHook = undefined;
-    }
-    if (this.sessionStartListener) {
-      this.metas.removeListener(this.sessionStartListener);
-      this.sessionStartListener = undefined;
+    this.lifetime = undefined;
+    const disposers = [() => lifetime.manager?.dispose(), ...lifetime.disposers];
+    for (const dispose of disposers) {
+      try {
+        dispose();
+      } catch (error) {
+        this.logWarn('Failed to dispose session instrumentation resource', error);
+      }
     }
   }
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/PersistentSessionsManager.ts
@@ -1,5 +1,5 @@
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
-import type { MetaSession } from '@grafana/faro-core';
+import type { Meta, MetaSession } from '@grafana/faro-core';
 
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
@@ -14,6 +14,10 @@ import type { FaroUserSession } from './types';
 export class PersistentSessionsManager {
   private static storageTypeLocal = webStorageType.local;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
+  private readonly metas = faro.metas;
+  private active = true;
+  private metaListener?: (meta: Meta) => void;
+  private readonly isActive = (): boolean => this.active;
 
   // Set only for the synchronous span of an adopting setSession(); the session
   // instrumentation reads isAdopting() to suppress its lifecycle event.
@@ -22,6 +26,9 @@ export class PersistentSessionsManager {
   isAdopting = (): boolean => this.adopting;
 
   private adoptSession = (sessionMeta: MetaSession): void => {
+    if (!this.active) {
+      return;
+    }
     this.adopting = true;
     try {
       faro.api?.setSession(sessionMeta);
@@ -33,9 +40,10 @@ export class PersistentSessionsManager {
   constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: PersistentSessionsManager.fetchUserSession,
-      storeUserSession: PersistentSessionsManager.storeUserSession,
+      storeUserSession: this.storeSession,
       adoptSession: this.adoptSession,
       updateInterval: STORAGE_UPDATE_DELAY,
+      isActive: this.isActive,
     });
 
     this.init();
@@ -59,32 +67,59 @@ export class PersistentSessionsManager {
     return null;
   }
 
+  storeSession = (session: FaroUserSession): void => {
+    const serialized = stringifyExternalJson(session);
+    if (this.active) {
+      setItem(STORAGE_KEY, serialized, PersistentSessionsManager.storageTypeLocal);
+    }
+  };
+
   updateSession = ({ refreshActivity = true }: { refreshActivity?: boolean } = {}): void =>
     this.updateUserSession({ refreshActivity });
 
   recordActivity: (sessionId: string) => void = getUserSessionActivityRecorder({
     fetchUserSession: PersistentSessionsManager.fetchUserSession,
-    storeUserSession: PersistentSessionsManager.storeUserSession,
+    storeUserSession: this.storeSession,
     updateInterval: STORAGE_UPDATE_DELAY,
+    isActive: this.isActive,
   });
 
-  private init(): void {
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        this.updateSession({ refreshActivity: false });
-        const sessionId = faro.api?.getSession()?.id;
-        if (sessionId) {
-          this.recordActivity(sessionId);
-        }
+  private readonly visibilityListener = (): void => {
+    if (this.active && document.visibilityState === 'visible') {
+      this.updateSession({ refreshActivity: false });
+      const sessionId = this.metas.value.session?.id;
+      if (this.active && sessionId) {
+        this.recordActivity(sessionId);
       }
-    });
+    }
+  };
 
-    // Users can call the setSession() method, so we need to sync this with the local storage session
-    faro.metas.addListener(
-      getSessionMetaUpdateHandler({
+  private init(): void {
+    try {
+      this.metaListener = getSessionMetaUpdateHandler({
         fetchUserSession: PersistentSessionsManager.fetchUserSession,
-        storeUserSession: PersistentSessionsManager.storeUserSession,
-      })
-    );
+        storeUserSession: this.storeSession,
+        isActive: this.isActive,
+      });
+      document.addEventListener('visibilitychange', this.visibilityListener);
+      this.metas.addListener(this.metaListener);
+    } catch (error) {
+      this.dispose();
+      throw error;
+    }
+  }
+
+  dispose(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    try {
+      if (this.metaListener) {
+        this.metas.removeListener(this.metaListener);
+      }
+    } finally {
+      document.removeEventListener('visibilitychange', this.visibilityListener);
+    }
   }
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/VolatileSessionManager.ts
@@ -1,4 +1,5 @@
 import { faro, stringifyExternalJson } from '@grafana/faro-core';
+import type { Meta } from '@grafana/faro-core';
 
 import { getItem, removeItem, setItem, webStorageType } from '../../../utils/webStorage';
 
@@ -13,6 +14,10 @@ import type { FaroUserSession } from './types';
 export class VolatileSessionsManager {
   private static storageTypeSession = webStorageType.session;
   private updateUserSession: ReturnType<typeof getUserSessionUpdater>;
+  private readonly metas = faro.metas;
+  private active = true;
+  private metaListener?: (meta: Meta) => void;
+  private readonly isActive = (): boolean => this.active;
 
   // sessionStorage is tab-local, so this manager never adopts another tab's
   // session. Stubbed so the instrumentation can treat both managers uniformly.
@@ -21,8 +26,9 @@ export class VolatileSessionsManager {
   constructor() {
     this.updateUserSession = getUserSessionUpdater({
       fetchUserSession: VolatileSessionsManager.fetchUserSession,
-      storeUserSession: VolatileSessionsManager.storeUserSession,
+      storeUserSession: this.storeSession,
       updateInterval: STORAGE_UPDATE_DELAY,
+      isActive: this.isActive,
     });
 
     this.init();
@@ -46,32 +52,59 @@ export class VolatileSessionsManager {
     return null;
   }
 
+  storeSession = (session: FaroUserSession): void => {
+    const serialized = stringifyExternalJson(session);
+    if (this.active) {
+      setItem(STORAGE_KEY, serialized, VolatileSessionsManager.storageTypeSession);
+    }
+  };
+
   updateSession = ({ refreshActivity = true }: { refreshActivity?: boolean } = {}): void =>
     this.updateUserSession({ refreshActivity });
 
   recordActivity: (sessionId: string) => void = getUserSessionActivityRecorder({
     fetchUserSession: VolatileSessionsManager.fetchUserSession,
-    storeUserSession: VolatileSessionsManager.storeUserSession,
+    storeUserSession: this.storeSession,
     updateInterval: STORAGE_UPDATE_DELAY,
+    isActive: this.isActive,
   });
 
-  private init(): void {
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        this.updateSession({ refreshActivity: false });
-        const sessionId = faro.api?.getSession()?.id;
-        if (sessionId) {
-          this.recordActivity(sessionId);
-        }
+  private readonly visibilityListener = (): void => {
+    if (this.active && document.visibilityState === 'visible') {
+      this.updateSession({ refreshActivity: false });
+      const sessionId = this.metas.value.session?.id;
+      if (this.active && sessionId) {
+        this.recordActivity(sessionId);
       }
-    });
+    }
+  };
 
-    // Users can call the setSession() method, so we need to sync this with the local storage session
-    faro.metas.addListener(
-      getSessionMetaUpdateHandler({
+  private init(): void {
+    try {
+      this.metaListener = getSessionMetaUpdateHandler({
         fetchUserSession: VolatileSessionsManager.fetchUserSession,
-        storeUserSession: VolatileSessionsManager.storeUserSession,
-      })
-    );
+        storeUserSession: this.storeSession,
+        isActive: this.isActive,
+      });
+      document.addEventListener('visibilitychange', this.visibilityListener);
+      this.metas.addListener(this.metaListener);
+    } catch (error) {
+      this.dispose();
+      throw error;
+    }
+  }
+
+  dispose(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    try {
+      if (this.metaListener) {
+        this.metas.removeListener(this.metaListener);
+      }
+    } finally {
+      document.removeEventListener('visibilitychange', this.visibilityListener);
+    }
   }
 }

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.test.ts
@@ -144,8 +144,7 @@ describe('sessionManagerUtils', () => {
     // session is invalid
     jest.spyOn(mockSessionManagerUtils, 'isUserSessionValid').mockReturnValueOnce(false);
 
-    const mockSetSession = jest.fn();
-    jest.spyOn(faro.api, 'setSession').mockImplementationOnce(mockSetSession);
+    const mockSetSession = jest.spyOn(faro.api, 'setSession');
 
     mockFetchUserSession.mockReturnValueOnce({
       sessionId: 'abc',
@@ -209,8 +208,7 @@ describe('sessionManagerUtils', () => {
     // session is invalid
     jest.spyOn(mockSessionManagerUtils, 'isUserSessionValid').mockReturnValueOnce(false);
 
-    const mockSetSession = jest.fn();
-    jest.spyOn(faro.api, 'setSession').mockImplementationOnce(mockSetSession);
+    const mockSetSession = jest.spyOn(faro.api, 'setSession');
 
     mockFetchUserSession.mockReturnValue({
       sessionId: currentSessionMeta.id,
@@ -384,8 +382,7 @@ describe('sessionManagerUtils', () => {
       storeUserSession: mockStoreUserSession,
     });
 
-    const mockSetSession = jest.fn();
-    jest.spyOn(faro.api, 'setSession').mockImplementationOnce(mockSetSession);
+    const mockSetSession = jest.spyOn(faro.api, 'setSession');
 
     updateSession({ forceSessionExtend: true });
 
@@ -460,7 +457,7 @@ describe('sessionManagerUtils', () => {
       const mockStoreUserSession = jest.fn();
       jest.spyOn(VolatileSessionsManager, 'storeUserSession').mockImplementationOnce(mockStoreUserSession);
 
-      initializeFaro(mockConfig({}));
+      const faro = initializeFaro(mockConfig({}));
 
       const handler = mockSessionManagerUtils.getSessionMetaUpdateHandler({
         fetchUserSession: VolatileSessionsManager.fetchUserSession,
@@ -468,11 +465,8 @@ describe('sessionManagerUtils', () => {
       });
 
       const newSessionId = 'new-session-id';
-      handler({
-        session: {
-          id: newSessionId,
-        },
-      });
+      faro.metas.addListener(handler);
+      faro.api.setSession({ id: newSessionId });
 
       expect(mockStoreUserSession).toHaveBeenCalledTimes(1);
       expect(mockStoreUserSession).toHaveBeenCalledWith(
@@ -732,11 +726,10 @@ describe('sessionManagerUtils', () => {
       const mockPushEvent = jest.fn();
       jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(mockPushEvent);
 
-      handler({
-        session: {
-          id: mockSessionId,
-          overrides: newOverrides,
-        },
+      faro.metas.addListener(handler);
+      faro.api.setSession({
+        id: mockSessionId,
+        overrides: newOverrides,
       });
 
       expect(mockPushEvent).toHaveBeenCalledTimes(1);
@@ -784,11 +777,10 @@ describe('sessionManagerUtils', () => {
 
       const newOverrides = { serviceName: 'my-new-service' };
 
-      handler({
-        session: {
-          id: mockSessionId,
-          overrides: newOverrides,
-        },
+      faro.metas.addListener(handler);
+      faro.api.setSession({
+        id: mockSessionId,
+        overrides: newOverrides,
       });
 
       expect(mockPushEvent).toHaveBeenCalledTimes(1);

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -1,5 +1,13 @@
-import { dateNow, deepEqual, EVENT_OVERRIDES_SERVICE_NAME, faro, genShortID, isEmpty } from '@grafana/faro-core';
-import type { Meta, MetaOverrides } from '@grafana/faro-core';
+import {
+  dateNow,
+  deepEqual,
+  EVENT_OVERRIDES_SERVICE_NAME,
+  faro,
+  genShortID,
+  isEmpty,
+  stringifyExternalJson,
+} from '@grafana/faro-core';
+import type { Meta, MetaOverrides, MetaSession } from '@grafana/faro-core';
 
 import { isLocalStorageAvailable, isSessionStorageAvailable } from '../../../utils';
 
@@ -59,6 +67,7 @@ type GetUserSessionUpdaterParams = {
   // Optional: only the valid (non-force-extend) branch uses it.
   adoptSession?: (sessionMeta: NonNullable<FaroUserSession['sessionMeta']>) => void;
   updateInterval?: number;
+  isActive?: () => boolean;
 };
 
 type UpdateSessionParams = { forceSessionExtend?: boolean; refreshActivity?: boolean };
@@ -68,13 +77,14 @@ export function getUserSessionUpdater({
   storeUserSession,
   adoptSession,
   updateInterval = 0,
+  isActive = () => true,
 }: GetUserSessionUpdaterParams): (options?: UpdateSessionParams) => void {
   let nextUpdate = 0;
   return function updateSession({
     forceSessionExtend = false,
     refreshActivity = true,
   }: UpdateSessionParams = {}): void {
-    if (!fetchUserSession || !storeUserSession) {
+    if (!isActive()) {
       return;
     }
 
@@ -91,6 +101,9 @@ export function getUserSessionUpdater({
     }
 
     const sessionFromStorage = fetchUserSession();
+    if (!isActive()) {
+      return;
+    }
     // Bound checks by both expiry deadlines. A backward clock adjustment must
     // not turn the storage interval into a long suspension of reconciliation.
     nextUpdate = Math.min(
@@ -107,6 +120,7 @@ export function getUserSessionUpdater({
       // Another tab rotated the shared session; adopt it so we stop emitting the stale id.
       const inMemorySessionId = faro.metas.value.session?.id;
       if (
+        isActive() &&
         adoptSession != null &&
         sessionFromStorage!.sessionMeta != null &&
         sessionFromStorage!.sessionId !== inMemorySessionId
@@ -114,16 +128,35 @@ export function getUserSessionUpdater({
         adoptSession(sessionFromStorage!.sessionMeta);
       }
     } else {
-      let newSession = addSessionMetadataToNextSession(
-        createUserSessionObject({ isSampled: isSampled() }),
-        sessionFromStorage
-      );
-      nextUpdate = now + updateInterval;
-
-      storeUserSession(newSession);
-
-      faro.api?.setSession(newSession.sessionMeta);
-      sessionTrackingConfig?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
+      const endPreparation = faro.metas.beginSessionUpdate?.();
+      try {
+        const sampled = isSampled();
+        if (!isActive()) {
+          return;
+        }
+        const newSession = addSessionMetadataToNextSession(
+          createUserSessionObject({ isSampled: sampled }),
+          sessionFromStorage
+        );
+        if (!isActive()) {
+          return;
+        }
+        storeUserSession(newSession);
+        if (!isActive()) {
+          return;
+        }
+        nextUpdate = now + updateInterval;
+        faro.api?.setSession(newSession.sessionMeta);
+        const currentSessionId = faro.metas.value.session?.id;
+        if (isActive() && currentSessionId === newSession.sessionId) {
+          sessionTrackingConfig?.onSessionChange?.(sessionFromStorage?.sessionMeta ?? null, newSession.sessionMeta!);
+        }
+      } catch (error) {
+        nextUpdate = 0;
+        throw error;
+      } finally {
+        endPreparation?.();
+      }
     }
   };
 }
@@ -132,13 +165,17 @@ export function getUserSessionActivityRecorder({
   fetchUserSession,
   storeUserSession,
   updateInterval = 0,
-}: Pick<GetUserSessionUpdaterParams, 'fetchUserSession' | 'storeUserSession' | 'updateInterval'>): (
+  isActive = () => true,
+}: Pick<GetUserSessionUpdaterParams, 'fetchUserSession' | 'storeUserSession' | 'updateInterval' | 'isActive'>): (
   sessionId: string
 ) => void {
   let lastSessionId: string | undefined;
   let nextUpdate = 0;
 
   return (sessionId) => {
+    if (!isActive()) {
+      return;
+    }
     const now = dateNow();
     if (sessionId === lastSessionId && now < nextUpdate && nextUpdate - now <= updateInterval) {
       return;
@@ -148,7 +185,7 @@ export function getUserSessionActivityRecorder({
     const session = fetchUserSession();
     // Accepted old batches must not refresh a replacement session or resurrect
     // an expired one. This path records activity only; it never rotates.
-    if (session?.sessionId !== sessionId || !isUserSessionValid(session)) {
+    if (!isActive() || session?.sessionId !== sessionId || !isUserSessionValid(session)) {
       return;
     }
     storeUserSession({ ...session, lastActivity: now });
@@ -187,20 +224,33 @@ export function addSessionMetadataToNextSession(
 type GetUserSessionMetaUpdateHandlerParams = {
   storeUserSession: (session: FaroUserSession) => void;
   fetchUserSession: () => FaroUserSession | null;
+  isActive?: () => boolean;
 };
 
 export function getSessionMetaUpdateHandler({
   fetchUserSession,
   storeUserSession,
+  isActive = () => true,
 }: GetUserSessionMetaUpdateHandlerParams) {
-  let isSyncing = false;
+  let synchronizing: 'preparing' | MetaSession | undefined;
+  let pendingNotification = false;
 
   return function syncSessionIfChangedExternally(meta: Meta): void {
-    if (isSyncing) {
+    if (!isActive()) {
+      return;
+    }
+    if (synchronizing === 'preparing') {
+      pendingNotification = true;
+      return;
+    }
+    if (synchronizing && deepEqual(meta.session, synchronizing)) {
       return;
     }
     const session = meta.session;
     const sessionFromSessionStorage = fetchUserSession();
+    if (!isActive()) {
+      return;
+    }
 
     let sessionId = session?.id;
     const sessionAttributes = session?.attributes;
@@ -214,19 +264,60 @@ export function getSessionMetaUpdateHandler({
     const hasSessionIdChanged = !!session && sessionId !== sessionFromSessionStorage?.sessionId;
 
     if (hasSessionIdChanged || hasAttributesChanged || hasSessionOverridesChanged) {
-      const userSession = addSessionMetadataToNextSession(
-        createUserSessionObject({ sessionId, isSampled: isSampled() }),
-        sessionFromSessionStorage
-      );
-
-      storeUserSession(userSession);
-      sendOverrideEvent(hasSessionOverridesChanged, sessionOverrides, storedSessionMetaOverrides);
-
-      isSyncing = true;
+      const previousMetaSession = session;
+      const previousSynchronization = synchronizing;
+      synchronizing = 'preparing';
+      pendingNotification = false;
+      const endPreparation = faro.metas.beginSessionUpdate?.();
+      let rescan = false;
       try {
-        faro.api.setSession(userSession.sessionMeta);
+        const sampled = isSampled();
+        if (!isActive()) {
+          return;
+        }
+        const userSession = JSON.parse(
+          stringifyExternalJson(
+            addSessionMetadataToNextSession(
+              createUserSessionObject({ sessionId, isSampled: sampled }),
+              sessionFromSessionStorage
+            )
+          )
+        ) as Required<FaroUserSession>;
+        const currentMetaSession = faro.metas.value.session;
+        if (!isActive()) {
+          return;
+        }
+        // Identical nested setters can share this normalization. A notification
+        // during comparison instead belongs to a newer operation.
+        rescan = pendingNotification;
+        pendingNotification = false;
+        if (deepEqual(currentMetaSession, previousMetaSession) && !pendingNotification && isActive()) {
+          rescan = false;
+          storeUserSession(userSession);
+          if (!isActive()) {
+            return;
+          }
+          // Suppress our completed replacement even when persistence failed.
+          synchronizing = userSession.sessionMeta;
+          faro.api.setSession(userSession.sessionMeta);
+          const currentSessionId = faro.metas.value.session?.id;
+          if (isActive() && currentSessionId === userSession.sessionId) {
+            sendOverrideEvent(
+              hasSessionOverridesChanged,
+              userSession.sessionMeta.overrides,
+              storedSessionMetaOverrides
+            );
+          }
+        }
       } finally {
-        isSyncing = false;
+        endPreparation?.();
+        synchronizing = previousSynchronization;
+        rescan ||= pendingNotification;
+        pendingNotification = false;
+      }
+      if (rescan && isActive()) {
+        faro.metas.assertCaptureAllowed?.();
+        syncSessionIfChangedExternally(faro.metas.value);
       }
     }
   };


### PR DESCRIPTION
## Why

Session replacement can expose a partially prepared owner to reentrant telemetry, and removed instrumentation can leave callbacks that mutate its replacement. Make replacement atomic, reject capture during preparation, and keep later nested changes authoritative.

## What

- Give capture cycles explicit admission and retained-failure handling, deliver fresh metadata to listeners, and normalize callback-bearing session data before committing it.
- Dispose both session managers and make instrumentation registration/removal safe during initialization and reentrant callbacks. Preserve stored sessions across removal.
- Investigate persistent-session concurrency with native browser evidence and a retained smoke test. Multiple tabs can still independently rotate an expired session; subsequent captures adopt the settled stored owner. Keep that documented best-effort contract.

Validation: 131 session tests and focused core regressions pass. The complete stack passes 970 unit tests (one existing skip), all 30 smoke tests, package builds/typechecks, lint, and circular-dependency checks. Standards and specification review findings are addressed.

## Links

Follow-up to #2261, within the merged #2259 → #2261 → #2260 → #2256 → #2264 chain.
Closes #2267 with the concurrency investigation and documented conclusion.

[Concurrency evidence](https://github.com/grafana/faro-web-sdk/blob/replay-lifecycle/session-capture/docs/sources/developer/persistent-session-concurrency.md)

Draft stack: #2272 (session capture) → #2273 (span ownership) → #2274 (recording leases) → #2275 (send deadline). Review and merge from the bottom.

## Checklist

- [x] Tests added
- [x] Conventional commit included for the release-please changelog
- [x] Documentation updated
