### PR TITLE
fix(tracing): preserve span ownership through export

### DIFF
--- a/docs/sources/developer/architecture/components/metas.md
+++ b/docs/sources/developer/architecture/components/metas.md
@@ -214,6 +214,7 @@ Methods and properties:
 - `remove()` - removes a specific meta
 - `replace(previous, replacement)` - atomically removes the previous item and appends its replacement
 - `beginSessionUpdate()` - rejects captures until a session replacement commits; returns a cancellation function
+- `assertCaptureAllowed()` - checks capture admission without reconciling or selecting new ownership
 - `addListener()` - adds a new listener
 - `removeListener()` - removes a specific listener
 - `capture(callback?)` - runs capture listeners and returns metadata assembled before the optional

--- a/packages/core/src/api/events/initialize.ts
+++ b/packages/core/src/api/events/initialize.ts
@@ -1,6 +1,7 @@
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
 import { captureMetas, type Metas } from '../../metas';
+import { markMetaCaptured } from '../../metas/capture';
 import { TransportItemType } from '../../transports';
 import type { TransportItem, Transports } from '../../transports';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
@@ -34,7 +35,13 @@ export function initializeEventsAPI({
     name,
     attributes,
     domain,
-    { skipDedupe, spanContext, timestampOverwriteMs, customPayloadTransformer = (payload: EventEvent) => payload } = {}
+    {
+      meta: capturedMeta,
+      skipDedupe,
+      spanContext,
+      timestampOverwriteMs,
+      customPayloadTransformer = (payload: EventEvent) => payload,
+    } = {}
   ) => {
     try {
       const attrs = stringifyObjectValues(attributes);
@@ -65,7 +72,8 @@ export function initializeEventsAPI({
       }
 
       const previousPayload = lastPayload;
-      const meta = captureMetas(metas);
+      const currentMeta = captureMetas(metas);
+      const meta = capturedMeta ? markMetaCaptured({ ...capturedMeta }) : currentMeta;
       // Capture can emit a nested event. Preserve dedupe without committing a failed capture.
       if (lastPayload !== previousPayload && !skipDedupe && config.dedupe && deepEqual(testingPayload, lastPayload)) {
         return;

--- a/packages/core/src/api/events/types.ts
+++ b/packages/core/src/api/events/types.ts
@@ -1,5 +1,6 @@
 import type { SpanContext } from '@opentelemetry/api';
 
+import type { Meta } from '../../metas';
 import type { TraceContext } from '../traces';
 import type { UserAction } from '../types';
 
@@ -17,6 +18,8 @@ export interface EventEvent {
 }
 
 export interface PushEventOptions {
+  /** Metadata captured by an instrumentation before deferred event publication. */
+  meta?: Meta;
   skipDedupe?: boolean;
   spanContext?: Pick<SpanContext, 'traceId' | 'spanId'>;
   timestampOverwriteMs?: number;

--- a/packages/core/src/api/traces/initialize.ts
+++ b/packages/core/src/api/traces/initialize.ts
@@ -1,6 +1,7 @@
 import type { Config } from '../../config';
 import type { InternalLogger } from '../../internalLogger';
 import { captureMetas, type Metas } from '../../metas';
+import { markMetaCaptured } from '../../metas/capture';
 import { TransportItemType } from '../../transports';
 import type { TransportItem, Transports } from '../../transports/types';
 import type { UnpatchedConsole } from '../../unpatchedConsole';
@@ -38,12 +39,13 @@ export function initializeTracesAPI(
         };
   };
 
-  const pushTraces: TracesAPI['pushTraces'] = (payload) => {
+  const pushTraces: TracesAPI['pushTraces'] = (payload, options) => {
     try {
+      const currentMeta = captureMetas(metas);
       const item: TransportItem<TraceEvent> = {
         type: TransportItemType.TRACE,
         payload,
-        meta: captureMetas(metas),
+        meta: options?.meta ? markMetaCaptured({ ...options.meta }) : currentMeta,
       };
 
       internalLogger.debug('Pushing trace\n', item);

--- a/packages/core/src/api/traces/types.ts
+++ b/packages/core/src/api/traces/types.ts
@@ -1,10 +1,8 @@
 import type { ContextAPI as OTELContextAPI, TraceAPI as OTELTraceAPI } from '@opentelemetry/api';
 import type { IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
-// TODO: Revert temporary patching
-// in latest OpenTelemetry packages protobuf type "instrumentationLibrary" has been renamed to "scope"
-// however on the Grafana Agent we use older OTel collector that doesn't have this change
-// temporarily patching types to the old shape until Grafana Agent catches up to otel-collector >= 0.52
+import type { Meta } from '../../metas';
+
 export interface TraceEvent {
   resourceSpans?: IResourceSpans[];
 }
@@ -19,7 +17,8 @@ export interface TracesAPI {
   getTraceContext: () => TraceContext | undefined;
   initOTEL: (trace: OTELTraceAPI, context: OTELContextAPI) => void;
   isOTELInitialized: () => boolean;
-  pushTraces: (traces: TraceEvent) => void;
+  /** Pass captured metadata when spans already have ownership established at span start. */
+  pushTraces: (traces: TraceEvent, options?: { meta?: Meta }) => void;
 }
 
 // trace context for logs, exceptions, measurements

--- a/packages/web-tracing/README.md
+++ b/packages/web-tracing/README.md
@@ -5,6 +5,23 @@ This package provides tools for integrating [OpenTelemetry][opentelemetry-js] ba
 
 See [quick start document][quick-start] for instructions how to set up and use.
 
+## Session ownership
+
+The default span processor retains the metadata attached at span start. The Faro exporter groups
+spans by that metadata, so a batch can contain spans from multiple sessions without assigning
+them to the current session. Client-span Faro events retain the same ownership. A sampled span
+is still delivered if a later session is unsampled.
+Spans started by a session generator or sampler during session preparation are discarded at
+span start, even if their batch would otherwise export after preparation finishes.
+
+When supplying a custom span processor with `FaroTraceExporter`, wrap it in
+`FaroMetaAttributesSpanProcessor` to retain this behavior. Spans submitted directly to the exporter
+without that processor retain the existing export-time metadata behavior.
+
+For other delayed signals, `api.pushTraces(payload, { meta })` and
+`api.pushEvent(name, attributes, domain, { meta })` accept previously captured metadata, such as
+the result of `captureMetas(faro.metas)`. Normal capture admission and filtering still apply.
+
 [faro-web-sdk-package]: https://github.com/grafana/faro-web-sdk/tree/main/packages/web-sdk
 [opentelemetry-js]: https://opentelemetry.io/docs/instrumentation/js/
 [quick-start]: https://github.com/grafana/faro-web-sdk/blob/main/docs/sources/tutorials/quick-start-browser.md

--- a/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
+++ b/packages/web-tracing/src/faroMetaAttributesSpanProcessor.ts
@@ -1,9 +1,12 @@
-import type { Context } from '@opentelemetry/api';
+import { type Context, diag } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 
-import type { Metas } from '@grafana/faro-web-sdk';
+import type { Meta, Metas } from '@grafana/faro-web-sdk';
 
 import { ATTR_SESSION_ID } from './semconv';
+
+// null records a rejected start; undefined is an unwrapped, externally supplied span.
+export const spanMetas: WeakMap<ReadableSpan, Meta | null> = new WeakMap();
 
 export class FaroMetaAttributesSpanProcessor implements SpanProcessor {
   constructor(
@@ -16,43 +19,56 @@ export class FaroMetaAttributesSpanProcessor implements SpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
-    const session = this.metas.value.session;
+    spanMetas.set(span, null);
+    try {
+      this.metas.assertCaptureAllowed?.();
+      const meta = { ...this.metas.value };
+      const session = meta.session;
 
-    if (session?.id) {
-      span.attributes[ATTR_SESSION_ID] = session.id;
-    }
+      if (session?.id) {
+        span.attributes[ATTR_SESSION_ID] = session.id;
+      }
 
-    const user = this.metas.value.user ?? {};
+      const user = meta.user ?? {};
 
-    if (user.email) {
-      span.attributes['user.email'] = user.email;
-    }
+      if (user.email) {
+        span.attributes['user.email'] = user.email;
+      }
 
-    if (user.id) {
-      span.attributes['user.id'] = user.id;
-    }
+      if (user.id) {
+        span.attributes['user.id'] = user.id;
+      }
 
-    if (user.username) {
-      span.attributes['user.name'] = user.username;
-    }
+      if (user.username) {
+        span.attributes['user.name'] = user.username;
+      }
 
-    if (user.fullName) {
-      span.attributes['user.full_name'] = user.fullName;
-    }
+      if (user.fullName) {
+        span.attributes['user.full_name'] = user.fullName;
+      }
 
-    if (user.roles) {
-      span.attributes['user.roles'] = user.roles.split(',').map((role) => role.trim());
-    }
+      if (user.roles) {
+        span.attributes['user.roles'] = user.roles.split(',').map((role) => role.trim());
+      }
 
-    if (user.hash) {
-      span.attributes['user.hash'] = user.hash;
+      if (user.hash) {
+        span.attributes['user.hash'] = user.hash;
+      }
+
+      this.metas.assertCaptureAllowed?.();
+      spanMetas.set(span, meta);
+    } catch (error) {
+      diag.warn('Discarding span because Faro metadata capture failed', error);
+      return;
     }
 
     this.processor.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    this.processor.onEnd(span);
+    if (spanMetas.get(span) !== null) {
+      this.processor.onEnd(span);
+    }
   }
 
   shutdown(): Promise<void> {

--- a/packages/web-tracing/src/faroTraceExporter.ts
+++ b/packages/web-tracing/src/faroTraceExporter.ts
@@ -4,6 +4,9 @@ import { JSON_ENCODER } from '@opentelemetry/otlp-transformer/build/src/common/u
 import { createExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/src/trace/internal';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 
+import type { Meta } from '@grafana/faro-web-sdk';
+
+import { spanMetas } from './faroMetaAttributesSpanProcessor';
 import { sendFaroEvents } from './faroTraceExporter.utils';
 import type { FaroTraceExporterConfig } from './types';
 
@@ -11,10 +14,25 @@ export class FaroTraceExporter implements SpanExporter {
   constructor(private config: FaroTraceExporterConfig) {}
 
   export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
-    const traceEvent = createExportTraceServiceRequest(spans, JSON_ENCODER);
-
-    this.config.api.pushTraces(traceEvent);
-    sendFaroEvents(traceEvent.resourceSpans, this.config.api);
+    const groups = new Map<string | undefined, { meta: Meta | undefined; spans: ReadableSpan[] }>();
+    for (const span of spans) {
+      const meta = spanMetas.get(span);
+      if (meta === null) {
+        continue;
+      }
+      const key = JSON.stringify(meta);
+      let group = groups.get(key);
+      if (!group) {
+        group = { meta, spans: [] };
+        groups.set(key, group);
+      }
+      group.spans.push(span);
+    }
+    for (const { meta, spans } of groups.values()) {
+      const traceEvent = createExportTraceServiceRequest(spans, JSON_ENCODER);
+      this.config.api.pushTraces(traceEvent, { meta });
+      sendFaroEvents(traceEvent.resourceSpans, this.config.api, meta);
+    }
 
     resultCallback({ code: ExportResultCode.SUCCESS });
   }

--- a/packages/web-tracing/src/faroTraceExporter.utils.ts
+++ b/packages/web-tracing/src/faroTraceExporter.utils.ts
@@ -2,11 +2,11 @@ import type { SpanContext } from '@opentelemetry/api';
 import { ESpanKind, type IResourceSpans } from '@opentelemetry/otlp-transformer/build/src/trace/internal-types';
 
 import { unknownString } from '@grafana/faro-web-sdk';
-import type { API, EventAttributes as FaroEventAttributes } from '@grafana/faro-web-sdk';
+import type { API, EventAttributes as FaroEventAttributes, Meta } from '@grafana/faro-web-sdk';
 
 const DURATION_NS_KEY = 'duration_ns';
 
-export function sendFaroEvents(resourceSpans: IResourceSpans[] = [], api: API): void {
+export function sendFaroEvents(resourceSpans: IResourceSpans[] = [], api: API, meta?: Meta): void {
   for (const resourceSpan of resourceSpans) {
     const { scopeSpans } = resourceSpan;
 
@@ -47,6 +47,7 @@ export function sendFaroEvents(resourceSpans: IResourceSpans[] = [], api: API): 
         }
 
         api.pushEvent(`faro.tracing.${eventName}`, faroEventAttributes, undefined, {
+          meta,
           spanContext,
           // Convert nanoseconds to milliseconds
           timestampOverwriteMs: Number(span.endTimeUnixNano) / 1_000_000,

--- a/packages/web-tracing/src/instrumentation.ts
+++ b/packages/web-tracing/src/instrumentation.ts
@@ -33,10 +33,6 @@ import {
 } from './semconv';
 import type { TracingInstrumentationOptions } from './types';
 
-// the providing of app name here is not great
-// should delay initialization and provide the full Faro config,
-// taking app name from it
-
 export class TracingInstrumentation extends BaseInstrumentation {
   name = '@grafana/faro-web-tracing';
   version: string = VERSION;
@@ -109,9 +105,15 @@ export class TracingInstrumentation extends BaseInstrumentation {
       resource,
       sampler: {
         shouldSample: () => {
-          return {
-            decision: getSamplingDecision(this.api.getSession()),
-          };
+          try {
+            this.metas.assertCaptureAllowed?.();
+            const session = this.api.getSession();
+            this.metas.assertCaptureAllowed?.();
+            return { decision: getSamplingDecision(session) };
+          } catch (error) {
+            this.logWarn('Discarding span because Faro metadata capture failed', error);
+            return { decision: getSamplingDecision() };
+          }
         },
       },
       spanProcessors: [

--- a/packages/web-tracing/src/session.integration.test.ts
+++ b/packages/web-tracing/src/session.integration.test.ts
@@ -1,0 +1,147 @@
+import { SpanKind } from '@opentelemetry/api';
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+
+import { initializeFaro, type TraceEvent, TransportItemType } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+
+import { SessionInstrumentation } from '../../web-sdk/src/instrumentations/session/instrumentation';
+import { SESSION_INACTIVITY_TIME } from '../../web-sdk/src/instrumentations/session/sessionManager';
+
+import { FaroMetaAttributesSpanProcessor } from './faroMetaAttributesSpanProcessor';
+import { FaroTraceExporter } from './faroTraceExporter';
+import { getSamplingDecision } from './sampler';
+
+it('exports a sampled span and its Faro event under its starting session after expiry into an unsampled session', async () => {
+  jest.useFakeTimers();
+  window.sessionStorage.clear();
+  const transport = new MockTransport();
+  const session = new SessionInstrumentation();
+  const sdk = initializeFaro(
+    mockConfig({
+      transports: [transport],
+      instrumentations: [session],
+      sessionTracking: { enabled: true, persistent: false, samplingRate: 1, session: { id: 'A' } },
+    })
+  );
+  const provider = new WebTracerProvider({
+    sampler: { shouldSample: () => ({ decision: getSamplingDecision(sdk.api.getSession()) }) },
+    spanProcessors: [
+      new FaroMetaAttributesSpanProcessor(new BatchSpanProcessor(new FaroTraceExporter({ api: sdk.api })), sdk.metas),
+    ],
+  });
+  try {
+    const span = provider.getTracer('test-request').startSpan('request-in-A', { kind: SpanKind.CLIENT });
+    transport.items.length = 0;
+    jest.setSystemTime(Date.now() + SESSION_INACTIVITY_TIME + 1);
+    sdk.config.sessionTracking!.samplingRate = 0;
+    sdk.api.pushEvent('rotate');
+    expect(sdk.api.getSession()!.id).not.toBe('A');
+    expect(sdk.api.getSession()!.attributes?.['isSampled']).toBe('false');
+
+    span.end();
+    await provider.forceFlush();
+
+    const traces = transport.items.filter((item) => item.type === TransportItemType.TRACE);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]!.meta.session?.id).toBe('A');
+    const exported = (traces[0]!.payload as TraceEvent).resourceSpans![0]!.scopeSpans[0]!.spans![0]!;
+    expect(exported.attributes).toContainEqual({ key: 'session.id', value: { stringValue: 'A' } });
+    const event = transport.items.find((item) => item.type === TransportItemType.EVENT);
+    expect(event?.meta.session?.id).toBe('A');
+  } finally {
+    await provider.shutdown();
+    session.destroy();
+    jest.useRealTimers();
+  }
+});
+
+it('partitions a mixed batch by the metadata captured for each span', async () => {
+  const transport = new MockTransport();
+  const sdk = initializeFaro(mockConfig({ transports: [transport] }));
+  sdk.api.setSession({ id: 'A', attributes: { isSampled: 'true' } });
+  const provider = new WebTracerProvider({
+    spanProcessors: [
+      new FaroMetaAttributesSpanProcessor(new BatchSpanProcessor(new FaroTraceExporter({ api: sdk.api })), sdk.metas),
+    ],
+  });
+  try {
+    const tracer = provider.getTracer('test');
+    const a1 = tracer.startSpan('A-1');
+    const a2 = tracer.startSpan('A-2');
+    sdk.api.setSession({ id: 'B', attributes: { isSampled: 'true' } });
+    const b = tracer.startSpan('B');
+    a1.end();
+    b.end();
+    a2.end();
+    sdk.api.setSession({ id: 'after-export-ownership' });
+
+    await provider.forceFlush();
+
+    const traces = transport.items.filter((item) => item.type === TransportItemType.TRACE);
+    expect(
+      traces.map((item) => ({
+        session: item.meta.session?.id,
+        spans: (item.payload as TraceEvent).resourceSpans!.flatMap((resource) =>
+          resource.scopeSpans.flatMap((scope) => scope.spans!.map((span) => span.name))
+        ),
+      }))
+    ).toEqual([
+      { session: 'A', spans: ['A-1', 'A-2'] },
+      { session: 'B', spans: ['B'] },
+    ]);
+  } finally {
+    await provider.shutdown();
+  }
+});
+
+it.each(['generator', 'sampler'])('discards a span submitted by a precommit session %s', async (source) => {
+  jest.useFakeTimers();
+  window.sessionStorage.clear();
+  const transport = new MockTransport();
+  const session = new SessionInstrumentation();
+  const sdk = initializeFaro(
+    mockConfig({
+      transports: [transport],
+      instrumentations: [session],
+      sessionTracking: { enabled: true, persistent: false, samplingRate: 1, session: { id: 'A' } },
+    })
+  );
+  const provider = new WebTracerProvider({
+    spanProcessors: [
+      new FaroMetaAttributesSpanProcessor(new BatchSpanProcessor(new FaroTraceExporter({ api: sdk.api })), sdk.metas),
+    ],
+  });
+  const warn = jest.spyOn(sdk.internalLogger, 'warn');
+  try {
+    const tracer = provider.getTracer('test');
+    const submit = () => tracer.startSpan('precommit-span').end();
+    if (source === 'generator') {
+      sdk.config.sessionTracking!.generateSessionId = () => {
+        submit();
+        return 'B';
+      };
+    } else {
+      sdk.config.sessionTracking!.sampler = () => {
+        submit();
+        return 1;
+      };
+    }
+    jest.setSystemTime(Date.now() + SESSION_INACTIVITY_TIME + 1);
+    sdk.api.pushEvent('rotate');
+    await provider.forceFlush();
+
+    expect(transport.items.filter((item) => item.type === TransportItemType.TRACE)).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('session preparation'));
+
+    tracer.startSpan('postcommit-span').end();
+    await provider.forceFlush();
+    const traces = transport.items.filter((item) => item.type === TransportItemType.TRACE);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]!.meta.session?.id).toBe(sdk.api.getSession()!.id);
+  } finally {
+    await provider.shutdown();
+    session.destroy();
+    warn.mockRestore();
+    jest.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Why

A span that starts in session A can finish after session B replaces it. Export currently risks attaching B's envelope to A's trace. Preserve the span-start metadata through batching and derived Faro events.

## What

- Capture metadata with each span, group exports by that captured owner, and pass the same metadata to traces and derived events.
- Reject spans started during session preparation, including the default sampler path.
- Preserve the documented export-time fallback for externally created spans and explain how custom processors can capture span-start ownership. Remove the obsolete collector compatibility note.

Validation: real OpenTelemetry/session integration covers sampled A finishing after unsampled B, mixed-owner batches, and generator/sampler reentrancy. The complete stack passes 970 unit tests (one existing skip), all 30 smoke tests, builds/typechecks, lint, and circular-dependency checks. Standards and specification review findings are addressed.

## Links

Fixes #2269. Builds on the session capture contract from #2261.

Draft stack: #2272 (session capture) → #2273 (span ownership) → #2274 (recording leases) → #2275 (send deadline). Review and merge from the bottom.

## Checklist

- [x] Tests added
- [x] Conventional commit included for the release-please changelog
- [x] Documentation updated
