### PR TITLE
refactor(replay): own recording lifecycle with Web Locks leases

### DIFF
--- a/docs/sources/developer/replay-lifecycle-validation.md
+++ b/docs/sources/developer/replay-lifecycle-validation.md
@@ -1,0 +1,143 @@
+# Replay lifecycle validation
+
+These implementation checks use the full Faro Web SDK, session instrumentation, Fetch transport,
+and `@grafana/rrweb` 2.0.0-grafana.2. They extend the design experiments, which used a smaller lease
+prototype. The comparison baseline is the completed PR chain at
+`002103dfc64c736a588126cd6580825e22aa2e26`.
+
+## Retained browser tests
+
+Build the packages, start the smoke harness, and run the native tests:
+
+```sh
+yarn build
+cd e2e/smoke
+yarn playwright test replay-lifecycle.spec.ts --workers=1
+```
+
+The `/replay-lifecycle` fixture explicitly initializes Replay alongside the default web
+instrumentations. It serves the published bundles without a development HMR client. Observations
+stay in document memory; they are not checkpoint or trace writes to storage.
+
+The tests use full Chromium with Playwright's BFCache-disabling flag removed. They assert original
+document and instrumentation identity and native `pageshow.persisted` in both directions. The
+freeze test uses a fresh raw Chromium process and `connectOverCDP({ noDefaults: true })` because
+Playwright's focus emulation suppresses native freeze. Its temporary profile and process are
+removed after the test.
+
+| Boundary                               | Verified behavior                                                                                                         |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Navigation, repeated Back/Forward      | Both original documents restore from BFCache; one recording and increasing counters survive.                              |
+| Reload and instrumentation replacement | New recorder snapshots continue the completed recording.                                                                  |
+| Inactivity                             | rrweb stops while the native recording lock remains held; one interaction resumes once.                                   |
+| Native freeze/resume                   | A trusted freeze event saves a clean checkpoint; trusted resume preserves document, initializer, and recording.           |
+| Abandoned view-transition navigation   | Native `pageswap` followed by `window.stop()` retains the document; trusted pointer or keyboard input restarts it.        |
+| Synthetic input after `pageswap`       | It does not restart recording or act as evidence of cancellation.                                                         |
+| Successful skipped transitions         | Ordinary and hash-changing skipped transitions navigate with a clean handoff.                                             |
+| Queued copied state                    | No rrweb starts while waiting; removal cancels the waiter; a later grant of copied active state starts a fresh recording. |
+| Session change while queued            | The obsolete request is cancelled and the new session acquires its own recording.                                         |
+| Storage read/write failures            | Native locks still own local counters; same-document replacement continues, and a later document splits.                  |
+| Failed final checkpoint write          | The active checkpoint remains unchanged; local replacement continues, and the next document starts a new ID.              |
+| Explicit stale clean copy              | Exclusive leases still permit the accepted duplicate sequence/generation tuples from independently copied counters.       |
+
+Unit tests additionally cover metadata admission, retained capture failures, partial initialization,
+stale returned stop handles, startup/checkout/deferred rrweb reentrancy, serialization gaps,
+ownership supersession, cancelled grants, invalid checkpoints, and counter bounds.
+
+## Additional native browser experiments
+
+The implementation experiments used Chromium **151.0.7922.34** and Firefox **153**. Firefox
+continued a recording through replacement, ordinary navigation, and Back reload with clean
+checkpoints and unique tuples. Native Firefox BFCache restoration was not established by the
+available driver; those results do not claim both-direction BFCache support in Firefox.
+
+WebKit **26.5** also preserved recording identity and unique tuples through replacement,
+navigation, Back, and Forward reloads. It ran with verified Ubuntu runtime libraries extracted
+into a temporary directory, without an OS installation. Its inspector connection
+[disables BFCache](https://github.com/microsoft/playwright/blob/dc0f852272a489af824b355c1db6628f366c59f0/browser_patches/webkit/patches/bootstrap.diff#L11593),
+so this run does not establish WebKit or Safari BFCache restoration. Trusted `pagehide` and
+`pageshow` were observed. WebKit's outgoing `pageswap` reported `isTrusted: false`; its
+[event factory defaults to untrusted](https://github.com/WebKit/WebKit/blob/5e03b0c541d3895e5a12a6b032185901e5e4d738/Source/WebCore/dom/PageSwapEvent.h#L43)
+and the [navigation caller omits that argument](https://github.com/WebKit/WebKit/blob/5e03b0c541d3895e5a12a6b032185901e5e4d738/Source/WebCore/dom/Document.cpp#L9094).
+The fixture did not dispatch those lifecycle events. Clean handoff was verified, with this
+qualification on the event's trust flag.
+
+Chromium's actual browser tab menu was also exercised on an isolated Ozone display with a fresh
+profile. The native UI command created the duplicate; neither `window.open()` nor a harness
+storage write created its inherited state:
+
+1. An active duplicate inherited the source's serialized checkpoint, waited without emitting
+   Replay events, and started a new recording after the source stopped. An independently opened
+   tab had a different recording.
+2. A clean duplicate remained stopped while the source resumed and advanced its own counters.
+   Starting the copy after source release reproduced the accepted collisions at generation 1,
+   sequences 2 and 3. There were no simultaneous holders of that recording lock.
+3. `Page.crash` crashed the renderer. Chromium's native Reload button reloaded the same tab with
+   the old active checkpoint, a new document, and a fresh recording ID. It did not reuse lost
+   counters. The native button was needed because Playwright's direct `page.reload()` rejected
+   the crashed page.
+
+The UI input was delivered through Chromium's native Views/menu testing interface, with real
+menu execution and browser storage copying. It was not a physical mouse test or a Safari test.
+The retained smoke tests explicitly copy active/clean serialized checkpoints for deterministic
+coverage; their titles distinguish those tests from native UI duplication.
+
+The measured SDK bundle SHA256 was
+`7875a7fdca668f8fc887f7d2d6d8249fbac8a6f96fab3d5445266ee8ea0353e2`, and Replay was
+`82533b4e318c81a5d3cd732dbfc77607d9ea315a28649cae182d72b6f60c56a7`.
+These hashes identify the native UI and cost experiment builds, before the final post-grant
+metadata-guard corrections covered by the retained tests.
+
+## Event cost and ownership structure
+
+The cost check dispatched 2,000 real rrweb click events per run through the full SDK with a
+counting transport. It used matching ES2015/minified builds, two warmups, and seven alternating
+runs of the implementation and baseline in Chromium. During measurement the observer used only
+integer counters: event/write observation arrays did not grow, and there were no trace writes.
+Network delivery was excluded.
+
+| Measurement                     | Completed PR chain | Recording leases  |
+| ------------------------------- | ------------------ | ----------------- |
+| Median per 2,000 events         | 69.7 ms            | 73.6 ms           |
+| Median per event                | 34.85 microseconds | 36.8 microseconds |
+| Run range                       | 59.5–75.5 ms       | 63.5–82.6 ms      |
+| Replay storage writes per event | 0                  | 0                 |
+
+Raw baseline times in milliseconds: `59.7, 59.5, 74.0, 60.5, 75.5, 73.9, 69.7`.
+Implementation times: `66.7, 66.6, 73.6, 63.5, 81.0, 78.6, 82.6`.
+The approximately 5.6% median difference has overlapping ranges and is a controlled measurement,
+not a production performance estimate. The baseline already reserved counters in memory; this
+refactor does not claim a reduction from per-event writes. An ordinary lease writes one active
+checkpoint and one final clean checkpoint, independently of event count.
+
+The structural review counted declared fields and call sites, rather than every guard or runtime
+instance:
+
+| Ownership area       | Structure                                                                                  |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| Initialization       | One current owner; 12 fields, including optional acquisition/lease and queued-start token. |
+| Acquisition          | Five fields, including cancellation and completion.                                        |
+| Lease                | Six checkpoint fields; four closure controls: owner, released, local, anchor.              |
+| Recorder             | One union with four phases; five fields on an active attempt.                              |
+| Candidate            | Four fields; one discriminator for fresh, memory, or storage provenance.                   |
+| Document             | Activation token and three-phase state; two fields per owner.                              |
+| Shared rrweb runtime | Producer slot, execution depth, and pending cleanup.                                       |
+
+Five cleanup-queue calls, one cleanup-await gate, and five rrweb execution wrappers coordinate
+physical stop/start. One checkpoint finalizer seals counters. Five native lifecycle registrations
+feed three document transition methods. The previous shared checkpoint pool, separate pointers,
+pruning, TTL, storage-event claims, and recorder-status booleans were removed.
+
+## Remaining limits
+
+The dependency's partial-startup cleanup fix remains tracked in
+[grafana/rrweb#59](https://github.com/grafana/rrweb/issues/59); the dependency was not upgraded here.
+Faro's real rrweb tests cover guarded returned handles and deferred callbacks, not the unresolved
+upstream rollback contract when rrweb fails without returning a usable cleanup handle.
+
+Clean browser copies can still collide. No receiver conflict detection, original-tab election,
+or targeted restart protocol is implied by Web Locks. Applications can still drop snapshot
+events through Replay filtering and are responsible for the resulting unplayable history.
+
+Persistent-session creation remains synchronously coordinated on a best-effort basis, separately
+from recording ownership. See [the concurrency investigation](persistent-session-concurrency.md).

--- a/e2e/smoke/replay-lifecycle.html
+++ b/e2e/smoke/replay-lifecycle.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Replay lifecycle fixture</title>
+    <style>
+      @view-transition { navigation: auto; }
+      #heading { view-transition-name: heading; }
+      body { min-height: 200px; }
+    </style>
+  </head>
+  <body>
+    <h1 id="heading">Replay lifecycle fixture</h1>
+    <input value="masked input" aria-label="Input" />
+    <button id="interact">Interact</button>
+    <a id="next" href="/replay-lifecycle?name=b">Next document</a>
+    <script src="/bundles/faro-web-sdk.iife.js"></script>
+    <script src="/bundles/faro-instrumentation-replay.iife.js"></script>
+    <script>
+      (() => {
+        const params = new URL(location.href).searchParams;
+        const documentId = crypto.randomUUID();
+        const key = 'com.grafana.faro.replay.current:["faro","replay-lifecycle","","test"]';
+        const initialCheckpoint = sessionStorage.getItem(key);
+        const events = [];
+        const lifecycle = [];
+        const writes = [];
+        let mode = params.get('mode');
+        let failReads = params.get('storage') === 'read';
+        let failWrites = params.get('storage') === 'write';
+        let countOnly = false;
+        let eventCount = 0;
+        let replay;
+        let initializationId;
+        const originalGet = Storage.prototype.getItem;
+        const originalSet = Storage.prototype.setItem;
+        Storage.prototype.getItem = function (name) {
+          if (name.startsWith('com.grafana.faro.replay.') && failReads) {
+            throw new Error('Fixture storage read failure');
+          }
+          return originalGet.call(this, name);
+        };
+        Storage.prototype.setItem = function (name, value) {
+          if (name.startsWith('com.grafana.faro.replay.')) {
+            writes.push({ name, handoff: JSON.parse(value).handoff, at: performance.now() });
+            if (failWrites) {
+              throw new Error('Fixture storage write failure');
+            }
+          }
+          return originalSet.call(this, name, value);
+        };
+        const { initializeFaro, getWebInstrumentations, BaseTransport } = window.GrafanaFaroWebSdk;
+        const { ReplayInstrumentation } = window.GrafanaFaroInstrumentationReplay;
+        class CountingTransport extends BaseTransport {
+          name = 'fixture-counting';
+          version = '1';
+          send() { return Promise.resolve(); }
+          isBatched() { return false; }
+        }
+        const sdk = initializeFaro({
+          url: '/collect',
+          app: { name: 'replay-lifecycle', environment: 'test' },
+          batching: { enabled: true, sendTimeout: 100 },
+          instrumentations: getWebInstrumentations(),
+          ...(params.has('cost') ? { transports: [new CountingTransport()], batching: { enabled: false } } : {}),
+          sessionTracking: {
+            enabled: true, persistent: false, samplingRate: 1,
+            session: { id: 'lifecycle-session' },
+          },
+          beforeSend: (item) => {
+            if (item.type === 'event' && item.payload.name.startsWith('faro.session_recording.')) {
+              eventCount++;
+              if (!countOnly) {
+                const attributes = item.payload.attributes ?? {};
+                events.push({
+                  name: item.payload.name, session: item.meta.session?.id,
+                  recording: attributes.recording_id,
+                  seq: attributes.seq == null ? undefined : Number(attributes.seq),
+                  gen: attributes.gen == null ? undefined : Number(attributes.gen),
+                  type: attributes.event == null ? undefined : JSON.parse(attributes.event).type,
+                });
+              }
+            }
+            return item;
+          },
+        });
+        function start() {
+          if (replay) { return; }
+          initializationId = crypto.randomUUID();
+          replay = new ReplayInstrumentation({
+            samplingRate: 1, recordAfter: 'DOMContentLoaded',
+            inactivityThresholdMs: Number(params.get('inactivity') ?? 0),
+          });
+          sdk.instrumentations.add(replay);
+        }
+        function stop() {
+          const previous = replay;
+          replay = undefined;
+          if (previous) { sdk.instrumentations.remove(previous); }
+        }
+        function checkpoint() {
+          return JSON.parse(originalGet.call(sessionStorage, key) ?? 'null');
+        }
+        if (params.get('autostart') !== '0') { start(); }
+        for (const name of ['pageswap', 'pagehide', 'pageshow']) {
+          addEventListener(name, (event) => {
+            lifecycle.push({ name, persisted: event.persisted, trusted: event.isTrusted, checkpoint: checkpoint() });
+            if (name === 'pageswap') {
+              if (mode === 'stop') { window.stop(); }
+              if (mode === 'hash-skip') { location.hash = 'outgoing'; }
+              if (mode === 'skip' || mode === 'hash-skip') { event.viewTransition?.skipTransition(); }
+              mode = undefined;
+            }
+          });
+        }
+        for (const name of ['freeze', 'resume']) {
+          document.addEventListener(name, (event) => {
+            lifecycle.push({ name, trusted: event.isTrusted, checkpoint: checkpoint() });
+          });
+        }
+        window.replayFixture = {
+          key, documentId, initialCheckpoint, events, lifecycle, writes,
+          get initializationId() { return initializationId; },
+          start, stop, replace: () => { stop(); start(); }, checkpoint,
+          storageFailure: (reads, writes) => { failReads = reads; failWrites = writes; },
+          measure: (count) => {
+            countOnly = true;
+            const before = eventCount;
+            const beforeWrites = writes.length;
+            const began = performance.now();
+            for (let index = 0; index < count; index++) {
+              document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: index }));
+            }
+            const elapsedMs = performance.now() - began;
+            countOnly = false;
+            return { elapsedMs, events: eventCount - before, writes: writes.length - beforeWrites };
+          },
+        };
+      })();
+    </script>
+  </body>
+</html>

--- a/e2e/smoke/tests/replay-lifecycle.spec.ts
+++ b/e2e/smoke/tests/replay-lifecycle.spec.ts
@@ -1,0 +1,384 @@
+import { type Browser, chromium, expect, type Page, test } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface ReplayEvent {
+  name: string;
+  session: string;
+  recording: string;
+  seq?: number;
+  gen?: number;
+  type?: number;
+}
+
+interface Checkpoint {
+  sessionId: string;
+  recordingId: string;
+  nextSeq: number;
+  gen: number;
+  documentId: string;
+  handoff: 'active' | 'clean';
+}
+
+declare global {
+  interface Window {
+    replayFixture: {
+      key: string;
+      documentId: string;
+      initializationId: string;
+      initialCheckpoint: string | null;
+      events: ReplayEvent[];
+      lifecycle: Array<{ name: string; trusted: boolean; persisted?: boolean; checkpoint: Checkpoint | null }>;
+      writes: Array<{ name: string; handoff: string; at: number }>;
+      checkpoint: () => Checkpoint | null;
+      start: () => void;
+      stop: () => void;
+      replace: () => void;
+      storageFailure: (reads: boolean, writes: boolean) => void;
+      measure: (count: number) => { elapsedMs: number; events: number; writes: number };
+    };
+  }
+}
+
+// Playwright disables BFCache by default; use the full Chromium build and allow
+// the browser to cache the actual SDK/rrweb documents in both directions.
+test.use({ launchOptions: { channel: 'chromium', ignoreDefaultArgs: ['--disable-back-forward-cache'] } });
+
+async function state(page: Page) {
+  return page.evaluate(() => {
+    const fixture = window.replayFixture;
+    return {
+      documentId: fixture.documentId,
+      initializationId: fixture.initializationId,
+      events: fixture.events,
+      lifecycle: fixture.lifecycle,
+      checkpoint: fixture.checkpoint(),
+      initialCheckpoint: fixture.initialCheckpoint,
+    };
+  });
+}
+
+async function snapshots(page: Page, count = 1) {
+  await expect
+    .poll(() => page.evaluate(() => window.replayFixture?.events.filter((event) => event.type === 2).length ?? 0))
+    .toBe(count);
+  return state(page);
+}
+
+function recordingEvents(observation: Awaited<ReturnType<typeof state>>) {
+  return observation.events.filter((event) => event.seq != null);
+}
+
+function expectContinuous(events: ReplayEvent[]) {
+  const sorted = [...events].sort((left, right) => left.seq! - right.seq!);
+  expect(new Set(sorted.map((event) => event.recording)).size).toBe(1);
+  expect(new Set(sorted.map((event) => event.session))).toEqual(new Set(['lifecycle-session']));
+  expect(sorted.map((event) => event.seq)).toEqual(sorted.map((_, index) => index));
+  const generations = sorted.filter((event) => event.type === 4).map((event) => event.gen);
+  expect(generations).toEqual(generations.map((_, index) => index));
+}
+
+test('continues real recordings through both BFCache directions, rapid traversal, replacement, and reload', async ({
+  page,
+}) => {
+  await page.goto('/replay-lifecycle?name=a');
+  const firstA = await snapshots(page);
+  await page.locator('#next').click();
+  const firstB = await snapshots(page);
+  expect(firstB.documentId).not.toBe(firstA.documentId);
+  expect(firstB.checkpoint?.recordingId).toBe(firstA.checkpoint?.recordingId);
+  let latestA = firstA;
+  for (let traversal = 0; traversal < 2; traversal++) {
+    await page.goBack({ waitUntil: 'commit' });
+    latestA = await snapshots(page, traversal + 2);
+    expect(latestA.documentId).toBe(firstA.documentId);
+    expect(latestA.initializationId).toBe(firstA.initializationId);
+    expect(latestA.lifecycle.filter((event) => event.name === 'pageshow').at(-1)).toMatchObject({
+      persisted: true,
+      trusted: true,
+    });
+    await page.goForward({ waitUntil: 'commit' });
+    const latestB = await snapshots(page, traversal + 2);
+    expect(latestB.documentId).toBe(firstB.documentId);
+    expect(latestB.initializationId).toBe(firstB.initializationId);
+    expect(latestB.lifecycle.filter((event) => event.name === 'pageshow').at(-1)).toMatchObject({
+      persisted: true,
+      trusted: true,
+    });
+  }
+  await page.evaluate(() => window.replayFixture.replace());
+  const latestB = await snapshots(page, 4);
+  expect(latestB.initializationId).not.toBe(firstB.initializationId);
+  expect(latestB.checkpoint?.recordingId).toBe(firstA.checkpoint?.recordingId);
+  for (const observation of [latestA, latestB]) {
+    expect(
+      observation.lifecycle
+        .filter((event) => event.name === 'pageswap')
+        .every((event) => event.trusted && event.checkpoint?.handoff === 'clean')
+    ).toBe(true);
+  }
+  await page.reload();
+  const reloaded = await snapshots(page);
+  expect(reloaded.documentId).not.toBe(firstB.documentId);
+  expect(reloaded.checkpoint?.recordingId).toBe(firstA.checkpoint?.recordingId);
+  expectContinuous([...recordingEvents(latestA), ...recordingEvents(latestB), ...recordingEvents(reloaded)]);
+  await test.info().attach('native-recording-handoff', {
+    contentType: 'application/json',
+    body: JSON.stringify({ latestA, latestB, reloaded }),
+  });
+});
+
+test('retains native ownership across inactivity and resumes with one new snapshot', async ({ page }) => {
+  await page.goto('/replay-lifecycle?inactivity=1000');
+  const initial = await snapshots(page);
+  await expect
+    .poll(async () => (await state(page)).events.filter((event) => event.name.endsWith('.paused')).length)
+    .toBe(1);
+  expect((await page.evaluate(() => navigator.locks.query())).held).toHaveLength(1);
+  expect((await state(page)).checkpoint?.handoff).toBe('active');
+  await page.locator('#interact').click();
+  const resumed = await snapshots(page, 2);
+  expect(resumed.checkpoint?.recordingId).toBe(initial.checkpoint?.recordingId);
+  expect(resumed.events.filter((event) => event.name.endsWith('.resumed'))).toHaveLength(1);
+  expectContinuous(recordingEvents(resumed));
+});
+
+test('finalizes on native freeze and reacquires on native resume', async ({ baseURL }) => {
+  // Playwright's focus emulation prevents native freeze. Connect without those
+  // overrides to the default context of a fresh, isolated browser process.
+  const profile = await mkdtemp(join(tmpdir(), 'faro-native-freeze-'));
+  const chromiumProcess = spawn(
+    chromium.executablePath(),
+    [
+      '--headless=new',
+      '--no-sandbox',
+      '--remote-debugging-port=0',
+      '--remote-debugging-address=127.0.0.1',
+      `--user-data-dir=${profile}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+      'about:blank',
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  );
+  const exited = new Promise<void>((resolve) => {
+    chromiumProcess.once('exit', () => resolve());
+    chromiumProcess.once('error', () => resolve());
+  });
+  let browser: Browser | undefined;
+  try {
+    const endpoint = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Chromium startup timed out')), 10_000);
+      const fail = (error: Error) => {
+        clearTimeout(timeout);
+        reject(error);
+      };
+      chromiumProcess.once('error', fail);
+      chromiumProcess.once('exit', () => fail(new Error('Chromium exited during startup')));
+      let stderr = '';
+      chromiumProcess.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+        const match = /DevTools listening on (ws:\/\/\S+)/.exec(stderr);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(match[1]!);
+        }
+      });
+    });
+    browser = await chromium.connectOverCDP(endpoint, { noDefaults: true });
+    const context = browser.contexts()[0]!;
+    const page = context.pages()[0] ?? (await context.newPage());
+    await page.goto(`${baseURL}/replay-lifecycle`);
+    const initial = await snapshots(page);
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Page.setWebLifecycleState', { state: 'frozen' });
+    await expect.poll(async () => (await state(page)).lifecycle.some((event) => event.name === 'freeze')).toBe(true);
+    await cdp.send('Page.setWebLifecycleState', { state: 'active' });
+    await page.bringToFront();
+    const resumed = await snapshots(page, 2);
+    expect(resumed.documentId).toBe(initial.documentId);
+    expect(resumed.initializationId).toBe(initial.initializationId);
+    expect(resumed.lifecycle.find((event) => event.name === 'freeze')).toMatchObject({
+      trusted: true,
+      checkpoint: { handoff: 'clean' },
+    });
+    expect(resumed.lifecycle.find((event) => event.name === 'resume')).toMatchObject({ trusted: true });
+    expectContinuous(recordingEvents(resumed));
+  } finally {
+    chromiumProcess.kill('SIGTERM');
+    const forceExit = setTimeout(() => chromiumProcess.kill('SIGKILL'), 3_000);
+    await exited;
+    clearTimeout(forceExit);
+    await browser?.close();
+    await rm(profile, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
+  }
+});
+
+for (const input of ['pointer', 'keyboard'] as const) {
+  test(`recovers a genuinely abandoned pageswap on trusted ${input} input`, async ({ page }) => {
+    await page.goto('/replay-lifecycle?mode=stop');
+    const initial = await snapshots(page);
+    await page.evaluate(() => {
+      const result = window.navigation.navigate('/replay-lifecycle?name=b');
+      void result.committed?.catch(() => {});
+      void result.finished?.catch(() => {});
+    });
+    await expect.poll(async () => (await state(page)).lifecycle.some((event) => event.name === 'pageswap')).toBe(true);
+    await expect.poll(async () => (await page.evaluate(() => navigator.locks.query())).held?.length).toBe(0);
+    const stopped = await state(page);
+    expect(stopped.documentId).toBe(initial.documentId);
+    expect(stopped.initializationId).toBe(initial.initializationId);
+    expect(stopped.checkpoint?.handoff).toBe('clean');
+    expect(stopped.lifecycle.some((event) => event.name === 'pagehide')).toBe(false);
+    await page.evaluate(async () => {
+      document.dispatchEvent(new PointerEvent('pointerdown'));
+      await new Promise(window.requestAnimationFrame);
+    });
+    expect((await state(page)).events.filter((event) => event.type === 2)).toHaveLength(1);
+    if (input === 'pointer') {
+      await page.locator('#interact').click();
+    } else {
+      await page.keyboard.press('a');
+    }
+    const resumed = await snapshots(page, 2);
+    expect(resumed.documentId).toBe(initial.documentId);
+    expect(resumed.initializationId).toBe(initial.initializationId);
+    expectContinuous(recordingEvents(resumed));
+  });
+}
+
+for (const mode of ['skip', 'hash-skip']) {
+  test(`keeps native navigation working when the outbound transition uses ${mode}`, async ({ page }) => {
+    await page.goto(`/replay-lifecycle?mode=${mode}`);
+    const source = await snapshots(page);
+    await page.locator('#next').click();
+    const target = await snapshots(page);
+    expect(target.documentId).not.toBe(source.documentId);
+    expect(target.checkpoint?.recordingId).toBe(source.checkpoint?.recordingId);
+    const clean = JSON.parse(target.initialCheckpoint!);
+    expect(clean.handoff).toBe('clean');
+    expect(clean.gen).toBe(0);
+    expect(clean.nextSeq).toBeGreaterThanOrEqual(recordingEvents(source).length);
+    expect(recordingEvents(target)[0]?.seq).toBe(clean.nextSeq);
+  });
+}
+
+test('keeps an explicit active-state copy queued, cancels obsolete waiting work, and splits after release', async ({
+  page,
+  context,
+}) => {
+  await page.goto('/replay-lifecycle');
+  const source = await snapshots(page);
+  const copied = await context.newPage();
+  await copied.goto('/replay-lifecycle?autostart=0');
+  await copied.evaluate((checkpoint) => {
+    window.sessionStorage.setItem(window.replayFixture.key, JSON.stringify(checkpoint));
+    window.replayFixture.start();
+  }, source.checkpoint);
+  await expect.poll(async () => (await copied.evaluate(() => navigator.locks.query())).pending?.length).toBe(1);
+  expect((await state(copied)).events).toEqual([]);
+  await copied.evaluate(() => window.replayFixture.stop());
+  await expect.poll(async () => (await copied.evaluate(() => navigator.locks.query())).pending?.length).toBe(0);
+  await copied.evaluate(() => window.replayFixture.start());
+  await expect.poll(async () => (await copied.evaluate(() => navigator.locks.query())).pending?.length).toBe(1);
+  expect((await state(copied)).events).toEqual([]);
+  await page.evaluate(() => window.replayFixture.stop());
+  const recovered = await snapshots(copied);
+  expect(recovered.checkpoint?.recordingId).not.toBe(source.checkpoint?.recordingId);
+  expect(recordingEvents(recovered)[0]?.seq).toBe(0);
+  const independent = await context.newPage();
+  await independent.goto('/replay-lifecycle');
+  const control = await snapshots(independent);
+  expect(control.initialCheckpoint).toBeNull();
+  expect(new Set([source, recovered, control].map((item) => item.checkpoint?.recordingId)).size).toBe(3);
+});
+
+test('documents the accepted native-lock collision from an explicit stale clean copy', async ({ page, context }) => {
+  await page.goto('/replay-lifecycle');
+  await snapshots(page);
+  await page.evaluate(() => window.replayFixture.stop());
+  await expect.poll(async () => (await page.evaluate(() => navigator.locks.query())).held?.length).toBe(0);
+  const clean = (await state(page)).checkpoint!;
+  expect(clean.handoff).toBe('clean');
+  const copy = await context.newPage();
+  await copy.goto('/replay-lifecycle?autostart=0');
+  await copy.evaluate(
+    (checkpoint) => window.sessionStorage.setItem(window.replayFixture.key, JSON.stringify(checkpoint)),
+    clean
+  );
+  await page.evaluate(() => window.replayFixture.start());
+  const advanced = await snapshots(page, 2);
+  await page.evaluate(() => window.replayFixture.stop());
+  await expect.poll(async () => (await page.evaluate(() => navigator.locks.query())).held?.length).toBe(0);
+  await copy.evaluate(() => window.replayFixture.start());
+  const stale = await snapshots(copy);
+  const repeated = recordingEvents(stale)[0]!;
+  expect(repeated).toMatchObject({ recording: clean.recordingId, seq: clean.nextSeq, gen: clean.gen + 1 });
+  expect(recordingEvents(advanced)).toContainEqual(
+    expect.objectContaining({
+      recording: repeated.recording,
+      seq: repeated.seq,
+      gen: repeated.gen,
+    })
+  );
+  expect((await copy.evaluate(() => navigator.locks.query())).held).toHaveLength(1);
+});
+
+test('reconciles a queued copied recording before acquiring for a new session', async ({ page, context }) => {
+  await page.goto('/replay-lifecycle');
+  const source = await snapshots(page);
+  const copy = await context.newPage();
+  await copy.goto('/replay-lifecycle?autostart=0');
+  await copy.evaluate((checkpoint) => {
+    window.sessionStorage.setItem(window.replayFixture.key, JSON.stringify(checkpoint));
+    window.replayFixture.start();
+  }, source.checkpoint);
+  await expect.poll(async () => (await copy.evaluate(() => navigator.locks.query())).pending?.length).toBe(1);
+  await copy.evaluate(() =>
+    window.faro.api.setSession({ id: 'replacement-session', attributes: { isSampled: 'true' } })
+  );
+  const replacement = await snapshots(copy);
+  expect(new Set(replacement.events.map((event) => event.session))).toEqual(new Set(['replacement-session']));
+  expect(replacement.checkpoint?.recordingId).not.toBe(source.checkpoint?.recordingId);
+  expect((await copy.evaluate(() => navigator.locks.query())).pending).toHaveLength(0);
+  expect((await page.evaluate(() => navigator.locks.query())).held).toHaveLength(2);
+});
+
+for (const failure of ['read', 'write']) {
+  test(`keeps document-local counters through replacement during storage ${failure} failures`, async ({ page }) => {
+    await page.goto(`/replay-lifecycle?storage=${failure}`);
+    const initial = await snapshots(page);
+    await page.evaluate(() => window.replayFixture.replace());
+    const replaced = await snapshots(page, 2);
+    expectContinuous(recordingEvents(replaced));
+    expect((await page.evaluate(() => navigator.locks.query())).held).toHaveLength(1);
+    await page.goto(`/replay-lifecycle?storage=${failure}&name=next`);
+    const next = await snapshots(page);
+    expect(next.documentId).not.toBe(initial.documentId);
+    expect(recordingEvents(next)[0]!.recording).not.toBe(recordingEvents(initial)[0]!.recording);
+    expect(recordingEvents(next)[0]?.seq).toBe(0);
+  });
+}
+
+test('keeps failed final persistence local and splits the next native document', async ({ page }) => {
+  await page.goto('/replay-lifecycle');
+  const initial = await snapshots(page);
+  await page.evaluate(() => {
+    window.replayFixture.storageFailure(false, true);
+    window.replayFixture.stop();
+  });
+  await expect.poll(async () => (await page.evaluate(() => navigator.locks.query())).held?.length).toBe(0);
+  expect((await state(page)).checkpoint?.handoff).toBe('active');
+  await page.evaluate(() => window.replayFixture.start());
+  const replaced = await snapshots(page, 2);
+  expectContinuous(recordingEvents(replaced));
+  await page.evaluate(() => window.replayFixture.stop());
+  await expect.poll(async () => (await page.evaluate(() => navigator.locks.query())).held?.length).toBe(0);
+  await page.goto('/replay-lifecycle?name=next');
+  const next = await snapshots(page);
+  expect(JSON.parse(next.initialCheckpoint!).handoff).toBe('active');
+  expect(next.checkpoint?.recordingId).not.toBe(initial.checkpoint?.recordingId);
+  expect(recordingEvents(next)[0]?.seq).toBe(0);
+});

--- a/e2e/smoke/vite.config.ts
+++ b/e2e/smoke/vite.config.ts
@@ -24,6 +24,14 @@ function faroHarnessPlugin(): Plugin {
       server.middlewares.use((req, res, next) => {
         const url = (req.url ?? '').split('?')[0] ?? '';
 
+        // Serve this navigation fixture without Vite's injected HMR client so
+        // native BFCache tests exercise only the SDK and browser lifecycle.
+        if (url === '/replay-lifecycle') {
+          res.setHeader('content-type', 'text/html');
+          res.end(readFileSync(join(REPO_ROOT, 'e2e/smoke/replay-lifecycle.html')));
+          return;
+        }
+
         const bundleMatch = /^\/bundles\/([\w-]+)\.iife\.js$/.exec(url);
         if (bundleMatch) {
           const requested = bundleMatch[1];

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Next
 
-- Feature (`@grafana/faro-instrumentation-replay`): Add per-tab recording identity, checkpoint
-  generations, and recording-wide sequence numbers. Preserve identity through clean navigation
-  using owner-scoped handoffs, and expose accepted-event serialization failures as sequence gaps.
-  Recover with a new identity after ownership loss, including same-document replacement when
-  the tab pointer cannot be updated.
+- Feature (`@grafana/faro-instrumentation-replay`): Add stable recording identity, checkpoint
+  generations, and recording-wide sequence numbers. Use Web Locks and one current tab checkpoint
+  to preserve completed counters through navigation, BFCache, replacement, and inactivity.
+  Remove the previous shared checkpoint pool and timed claims. Guard reentrant recorder startup
+  and teardown, reject conflicting Replay registrations, and retry failed startup on interaction.
+  Recover with a new identity when continuation counters are unavailable; document-local state
+  can survive same-document replacement after storage failures.
 
 ## 2.4.0
 

--- a/experimental/instrumentation-replay/README.md
+++ b/experimental/instrumentation-replay/README.md
@@ -119,6 +119,54 @@ initializeFaro({
 | ------------ | -------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
 | `beforeSend` | `(event: eventWithTime) => eventWithTime \| null \| undefined` | `undefined` | Transform or filter events before they are sent. Return `null` or `undefined` to skip sending |
 
+Filtering is unrestricted. Dropping rrweb Meta or FullSnapshot events can make later events
+unplayable; the application owns that decision. Replay's `beforeSend` runs before reservation,
+so its dropped events consume no sequence number. The global Faro `config.beforeSend` runs after
+reservation and can leave a gap, just like serialization or delivery failure. Retries reuse the
+original event identity.
+
+## Recording identity and lifecycle
+
+Each `faro.session_recording.event` has three identity attributes:
+
+| Attribute      | Meaning                                                          |
+| -------------- | ---------------------------------------------------------------- |
+| `recording_id` | One recording for a Faro owner, tab, and captured session.       |
+| `seq`          | Sequence number across the entire recording, beginning at zero.  |
+| `gen`          | Snapshot generation, advanced by each accepted rrweb Meta event. |
+
+A Faro owner consists of the global object key and application name, namespace, and environment.
+Changing a deployment version does not change the owner. Replay requires the Web Locks API and
+holds an exclusive recording lock before starting rrweb. Only one Replay instrumentation can
+register with a shared rrweb runtime, including while paused.
+
+One checkpoint in the tab's `sessionStorage` preserves the recording and counters through clean
+navigation, reload, BFCache restoration, and instrumentation replacement. Counters stay in memory
+while the lock is held and are saved on release. Inactivity pauses retain the lock and counters;
+resuming starts a fresh snapshot. The `started`, `paused`, and `resumed` lifecycle events include
+`recording_id` and bypass deduplication.
+
+Replay releases on `pageswap`, `pagehide`, and supported `freeze` events. Background visibility
+alone does not release ownership. A persisted `pageshow` or supported `resume` reacquires and
+rereads the checkpoint. If navigation is abandoned after `pageswap`, the next trusted pointer or
+keyboard interaction in the visible retained document restarts recording. Initial or resumed
+startup failures can also retry on later interaction; there is no automatic retry timer.
+
+Missing, malformed, or unfinished checkpoints recover under a new recording ID. Storage failures
+use the same lock protocol with document-local counters; same-document replacement can continue,
+but a later document may need a new ID. Earlier experimental checkpoint formats are ignored.
+
+Browser-copied tab state has limits. A copy of an active checkpoint waits without recording until
+the source releases, then starts a new ID. That wait can last indefinitely while the source retains
+its lock, including during inactivity. A copy of a stale clean checkpoint can reuse sequence
+numbers already emitted by the source, despite exclusive locks. Detection and targeted restart
+of those conflicts are future work.
+
+The installed rrweb version still has a partial-startup cleanup limitation tracked in
+[grafana/rrweb#59](https://github.com/grafana/rrweb/issues/59). Faro guards obsolete callbacks and
+defers stop/replacement beyond rrweb callbacks; the upstream cleanup fix and dependency update
+remain separate work.
+
 ## Privacy and Security
 
 This instrumentation records user interactions on your website. Make sure to:

--- a/experimental/instrumentation-replay/jest.config.js
+++ b/experimental/instrumentation-replay/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   ...jestBaseConfig,
   roots: ['experimental/instrumentation-replay/src'],
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/experimental/instrumentation-replay/setup.jest.ts'],
 };

--- a/experimental/instrumentation-replay/setup.jest.ts
+++ b/experimental/instrumentation-replay/setup.jest.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
       options: LockOptions | LockGrantedCallback<unknown>,
       callback?: LockGrantedCallback<unknown>
     ) =>
-      new Promise((resolve, reject) => {
+      new Promise<unknown>((resolve, reject) => {
         const signal = typeof options === 'function' ? undefined : options.signal;
         if (signal?.aborted) {
           reject(signal.reason);

--- a/experimental/instrumentation-replay/setup.jest.ts
+++ b/experimental/instrumentation-replay/setup.jest.ts
@@ -1,0 +1,85 @@
+interface LockRequest {
+  name: string;
+  callback: LockGrantedCallback<unknown>;
+  signal?: AbortSignal;
+  abort: () => void;
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+// The browser boundary: grants are asynchronous, return values hold the lock,
+// and aborting after grant does not release an acquired lock.
+beforeEach(() => {
+  const queues = new Map<string, LockRequest[]>();
+  const held = new Set<string>();
+  const drain = (name: string) => {
+    if (held.has(name)) {
+      return;
+    }
+    const request = queues.get(name)?.shift();
+    if (!request) {
+      return;
+    }
+    request.signal?.removeEventListener('abort', request.abort);
+    held.add(name);
+    let result: unknown;
+    try {
+      result = request.callback({ name, mode: 'exclusive' });
+    } catch (error) {
+      result = Promise.reject(error);
+    }
+    const release = () => {
+      held.delete(name);
+      void Promise.resolve().then(() => drain(name));
+    };
+    void Promise.resolve(result).then(
+      (value) => {
+        release();
+        request.resolve(value);
+      },
+      (error) => {
+        release();
+        request.reject(error);
+      }
+    );
+  };
+  const manager: LockManager = {
+    request: ((
+      name: string,
+      options: LockOptions | LockGrantedCallback<unknown>,
+      callback?: LockGrantedCallback<unknown>
+    ) =>
+      new Promise((resolve, reject) => {
+        const signal = typeof options === 'function' ? undefined : options.signal;
+        if (signal?.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        const request: LockRequest = {
+          name,
+          callback: typeof options === 'function' ? options : callback!,
+          signal,
+          resolve,
+          reject,
+          abort: () => {
+            queues.set(
+              name,
+              queues.get(name)!.filter((queued) => queued !== request)
+            );
+            reject(signal?.reason);
+          },
+        };
+        const queue = queues.get(name) ?? [];
+        queue.push(request);
+        queues.set(name, queue);
+        signal?.addEventListener('abort', request.abort, { once: true });
+        void Promise.resolve().then(() => drain(name));
+      })) as LockManager['request'],
+    query: async () => ({
+      held: [...held].map((name) => ({ name, mode: 'exclusive' as const })),
+      pending: [...queues.values()].flat().map(({ name }) => ({ name, mode: 'exclusive' as const })),
+    }),
+  };
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: manager });
+});
+import { beforeEach } from '@jest/globals';

--- a/experimental/instrumentation-replay/src/documentLifecycle.ts
+++ b/experimental/instrumentation-replay/src/documentLifecycle.ts
@@ -1,0 +1,94 @@
+import { genShortID } from '@grafana/faro-core';
+
+import type { DocumentRecordingState } from './recordingState';
+
+const documents = new WeakMap<Document, RecordingDocument>();
+
+/** Document lifetime outlasts instrumentation replacements and their memory handoffs. */
+export class RecordingDocument {
+  readonly id: string = genShortID();
+  activation: object = {};
+  phase: 'active' | 'pageswap' | 'suspended' = 'active';
+  private readonly owners = new Map<string, DocumentRecordingState>();
+  private readonly listeners = new Set<() => void>();
+
+  constructor() {
+    // These document-owned listeners retain no instrumentation. They must also
+    // expire handoffs when no Replay instance is installed at departure.
+    window.addEventListener('pageswap', () => this.suspend('pageswap'), { capture: true });
+    window.addEventListener('pagehide', () => this.suspend('suspended'), { capture: true });
+    document.addEventListener('freeze', () => this.suspend('suspended'), { capture: true });
+    document.addEventListener('resume', () => this.resume(), { capture: true });
+    window.addEventListener(
+      'pageshow',
+      (event) => {
+        if (event.persisted) {
+          this.resume();
+        }
+      },
+      { capture: true }
+    );
+  }
+
+  state(owner: string): DocumentRecordingState {
+    let state = this.owners.get(owner);
+    if (!state) {
+      state = {};
+      this.owners.set(owner, state);
+    }
+    return state;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  resumeRetainedActivation(): void {
+    if (this.phase === 'pageswap') {
+      this.phase = 'active';
+      this.notify();
+    }
+  }
+
+  private suspend(phase: 'pageswap' | 'suspended'): void {
+    if (this.phase === phase || this.phase === 'suspended') {
+      return;
+    }
+    this.phase = phase;
+    if (phase === 'suspended') {
+      this.activation = {};
+      this.owners.clear();
+    }
+    this.notify();
+  }
+
+  private resume(): void {
+    if (this.phase === 'active') {
+      return;
+    }
+    if (this.phase === 'pageswap') {
+      this.activation = {};
+      this.owners.clear();
+    }
+    this.phase = 'active';
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of [...this.listeners]) {
+      listener();
+    }
+  }
+}
+
+export function getRecordingDocument(): RecordingDocument {
+  let state = documents.get(document);
+  if (!state) {
+    state = new RecordingDocument();
+    documents.set(document, state);
+  }
+  return state;
+}

--- a/experimental/instrumentation-replay/src/instrumentation.lease.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.lease.test.ts
@@ -1,0 +1,33 @@
+import { initializeFaro } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { ReplayInstrumentation } from './instrumentation';
+
+jest.mock('@grafana/rrweb', () => ({ record: jest.fn(() => jest.fn()) }));
+
+it('does not start rrweb or buffer events while recording ownership is queued', async () => {
+  const request = jest.fn(
+    (_name: string, { signal }: { signal: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+      })
+  );
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: { request } });
+  const sdk = initializeFaro(mockConfig());
+  sdk.api.setSession({ id: 'A', attributes: { isSampled: 'true' } });
+  const replay = new ReplayInstrumentation();
+  try {
+    sdk.instrumentations.add(replay);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(require('@grafana/rrweb').record).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ mode: 'exclusive', signal: expect.any(AbortSignal) }),
+      expect.any(Function)
+    );
+  } finally {
+    replay.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+});

--- a/experimental/instrumentation-replay/src/instrumentation.namespace.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.namespace.test.ts
@@ -13,9 +13,11 @@ describe('replay handoff owner namespace', () => {
   let removeRecorders: Array<() => void>;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     window.sessionStorage.clear();
     window.localStorage.clear();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
     removeRecorders = [];
     require('@grafana/rrweb').record.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
       options.emit({
@@ -27,19 +29,23 @@ describe('replay handoff owner namespace', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    window.dispatchEvent(new Event('pagehide'));
     removeRecorders.forEach((remove) => remove());
+    await jest.advanceTimersByTimeAsync(0);
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  function startOwner(app: MetaApp) {
-    const faro = initializeFaro(mockConfig({ app, globalObjectKey: 'shared-faro' }));
+  async function startOwner(app: MetaApp, globalObjectKey = 'shared-faro') {
+    const faro = initializeFaro(mockConfig({ app, globalObjectKey }));
     faro.api.setSession({ id: 'shared-session', attributes: { isSampled: 'true' } });
     const pushEvent = jest.spyOn(faro.api, 'pushEvent');
     const instrumentation = new ReplayInstrumentation();
     const remove = () => faro.instrumentations.remove(instrumentation);
     removeRecorders.push(remove);
     faro.instrumentations.add(instrumentation);
+    await jest.advanceTimersByTimeAsync(0);
 
     const replay = pushEvent.mock.calls.find(([name]) => name === 'faro.session_recording.event');
     expect(replay).toBeDefined();
@@ -56,52 +62,54 @@ describe('replay handoff owner namespace', () => {
       { name: 'app', environment: 'production' },
       { name: 'app', environment: 'staging' },
     ],
-  ])('preserves A through an intervening B replacement (%j, %j)', (appA, appB) => {
-    const firstA = startOwner(appA);
+  ])('preserves A through an intervening B replacement (%j, %j)', async (appA, appB) => {
+    const firstA = await startOwner(appA);
     firstA.remove();
 
-    const ownerB = startOwner(appB);
+    const ownerB = await startOwner(appB);
     expect(ownerB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
     ownerB.remove();
 
-    const nextA = startOwner(appA);
+    const nextA = await startOwner(appA);
     expect(nextA.attributes).toEqual(
       expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
     );
   });
 
-  it('preserves clean navigation handoffs across application releases without admitting another app', () => {
-    const firstA = startOwner({ name: 'navigation-a', version: '1.0.0', release: 'first' });
+  it('preserves clean navigation handoffs across application releases without admitting another app', async () => {
+    const firstA = await startOwner({ name: 'navigation-a', version: '1.0.0', release: 'first' });
     window.dispatchEvent(new Event('pagehide'));
     firstA.remove();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
 
-    const ownerB = startOwner({ name: 'navigation-b', version: '1.0.0', release: 'first' });
+    const ownerB = await startOwner({ name: 'navigation-b', version: '1.0.0', release: 'first' });
     expect(ownerB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
     window.dispatchEvent(new Event('pagehide'));
     ownerB.remove();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
 
-    const nextA = startOwner({ name: 'navigation-a', version: '2.0.0', release: 'second' });
+    const nextA = await startOwner({ name: 'navigation-a', version: '2.0.0', release: 'second' });
     expect(nextA.attributes).toEqual(
       expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
     );
   });
 
-  it('keeps concurrently recording owners isolated through a shared navigation', () => {
-    const firstA = startOwner({ name: 'concurrent-a' });
-    const firstB = startOwner({ name: 'concurrent-b' });
+  it('includes the global object key in the owner namespace', async () => {
+    const firstA = await startOwner({ name: 'app' }, 'first');
+    firstA.remove();
+    const firstB = await startOwner({ name: 'app' }, 'second');
     expect(firstB.attributes['recording_id']).not.toBe(firstA.attributes['recording_id']);
-
-    window.dispatchEvent(new Event('pagehide'));
-    firstA.remove();
     firstB.remove();
-
-    const nextB = startOwner({ name: 'concurrent-b' });
-    const nextA = startOwner({ name: 'concurrent-a' });
+    const nextA = await startOwner({ name: 'app' }, 'first');
     expect(nextA.attributes).toEqual(
       expect.objectContaining({ recording_id: firstA.attributes['recording_id'], gen: '1', seq: '1' })
     );
-    expect(nextB.attributes).toEqual(
-      expect.objectContaining({ recording_id: firstB.attributes['recording_id'], gen: '1', seq: '1' })
-    );
+  });
+
+  it('rejects overlapping registrations even for different owners', async () => {
+    const first = await startOwner({ name: 'first' });
+    await expect(startOwner({ name: 'second' })).rejects.toThrow('already has a Replay producer');
+    first.remove();
+    await expect(startOwner({ name: 'second' })).resolves.toBeDefined();
   });
 });

--- a/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.safety.test.ts
@@ -2,7 +2,9 @@ import { type EventEvent, type Faro, initializeFaro, type TransportItem } from '
 import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
 import { EventType, type eventWithTime } from '@grafana/rrweb-types';
 
+import { getRecordingDocument } from './documentLifecycle';
 import { ReplayInstrumentation } from './instrumentation';
+import { replayRecordingStorageKeyPrefix } from './recordingState';
 import type { ReplayInstrumentationOptions } from './types';
 
 jest.mock('@grafana/rrweb', () => ({ record: jest.fn() }));
@@ -17,6 +19,7 @@ const changeEvent = (): eventWithTime => ({
   data: { tag: 'change', payload: null },
   timestamp: Date.now(),
 });
+const flush = () => jest.advanceTimersByTimeAsync(0);
 
 describe('Replay callback and startup safety', () => {
   let faro: Faro;
@@ -30,6 +33,7 @@ describe('Replay callback and startup safety', () => {
     jest.useFakeTimers();
     window.sessionStorage.clear();
     window.localStorage.clear();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
     mockRecord = require('@grafana/rrweb').record;
     mockRecord.mockReset();
     stop = jest.fn();
@@ -42,12 +46,12 @@ describe('Replay callback and startup safety', () => {
     setSession('A');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    window.dispatchEvent(new Event('pagehide'));
     replay?.destroy();
+    await flush();
     jest.restoreAllMocks();
     document.body.replaceChildren();
-    window.sessionStorage.clear();
-    window.localStorage.clear();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -56,9 +60,10 @@ describe('Replay callback and startup safety', () => {
     faro.api.setSession({ id, attributes: { isSampled: String(sampled) } });
   }
 
-  function start(options: ReplayInstrumentationOptions = {}) {
+  async function start(options: ReplayInstrumentationOptions = {}) {
     replay = new ReplayInstrumentation({ recordAfter: 'DOMContentLoaded', ...options });
     faro.instrumentations.add(replay);
+    await flush();
   }
 
   function events() {
@@ -69,22 +74,23 @@ describe('Replay callback and startup safety', () => {
     return events().filter((item) => item.payload.name === 'faro.session_recording.event');
   }
 
-  it('pauses despite a capture listener failure and resumes after the listener recovers', () => {
-    start({ inactivityThresholdMs: 5_000 });
-    const failedCapture = () => {
-      throw new Error('capture failed');
-    };
-    faro.metas.addCaptureListener!(failedCapture);
+  function hasActiveCheckpoint() {
+    return Object.keys(window.sessionStorage)
+      .filter((key) => key.startsWith(replayRecordingStorageKeyPrefix))
+      .some((key) => JSON.parse(window.sessionStorage.getItem(key)!).handoff === 'active');
+  }
 
-    expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
+  it('stays paused when publishing the paused event fails', async () => {
+    await start({ inactivityThresholdMs: 1_000 });
+    jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(() => {
+      throw new Error('publication failed');
+    });
+    await jest.advanceTimersByTimeAsync(1_000);
     expect(stop).toHaveBeenCalledTimes(1);
-    expect(events().map((item) => item.payload.name)).toEqual(['faro.session_recording.started']);
-
-    faro.metas.removeCaptureListener!(failedCapture);
     emit(changeEvent());
     expect(recordings()).toEqual([]);
     document.dispatchEvent(new Event('pointerdown'));
-
+    await flush();
     expect(mockRecord).toHaveBeenCalledTimes(2);
     expect(events().map((item) => item.payload.name)).toEqual([
       'faro.session_recording.started',
@@ -92,274 +98,287 @@ describe('Replay callback and startup safety', () => {
     ]);
   });
 
-  it('stays paused when publishing the paused event fails', () => {
-    start({ inactivityThresholdMs: 5_000 });
-    const pushEvent = jest.spyOn(faro.api, 'pushEvent').mockImplementationOnce(() => {
-      throw new Error('publication failed');
-    });
-
-    try {
-      expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
+  it.each(['rotate', 'clear'])(
+    'does not publish a paused event after capture changes the session: %s',
+    async (action) => {
+      await start({ inactivityThresholdMs: 1_000 });
+      const changeSession = () => {
+        faro.metas.removeCaptureListener!(changeSession);
+        if (action === 'rotate') {
+          setSession('B');
+        } else {
+          faro.api.setSession(undefined);
+        }
+      };
+      faro.metas.addCaptureListener!(changeSession);
+      await jest.advanceTimersByTimeAsync(1_000);
       expect(stop).toHaveBeenCalledTimes(1);
-      emit(changeEvent());
-      expect(recordings()).toEqual([]);
-      document.dispatchEvent(new Event('pointerdown'));
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(events().map((item) => item.payload.name)).toEqual([
-        'faro.session_recording.started',
-        'faro.session_recording.resumed',
-      ]);
-    } finally {
-      pushEvent.mockRestore();
+      expect(events().filter((item) => item.payload.name === 'faro.session_recording.paused')).toEqual([]);
     }
-  });
+  );
 
-  it.each(['rotate', 'clear'])('does not publish a paused event after capture changes the session: %s', (action) => {
-    start({ inactivityThresholdMs: 5_000 });
-    const changeSession = () => {
-      faro.metas.removeCaptureListener!(changeSession);
-      if (action === 'rotate') {
-        setSession('B');
-      } else {
-        faro.api.setSession(undefined);
-      }
-    };
-    faro.metas.addCaptureListener!(changeSession);
-
-    jest.advanceTimersByTime(5_000);
-
-    expect(stop).toHaveBeenCalledTimes(1);
-    expect(events().filter((item) => item.payload.name === 'faro.session_recording.paused')).toEqual([]);
-  });
-
-  it.each(['no-stop', 'throw'])('discards synchronous startup events when record fails: %s', (failure) => {
-    mockRecord.mockImplementation((options) => {
-      options.emit(metaEvent());
-      if (failure === 'throw') {
-        throw new Error('recorder failed');
-      }
-      return undefined;
-    });
-    start();
-    expect(events()).toEqual([]);
-  });
-
-  it.each(['start', 'resume'])('logs stop failures when an attempt is invalidated during %s', async (phase) => {
-    replay = new ReplayInstrumentation({ inactivityThresholdMs: 5_000 });
-    const logWarn = jest.spyOn(replay, 'logWarn');
-    if (phase === 'resume') {
-      faro.instrumentations.add(replay);
-      jest.advanceTimersByTime(5_000);
-    }
-    const previousEvents = [...events()];
-    const stopError = new Error('stop failed');
-    const stopInvalidated = jest.fn(() => {
-      throw stopError;
-    });
-    mockRecord.mockImplementationOnce((options) => {
-      emit = options.emit;
+  it.each(['no-stop', 'throw'])(
+    'discards failed startup events, releases the lease, and retries only on input: %s',
+    async (failure) => {
+      let failedId: string | undefined;
+      mockRecord.mockImplementationOnce((options) => {
+        failedId = JSON.parse(window.sessionStorage.getItem(Object.keys(window.sessionStorage)[0]!)!).recordingId;
+        options.emit(metaEvent());
+        if (failure === 'throw') {
+          throw new Error('recorder failed');
+        }
+        return undefined;
+      });
+      await start();
+      expect(events()).toEqual([]);
+      expect((await navigator.locks.query()).held).toEqual([]);
+      await flush();
+      expect(mockRecord).toHaveBeenCalledTimes(1);
+      document.dispatchEvent(new Event('keydown'));
+      await flush();
       emit(metaEvent());
-      setSession('B');
-      return stopInvalidated;
-    });
+      expect(recordings()[0]!.payload.attributes).toMatchObject({ recording_id: failedId, seq: '0', gen: '0' });
+    }
+  );
 
-    expect(() => {
+  it.each(['start', 'resume'])(
+    'stops a stale returned handle after the enclosing %s call and releases despite a stop error',
+    async (phase) => {
+      replay = new ReplayInstrumentation({ inactivityThresholdMs: 1_000 });
+      const logWarn = jest.spyOn(replay, 'logWarn');
+      if (phase === 'resume') {
+        faro.instrumentations.add(replay);
+        await flush();
+        await jest.advanceTimersByTimeAsync(1_000);
+      }
+      let staleEmit!: typeof emit;
+      const stopError = new Error('stop failed');
+      const order: string[] = [];
+      const staleStop = jest.fn(() => {
+        order.push('stop');
+        throw stopError;
+      });
+      mockRecord.mockImplementationOnce((options) => {
+        staleEmit = options.emit;
+        options.emit(metaEvent());
+        setSession('B');
+        expect(staleStop).not.toHaveBeenCalled();
+        order.push('record returned');
+        return staleStop;
+      });
       if (phase === 'resume') {
         document.dispatchEvent(new Event('pointerdown'));
       } else {
         faro.instrumentations.add(replay);
       }
-    }).not.toThrow();
+      await flush();
+      expect(order).toEqual(['record returned', 'stop']);
+      expect(staleStop).toHaveBeenCalledTimes(1);
+      expect(logWarn).toHaveBeenCalledWith('Failed to stop session replay', stopError);
+      expect(mockRecord).toHaveBeenCalledTimes(phase === 'resume' ? 3 : 2);
+      expect((await navigator.locks.query()).held).toHaveLength(1);
+      staleEmit(changeEvent());
+      expect(recordings()).toEqual([]);
+      emit(changeEvent());
+      expect(recordings().map((item) => item.meta.session?.id)).toEqual(['B']);
+    }
+  );
 
-    expect(stopInvalidated).toHaveBeenCalledTimes(1);
-    expect(logWarn).toHaveBeenCalledWith('Failed to stop session replay', stopError);
-    expect(logWarn).not.toHaveBeenCalledWith(`Failed to ${phase} session replay`, stopError);
-    expect(events()).toEqual(previousEvents);
-    const staleEmit = emit;
-    staleEmit(changeEvent());
-    expect(recordings()).toEqual([]);
+  it.each(['start', 'resume'])(
+    'retains the returned stop handle when post-%s metadata validation throws',
+    async (phase) => {
+      if (phase === 'resume') {
+        await start({ inactivityThresholdMs: 1_000 });
+        await jest.advanceTimersByTimeAsync(1_000);
+      }
+      let fail = false;
+      faro.metas.add(() => {
+        if (fail) {
+          fail = false;
+          throw new Error('metadata getter failed');
+        }
+        return {};
+      });
+      mockRecord.mockImplementationOnce((options) => {
+        emit = options.emit;
+        fail = true;
+        return stop;
+      });
+      if (phase === 'start') {
+        await start();
+      } else {
+        document.dispatchEvent(new Event('pointerdown'));
+        await flush();
+      }
+      expect(stop).toHaveBeenCalledTimes(phase === 'start' ? 1 : 2);
+      emit(changeEvent());
+      expect(recordings()).toEqual([]);
+      expect((await navigator.locks.query()).held).toHaveLength(phase === 'start' ? 0 : 1);
+    }
+  );
 
-    await Promise.resolve();
-
-    expect(mockRecord).toHaveBeenCalledTimes(phase === 'resume' ? 3 : 2);
-    staleEmit(changeEvent());
-    expect(recordings()).toEqual([]);
-    emit(changeEvent());
-    expect(recordings().map((item) => item.meta.session?.id)).toEqual(['B']);
-  });
-
-  it('does not retry a failed reinitialization from a previous lifecycle', async () => {
-    start();
-    setSession('B');
-    faro.instrumentations.remove(replay);
-    mockRecord.mockReturnValueOnce(undefined);
-    faro.instrumentations.add(replay);
-    expect(mockRecord).toHaveBeenCalledTimes(2);
-
-    await Promise.resolve();
-
-    expect(mockRecord).toHaveBeenCalledTimes(2);
-    setSession('B');
-    await Promise.resolve();
-    expect(mockRecord).toHaveBeenCalledTimes(3);
-  });
-
-  it('preserves coalescing of new starts when a previous lifecycle callback runs', async () => {
-    start();
-    setSession('B');
-    faro.instrumentations.remove(replay);
-    faro.instrumentations.add(replay);
-
-    // Notify between the old callback and the new one; this must not queue a second retry.
-    const notification = Promise.resolve().then(() => setSession('D'));
-    setSession('C');
-    mockRecord.mockReturnValueOnce(undefined);
-    await notification;
-    await Promise.resolve();
-
-    expect(mockRecord).toHaveBeenCalledTimes(3);
-    expect(stop).toHaveBeenCalledTimes(2);
-  });
-
-  it('can restart after a removed listener queues work during destruction', async () => {
+  it('does not let a removed metadata callback queue work for its replacement', async () => {
     faro.metas.addListener((meta) => {
       if (meta.session?.id === 'B') {
         faro.instrumentations.remove(replay);
       }
     });
-    start();
-    // Core still invokes the removed replay listener in this notification's iteration.
+    await start();
     setSession('B');
     faro.instrumentations.add(replay);
-    await Promise.resolve();
-
+    await flush();
     setSession('C');
-    await Promise.resolve();
-
+    await flush();
     expect(mockRecord).toHaveBeenCalledTimes(3);
     expect(stop).toHaveBeenCalledTimes(2);
     emit(changeEvent());
     expect(recordings().map((item) => item.meta.session?.id)).toEqual(['C']);
   });
 
-  it('does not leak a recorder when a capture listener reinitializes replay', () => {
+  it('does not retain a document subscriber when metadata registration removes Replay', async () => {
+    const subscribe = jest.spyOn(getRecordingDocument(), 'subscribe');
+    const addListener = faro.metas.addListener;
+    jest.spyOn(faro.metas, 'addListener').mockImplementation((listener) => {
+      addListener(listener);
+      faro.instrumentations.remove(replay);
+    });
+    await start();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(mockRecord).not.toHaveBeenCalled();
+    expect(faro.instrumentations.instrumentations).toHaveLength(0);
+  });
+
+  it('releases unused ownership when dynamic metadata withdraws eligibility after grant', async () => {
+    let eligible = true;
+    faro.metas.add(() => ({ session: eligible ? { id: 'A', attributes: { isSampled: 'true' } } : undefined }));
+    const withdraw = () => {
+      if (hasActiveCheckpoint()) {
+        eligible = false;
+      }
+    };
+    faro.metas.addCaptureListener!(withdraw);
+    await start();
+    expect(mockRecord).not.toHaveBeenCalled();
+    expect((await navigator.locks.query()).held).toEqual([]);
+    faro.metas.removeCaptureListener!(withdraw);
+    eligible = true;
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start rrweb after an eligibility getter destroys the granted owner', async () => {
+    let invalidate = false;
+    faro.metas.add(() => {
+      if (invalidate) {
+        invalidate = false;
+        replay.destroy();
+      }
+      return {};
+    });
+    const capture = faro.metas.capture!;
+    jest.spyOn(faro.metas, 'capture').mockImplementation((callback) =>
+      capture(
+        callback &&
+          (() => {
+            invalidate = hasActiveCheckpoint();
+            callback();
+          })
+      )
+    );
+    await start();
+    expect(mockRecord).not.toHaveBeenCalled();
+    expect((await navigator.locks.query()).held).toEqual([]);
+  });
+
+  it.each(['start', 'resume'])('preserves a replacement installed by capture during %s', async (phase) => {
+    if (phase === 'resume') {
+      await start({ inactivityThresholdMs: 1_000 });
+      await jest.advanceTimersByTimeAsync(1_000);
+    }
     const reinitialize = () => {
       faro.metas.removeCaptureListener!(reinitialize);
       faro.instrumentations.remove(replay);
       faro.instrumentations.add(replay);
     };
     faro.metas.addCaptureListener!(reinitialize);
-
-    start();
-
-    expect(mockRecord).toHaveBeenCalledTimes(1);
-    expect(stop).not.toHaveBeenCalled();
+    if (phase === 'start') {
+      await start();
+    } else {
+      document.dispatchEvent(new Event('pointerdown'));
+      await flush();
+    }
+    expect(mockRecord).toHaveBeenCalledTimes(phase === 'resume' ? 2 : 1);
     emit(changeEvent());
     expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
-
     faro.instrumentations.remove(replay);
-
-    expect(stop).toHaveBeenCalledTimes(1);
+    await flush();
+    expect((await navigator.locks.query()).held).toEqual([]);
     emit(changeEvent());
     expect(recordings()).toHaveLength(1);
   });
 
-  it.each(['A', 'B'])('preserves a recorder reinitialized during resume for session %s', async (sessionId) => {
-    start({ inactivityThresholdMs: 5_000 });
-    jest.advanceTimersByTime(5_000);
-    const reinitialize = () => {
-      faro.metas.removeCaptureListener!(reinitialize);
-      faro.instrumentations.remove(replay);
-      setSession(sessionId);
-      faro.instrumentations.add(replay);
-    };
-    faro.metas.addCaptureListener!(reinitialize);
-
-    document.dispatchEvent(new Event('pointerdown'));
-    await Promise.resolve();
-
-    expect(mockRecord).toHaveBeenCalledTimes(2);
-    expect(stop).toHaveBeenCalledTimes(1);
-    expect(events().filter((item) => item.payload.name === 'faro.session_recording.resumed')).toEqual([]);
-    emit(changeEvent());
-    expect(recordings().map((item) => item.meta.session?.id)).toEqual([sessionId]);
-
-    faro.instrumentations.remove(replay);
-
-    expect(stop).toHaveBeenCalledTimes(2);
-    emit(changeEvent());
-    expect(recordings()).toHaveLength(1);
-  });
-
-  it('publishes the lifecycle marker before buffered events and then accepts live events', () => {
-    mockRecord.mockImplementation((options) => {
-      emit = options.emit;
-      emit(metaEvent());
-      emit(changeEvent());
-      return stop;
-    });
-    start();
-    emit({ ...changeEvent(), timestamp: Date.now() + 1 });
-    expect(events().map((item) => item.payload.name)).toEqual([
-      'faro.session_recording.started',
-      'faro.session_recording.event',
-      'faro.session_recording.event',
-      'faro.session_recording.event',
-    ]);
-  });
-
-  it.each(['rotate', 'unsample', 'away-back', 'destroy'])(
-    'discards real rrweb startup invalidated by maskInputFn: %s',
-    async (action) => {
+  it.each(['startup', 'checkout', 'deferred'])(
+    'guards real rrweb %s through reentrant input masking and replacement',
+    async (phase) => {
       const input = document.createElement('input');
       input.value = 'private';
       document.body.appendChild(input);
       const realRecord = jest.requireActual('@grafana/rrweb').record;
+      const readyState =
+        phase === 'deferred' ? jest.spyOn(document, 'readyState', 'get').mockReturnValue('loading') : undefined;
+      const order: string[] = [];
       mockRecord.mockImplementation((options) => {
         const stopRecorder = realRecord(options);
         return () => {
+          order.push('stop');
           stop();
           stopRecorder?.();
         };
       });
-      let invalidated = false;
-      start({
+      let invalidate = phase !== 'checkout';
+      await start({
         maskInputFn: () => {
-          if (!invalidated) {
-            invalidated = true;
-            if (action === 'destroy') {
-              replay.destroy();
-            } else if (action === 'unsample') {
-              setSession('A', false);
-            } else {
-              setSession('B');
-              if (action === 'away-back') {
-                setSession('A');
-              }
-            }
+          if (invalidate) {
+            invalidate = false;
+            const count = stop.mock.calls.length;
+            setSession('B');
+            expect(stop).toHaveBeenCalledTimes(count);
+            order.push('mask returned');
           }
           return '******';
         },
       });
-      expect(invalidated).toBe(true);
-      expect(stop).toHaveBeenCalledTimes(1);
-      expect(events()).toEqual([]);
-      await Promise.resolve();
-      if (action === 'rotate' || action === 'away-back') {
-        expect(events()[0]?.payload.name).toBe('faro.session_recording.started');
-        expect(recordings().map((item) => JSON.parse(item.payload.attributes!['event']!).type)).toEqual([
-          EventType.Meta,
-          EventType.FullSnapshot,
-        ]);
-        expect(recordings().every((item) => item.meta.session?.id === (action === 'rotate' ? 'B' : 'A'))).toBe(true);
-      } else {
-        expect(events()).toEqual([]);
+      if (phase === 'checkout') {
+        transport.items.splice(0);
+        invalidate = true;
+        realRecord.takeFullSnapshot();
+      } else if (phase === 'deferred') {
+        readyState!.mockReturnValue('interactive');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
       }
+      await flush();
+      expect(order.slice(0, 2)).toEqual(['mask returned', 'stop']);
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(
+        recordings()
+          .filter((item) => item.meta.session?.id === 'A')
+          .some((item) => JSON.parse(item.payload.attributes!['event']!).type === EventType.FullSnapshot)
+      ).toBe(false);
+      const current = recordings().filter((item) => item.meta.session?.id === 'B');
+      expect(current.map((item) => JSON.parse(item.payload.attributes!['event']!).type)).toEqual([
+        EventType.Meta,
+        EventType.FullSnapshot,
+      ]);
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 7 }));
+      await flush();
+      expect(recordings().at(-1)!.meta.session?.id).toBe('B');
+      readyState?.mockRestore();
     }
   );
 
-  it.each(['rotate', 'unsample', 'destroy'])('discards an event invalidated inside beforeSend: %s', (action) => {
-    start({
+  it.each(['rotate', 'unsample', 'destroy'])('discards an event invalidated inside beforeSend: %s', async (action) => {
+    await start({
       beforeSend: (event) => {
         if (action === 'destroy') {
           replay.destroy();
@@ -371,17 +390,19 @@ describe('Replay callback and startup safety', () => {
     });
     emit(changeEvent());
     expect(recordings()).toEqual([]);
+    expect(stop).not.toHaveBeenCalled();
+    await flush();
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
-  it('does not reconcile again between accepting an event and submitting it', () => {
+  it('keeps the accepted capture through filtering and reconciles again on the next event', async () => {
     let expired = false;
     faro.metas.addCaptureListener!(() => {
       if (expired) {
         setSession('B');
       }
     });
-    start({
+    await start({
       beforeSend: (event) => {
         expired = true;
         return event;
@@ -394,48 +415,23 @@ describe('Replay callback and startup safety', () => {
     expect(faro.api.getSession()?.id).toBe('B');
   });
 
-  it('discards serialization callbacks that invalidate the current attempt', () => {
-    start();
-    const event = {
+  it('rejects serialization invalidation and old callbacks even after returning to the same session', async () => {
+    await start();
+    const staleEmit = emit;
+    const invalidated = {
       ...changeEvent(),
       toJSON: () => {
         setSession('B');
         return changeEvent();
       },
     };
-    emit(event);
+    emit(invalidated);
     expect(recordings()).toEqual([]);
-  });
-
-  it('rejects a stale rrweb callback after rotating away and back to the same session', async () => {
-    start();
-    const staleEmit = emit;
-    setSession('B');
     setSession('A');
-    await Promise.resolve();
+    await flush();
     staleEmit(changeEvent());
     expect(recordings()).toEqual([]);
     emit(changeEvent());
     expect(recordings().map((item) => item.meta.session?.id)).toEqual(['A']);
-  });
-
-  it('reconciles a paused session before choosing resume versus a new recorder', async () => {
-    let expired = false;
-    faro.metas.addCaptureListener!(() => {
-      if (expired) {
-        setSession('B');
-      }
-    });
-    start({ inactivityThresholdMs: 1000 });
-    jest.advanceTimersByTime(1000);
-    expired = true;
-    document.dispatchEvent(new Event('pointerdown'));
-    await Promise.resolve();
-    expect(events().filter((item) => item.payload.name === 'faro.session_recording.resumed')).toEqual([]);
-    expect(
-      events()
-        .filter((item) => item.payload.name === 'faro.session_recording.started')
-        .map((item) => item.meta.session?.id)
-    ).toEqual(['A', 'B']);
   });
 });

--- a/experimental/instrumentation-replay/src/instrumentation.test.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.test.ts
@@ -1,2097 +1,501 @@
-import {
-  BaseTransport,
-  genShortID,
-  getTransportBody,
-  initializeFaro,
-  type TransportBody,
-  type TransportItem,
-} from '@grafana/faro-core';
-import { mockConfig } from '@grafana/faro-core/src/testUtils';
-import { EventType } from '@grafana/rrweb-types';
+import { type EventEvent, type Faro, initializeFaro, type TransportItem } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+import type { recordOptions } from '@grafana/rrweb';
+import { EventType, type eventWithTime } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn } from './const';
 import { ReplayInstrumentation } from './instrumentation';
-import { replayRecordingCheckpointKeyPrefix } from './recordingState';
-import { MaskInputFn, ReplayInstrumentationOptions } from './types';
+import { recordingLockName, replayRecordingStorageKeyPrefix } from './recordingState';
+import type { ReplayInstrumentationOptions } from './types';
 
-// Mock rrweb
-jest.mock('@grafana/rrweb', () => {
-  const record = Object.assign(jest.fn(), { takeFullSnapshot: jest.fn() });
-  return { record };
+jest.mock('@grafana/rrweb', () => ({ record: jest.fn() }));
+
+const namespace = '["owner","app","ns","test"]';
+const key = `${replayRecordingStorageKeyPrefix}${namespace}`;
+const metaEvent = (href = 'https://user:password@example.com/path?token=secret#fragment'): eventWithTime => ({
+  type: EventType.Meta,
+  timestamp: Date.now(),
+  data: { href, width: 1, height: 1 },
 });
-
-class BatchedBodyTransport extends BaseTransport {
-  readonly name = '@grafana/transport-batched-body-mock';
-  readonly version = 'test';
-
-  sentBodies: TransportBody[] = [];
-
-  send(items: TransportItem | TransportItem[]): void {
-    this.sentBodies.push(getTransportBody(Array.isArray(items) ? items : [items]));
-  }
-
-  override isBatched(): boolean {
-    return true;
-  }
-}
-
-function createSeededRandom(seed: number): () => number {
-  let current = seed >>> 0;
-
-  return () => {
-    current = (Math.imul(current, 1_664_525) + 1_013_904_223) >>> 0;
-    return current / 0x1_0000_0000;
-  };
-}
+const changeEvent = (tag = 'change'): eventWithTime => ({
+  type: EventType.Custom,
+  timestamp: Date.now(),
+  data: { tag, payload: null },
+});
+const flush = () => jest.advanceTimersByTimeAsync(0);
 
 describe('ReplayInstrumentation', () => {
-  let instrumentation: ReplayInstrumentation;
-  let mockRecord: jest.Mock & { takeFullSnapshot: jest.Mock };
-  let mockGetSession: jest.Mock;
-  let mockAddListener: jest.Mock;
-  let mockPushEvent: jest.Mock;
-  const mockCapture = (callback?: () => void) => {
-    const meta = { session: mockGetSession() };
-    callback?.();
-    return meta;
-  };
+  let sdk: Faro;
+  let transport: MockTransport;
+  let mockRecord: jest.Mock;
+  let attempts: Array<{ options: recordOptions<eventWithTime>; stop: jest.Mock }>;
+  let recorders: ReplayInstrumentation[];
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.useFakeTimers();
     window.sessionStorage.clear();
     window.localStorage.clear();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+    attempts = [];
+    recorders = [];
     mockRecord = require('@grafana/rrweb').record;
-    mockRecord.mockReturnValue(jest.fn());
-
-    // Mock API and metas
-    mockGetSession = jest.fn();
-    mockAddListener = jest.fn();
-    mockPushEvent = jest.fn();
+    mockRecord.mockReset().mockImplementation((options) => {
+      const stop = jest.fn();
+      attempts.push({ options, stop });
+      return stop;
+    });
+    transport = new MockTransport();
+    sdk = initializeFaro(
+      mockConfig({
+        transports: [transport],
+        dedupe: true,
+        globalObjectKey: 'owner',
+        app: { name: 'app', namespace: 'ns', environment: 'test', version: '1' },
+      })
+    );
+    setSession('A');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    window.dispatchEvent(new Event('pagehide'));
+    recorders.forEach((replay) => replay.destroy());
+    await flush();
     jest.restoreAllMocks();
-    if (instrumentation) {
-      instrumentation.destroy();
-    }
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
-  function initSampled(
-    options: ReplayInstrumentationOptions = {},
-    sessionId: string = 'test-session'
-  ): ReplayInstrumentation {
-    const inst = new ReplayInstrumentation(options);
-    mockGetSession.mockReturnValue({ id: sessionId, attributes: { isSampled: 'true' } });
-    inst['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-    inst['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-    inst.initialize();
-    return inst;
+
+  function setSession(id?: string, sampled = true) {
+    sdk.api.setSession({ id, attributes: { isSampled: String(sampled) } });
   }
 
-  describe('constructor', () => {
-    it('should have correct name and version', () => {
-      instrumentation = new ReplayInstrumentation();
+  async function start(options: ReplayInstrumentationOptions = {}, target = sdk) {
+    const replay = new ReplayInstrumentation(options);
+    recorders.push(replay);
+    target.instrumentations.add(replay);
+    await flush();
+    return replay;
+  }
 
-      expect(instrumentation.name).toBe('@grafana/faro-instrumentation-replay');
-      expect(instrumentation.version).toBeDefined();
+  function events(name?: string) {
+    const items = transport.items as Array<TransportItem<EventEvent>>;
+    return name ? items.filter((item) => item.payload.name === `faro.session_recording.${name}`) : items;
+  }
+
+  function recordings() {
+    return events('event').map((item) => item.payload.attributes!);
+  }
+
+  function emit(event: eventWithTime, index = attempts.length - 1) {
+    attempts[index]!.options.emit!(event);
+  }
+
+  it('keeps the active marker ahead of startup publication and preserves buffered ordering', async () => {
+    mockRecord.mockImplementationOnce((options) => {
+      expect(JSON.parse(window.sessionStorage.getItem(key)!).handoff).toBe('active');
+      options.emit(metaEvent());
+      options.emit(changeEvent('startup'));
+      return jest.fn();
     });
-
-    it('should use default options when none provided', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      const expectedDefaults: ReplayInstrumentationOptions = {
-        recordCrossOriginIframes: false,
-        recordAfter: 'load',
-        maskAllInputs: true,
-        maskInputOptions: {
-          password: true,
-        },
-        maskInputFn: defaultMaskInputFn,
-        collectFonts: false,
-        inlineImages: false,
-        inlineStylesheet: false,
-        recordCanvas: false,
-        maskTextSelector: '*',
-        blockSelector: undefined,
-        ignoreSelector: undefined,
-        beforeSend: undefined,
-        sanitizeMetaHref: true,
-        samplingRate: 1,
-        inactivityThresholdMs: 60_000,
-      };
-
-      expect(instrumentation['options']).toEqual(expectedDefaults);
-    });
-
-    it('should use custom options when provided', () => {
-      const beforeSendFn = jest.fn();
-      const maskInputFn: MaskInputFn = jest.fn((text, _element) => '*'.repeat(text.length));
-      const customOptions: ReplayInstrumentationOptions = {
-        recordCrossOriginIframes: true,
-        maskAllInputs: true,
-        maskInputOptions: {
-          password: true,
-          email: true,
-        },
-        maskInputFn,
-        collectFonts: true,
-        inlineImages: true,
-        inlineStylesheet: true,
-        recordCanvas: true,
-        recordAfter: 'DOMContentLoaded',
-        maskTextSelector: '.mask-me',
-        blockSelector: '.block-me',
-        ignoreSelector: '.ignore-me',
-        beforeSend: beforeSendFn,
-        sanitizeMetaHref: false,
-        samplingRate: 1,
-        inactivityThresholdMs: 30_000,
-      };
-
-      instrumentation = new ReplayInstrumentation(customOptions);
-
-      expect(instrumentation['options']).toEqual(customOptions);
-    });
-
-    it('should merge partial custom options with defaults', () => {
-      const partialOptions: ReplayInstrumentationOptions = {
-        recordAfter: 'DOMContentLoaded',
-        maskAllInputs: false,
-        recordCanvas: true,
-      };
-
-      instrumentation = new ReplayInstrumentation(partialOptions);
-
-      expect(instrumentation['options'].maskAllInputs).toBe(false);
-      expect(instrumentation['options'].recordCanvas).toBe(true);
-
-      // Defaults should still be present
-      const expected: ReplayInstrumentationOptions = {
-        recordCrossOriginIframes: false,
-        recordAfter: 'DOMContentLoaded',
-        maskAllInputs: false,
-        maskInputOptions: {
-          password: true,
-        },
-        maskInputFn: defaultMaskInputFn,
-        collectFonts: false,
-        inlineImages: false,
-        inlineStylesheet: false,
-        recordCanvas: true,
-        maskTextSelector: '*',
-        blockSelector: undefined,
-        ignoreSelector: undefined,
-        beforeSend: undefined,
-        sanitizeMetaHref: true,
-        samplingRate: 1,
-        inactivityThresholdMs: 60_000,
-      };
-
-      expect(instrumentation['options']).toEqual(expected);
-    });
+    await start();
+    expect(events().map((item) => item.payload.name)).toEqual([
+      'faro.session_recording.started',
+      'faro.session_recording.event',
+      'faro.session_recording.event',
+    ]);
+    expect(recordings().map((item) => [item['seq'], item['gen']])).toEqual([
+      ['0', '0'],
+      ['1', '0'],
+    ]);
   });
 
-  describe('maskInputFn', () => {
-    it('should produce identical-length output for inputs of different lengths', () => {
-      const short = defaultMaskInputFn('1234', document.createElement('input'));
-      const long = defaultMaskInputFn('4111111111111111card', document.createElement('input'));
-
-      expect(short).toBe('******');
-      expect(long).toBe('******');
-      expect(short.length).toBe(long.length);
-    });
-
-    it('should return an empty string for empty input', () => {
-      const empty = defaultMaskInputFn('', document.createElement('input'));
-      expect(empty).toBe('');
-    });
-
-    it('should use the default fixed-length maskInputFn when none is provided', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalledWith(
-        expect.objectContaining({
-          maskInputFn: defaultMaskInputFn,
-        })
-      );
-    });
-
-    it('should allow a custom maskInputFn to override the default', () => {
-      const customMaskFn: MaskInputFn = () => 'CUSTOM_MASK';
-
-      instrumentation = new ReplayInstrumentation({ maskInputFn: customMaskFn });
-
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalledWith(
-        expect.objectContaining({
-          maskInputFn: customMaskFn,
-        })
-      );
-      expect(instrumentation['options'].maskInputFn).not.toBe(defaultMaskInputFn);
-    });
-
-    it('should fall back to the secure default when maskInputFn is explicitly undefined', () => {
-      instrumentation = new ReplayInstrumentation({ maskInputFn: undefined });
-
-      expect(instrumentation['options'].maskInputFn).toBe(defaultMaskInputFn);
-    });
+  it('reserves immutable sequence and generation before reentrant serialization', async () => {
+    await start();
+    emit(metaEvent());
+    const outer = {
+      ...changeEvent('outer'),
+      toJSON: () => {
+        emit(metaEvent());
+        return changeEvent('outer');
+      },
+    };
+    emit(outer);
+    expect(recordings().map((item) => [item['seq'], item['gen']])).toEqual([
+      ['0', '0'],
+      ['2', '1'],
+      ['1', '0'],
+    ]);
   });
 
-  describe('initialize', () => {
-    it('should start recording when session is sampled', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockGetSession).toHaveBeenCalled();
-      expect(mockAddListener).toHaveBeenCalled();
-      expect(mockRecord).toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(true);
-    });
-
-    it('should not start recording when session is not sampled', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock unsampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'false' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockGetSession).toHaveBeenCalled();
-      expect(mockAddListener).toHaveBeenCalled();
-      expect(mockRecord).not.toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should pass default recordAfter option to rrweb record', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalledWith(
-        expect.objectContaining({
-          recordAfter: 'load',
-          maskAllInputs: true,
-          maskTextSelector: '*',
-        })
-      );
-    });
-
-    it('should pass correct options to rrweb record', () => {
-      const maskInputFn: MaskInputFn = jest.fn((text, _element) => '*'.repeat(text.length));
-      const customOptions: ReplayInstrumentationOptions = {
-        maskAllInputs: true,
-        blockSelector: '.secret',
-        recordCanvas: true,
-        collectFonts: true,
-        inlineImages: true,
-        inlineStylesheet: true,
-        recordCrossOriginIframes: true,
-        maskTextSelector: '.mask',
-        ignoreSelector: '.ignore',
-        maskInputOptions: { password: true, email: true },
-        maskInputFn,
-        recordAfter: 'DOMContentLoaded',
-      };
-
-      instrumentation = new ReplayInstrumentation(customOptions);
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalledWith(
-        expect.objectContaining({
-          maskAllInputs: true,
-          blockSelector: '.secret',
-          recordCanvas: true,
-          collectFonts: true,
-          inlineImages: true,
-          inlineStylesheet: true,
-          recordCrossOriginIframes: true,
-          maskTextSelector: '.mask',
-          ignoreSelector: '.ignore',
-          maskInputOptions: { password: true, email: true },
-          maskInputFn,
-          recordAfter: 'DOMContentLoaded',
-          recordDOM: true,
-          checkoutEveryNms: 300_000,
-        })
-      );
-    });
-
-    it('should push a faro.session_recording.started event when recording begins', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.started', {
-        recording_id: expect.any(String),
-      });
-    });
-
-    it('should not push a faro.session_recording.started event when session is not sampled', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'false' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockPushEvent).not.toHaveBeenCalled();
-    });
-
-    it('should handle errors during recording start gracefully', () => {
-      mockRecord.mockImplementation(() => {
-        throw new Error('rrweb init failed');
-      });
-
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-
-      expect(() => instrumentation.initialize()).not.toThrow();
-      expect(logWarnSpy).toHaveBeenCalledWith('Failed to start session replay', expect.any(Error));
-    });
+  it('leaves a sequence gap when an accepted Meta cannot be serialized', async () => {
+    await start();
+    emit(metaEvent());
+    const invalid = {
+      ...metaEvent(),
+      toJSON: () => {
+        throw new Error('serialization');
+      },
+    };
+    emit(invalid);
+    emit(changeEvent());
+    expect(recordings().map((item) => [item['seq'], item['gen']])).toEqual([
+      ['0', '0'],
+      ['2', '1'],
+    ]);
   });
 
-  describe('handleEvent', () => {
-    let emitCallback: (event: any, isCheckout?: boolean) => void;
-
-    beforeEach(() => {
-      mockRecord.mockImplementation((opts) => {
-        emitCallback = opts.emit;
-        return jest.fn();
-      });
-    });
-
-    it('should push events to the API', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
-      emitCallback(testEvent);
-
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
-        event: JSON.stringify(testEvent),
-        recording_id: expect.any(String),
-        gen: '0',
-        seq: '0',
-      });
-    });
-
-    it('should apply beforeSend transformation to events', () => {
-      const beforeSend = jest.fn((event) => ({ ...event, modified: true }));
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const testEvent = { type: 1, data: {}, timestamp: Date.now() };
-      emitCallback(testEvent);
-
-      expect(beforeSend).toHaveBeenCalledWith(testEvent);
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.event', {
-        event: JSON.stringify({ ...testEvent, modified: true }),
-        recording_id: expect.any(String),
-        gen: '0',
-        seq: '0',
-      });
-    });
-
-    it('should skip sending event if beforeSend returns null', () => {
-      const beforeSend = jest.fn(() => null);
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      emitCallback({ type: 1, data: {}, timestamp: Date.now() });
-
-      expect(beforeSend).toHaveBeenCalled();
-      expect(mockPushEvent).not.toHaveBeenCalledWith('faro.session_recording.event', expect.anything());
-    });
-
-    it('should skip sending event if beforeSend returns undefined', () => {
-      const beforeSend = jest.fn(() => undefined);
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      emitCallback({ type: 1, data: {}, timestamp: Date.now() });
-
-      expect(beforeSend).toHaveBeenCalled();
-      expect(mockPushEvent).not.toHaveBeenCalledWith('faro.session_recording.event', expect.anything());
-    });
-
-    it('should strip query string and fragment from Meta event href by default', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'https://example.com/app/dashboard?code=abc&token=xyz#fragment', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('https://example.com/app/dashboard');
-    });
-
-    it('should not modify non-Meta events', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const nonMetaEvent = {
-        type: 3,
-        data: { href: 'https://example.com/page?secret=value' },
-        timestamp: Date.now(),
-      };
-      emitCallback(nonMetaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('https://example.com/page?secret=value');
-    });
-
-    it('should preserve Meta event href when sanitizeMetaHref is false', () => {
-      instrumentation = new ReplayInstrumentation({ sanitizeMetaHref: false });
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'https://example.com/app?keep=this#and-this', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('https://example.com/app?keep=this#and-this');
-    });
-
-    it('should strip Meta event href before beforeSend sees the event', () => {
-      const beforeSend = jest.fn((event) => event);
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'https://example.com/path?token=secret', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      expect(beforeSend).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ href: 'https://example.com/path' }),
-        })
-      );
-    });
-
-    it('should strip Meta event href again after beforeSend returns a replacement event', () => {
-      const beforeSend: ReplayInstrumentationOptions['beforeSend'] = jest.fn(() => ({
-        type: EventType.Meta,
-        data: { href: 'https://example.com/reintroduced?token=secret#hash', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      })) as ReplayInstrumentationOptions['beforeSend'];
-
-      instrumentation = new ReplayInstrumentation({ beforeSend });
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'https://example.com/path?token=secret', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('https://example.com/reintroduced');
-    });
-
-    it('should strip credentials from Meta event href', () => {
-      instrumentation = new ReplayInstrumentation();
-      const hrefWithCredentials = new URL('https://example.com/app?token=secret#hash');
-      hrefWithCredentials.username = 'user';
-      hrefWithCredentials.password = 'password';
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: hrefWithCredentials.href, width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('https://example.com/app');
-    });
-
-    it('should leave malformed href untouched on Meta events', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'not-a-valid-url', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('not-a-valid-url');
-    });
-
-    it('should handle Meta event with missing href', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBeUndefined();
-    });
-
-    it('should leave malformed Meta event without data untouched', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed).toEqual(metaEvent);
-    });
-
-    it('should handle file:// URLs without corrupting them', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      const metaEvent = {
-        type: EventType.Meta,
-        data: { href: 'file:///android_asset/www/index.html?token=secret#hash', width: 1920, height: 1080 },
-        timestamp: Date.now(),
-      };
-      emitCallback(metaEvent);
-
-      const pushed = mockPushEvent.mock.calls.find((c: any[]) => c[0] === 'faro.session_recording.event');
-      const parsed = JSON.parse(pushed![1].event);
-      expect(parsed.data.href).toBe('file:///android_asset/www/index.html');
-    });
-
-    it('should keep Meta event href sanitized when batched after a non-replay event', async () => {
-      jest.useFakeTimers();
-      try {
-        const transport = new BatchedBodyTransport();
-        instrumentation = new ReplayInstrumentation();
-        const { api } = initializeFaro(
-          mockConfig({
-            instrumentations: [instrumentation],
-            transports: [transport],
-            metas: [{ page: { url: 'https://example.com/callback?code=abc#fragment' } }],
-            batching: {
-              enabled: true,
-              sendTimeout: 1,
-              itemLimit: 10,
-            },
-          })
-        );
-
-        api.setSession({ id: 'test-session', attributes: { isSampled: 'true' } });
-        // Listener-triggered starts are deferred by a microtask.
-        await Promise.resolve();
-        jest.advanceTimersByTime(1);
-        transport.sentBodies = [];
-
-        api.pushEvent('custom.event');
-        emitCallback({
-          type: EventType.Meta,
-          data: { href: 'https://example.com/app/dashboard?token=secret#hash', width: 1920, height: 1080 },
-          timestamp: Date.now(),
-        });
-        jest.advanceTimersByTime(1);
-
-        expect(transport.sentBodies).toHaveLength(1);
-        expect(transport.sentBodies[0]!.meta.page?.url).toBe('https://example.com/callback?code=abc#fragment');
-
-        const replayEvent = transport.sentBodies[0]!.events?.find(
-          (event) => event.name === 'faro.session_recording.event'
-        );
-        expect(replayEvent).toBeDefined();
-
-        const replayEventPayload = replayEvent!.attributes!['event'];
-        expect(replayEventPayload).toBeDefined();
-
-        const rrwebEvent = JSON.parse(replayEventPayload!);
-        expect(rrwebEvent.data.href).toBe('https://example.com/app/dashboard');
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('should handle errors when pushing events gracefully', () => {
-      mockPushEvent.mockImplementation((eventName: string) => {
-        if (eventName === 'faro.session_recording.event') {
-          throw new Error('Push failed');
-        }
-      });
-
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { pushEvent: mockPushEvent, getSession: mockGetSession } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-      instrumentation.initialize();
-
-      expect(() => emitCallback({ type: 1, data: {}, timestamp: Date.now() })).not.toThrow();
-      expect(logWarnSpy).toHaveBeenCalledWith('Failed to push faro.session_recording.event event', expect.any(Error));
-    });
+  it.each([null, undefined])('allows Replay filters to drop snapshots without consuming counters: %s', async (drop) => {
+    await start({ beforeSend: (event) => (event.type === EventType.Meta ? drop : event) });
+    emit(metaEvent());
+    emit(changeEvent());
+    expect(recordings().map((item) => [item['seq'], item['gen']])).toEqual([['0', '0']]);
   });
 
-  describe('delivery identity', () => {
-    let emitCallback: (event: any, isCheckout?: boolean) => void;
-    let metaListener: (() => void) | undefined;
-
-    beforeEach(() => {
-      mockRecord.mockImplementation((opts: any) => {
-        emitCallback = opts.emit;
-        return jest.fn();
-      });
-      metaListener = undefined;
-      mockAddListener.mockImplementation((cb: () => void) => {
-        metaListener = cb;
-      });
-    });
-
-    function replayAttributes(): Array<Record<string, string>> {
-      return mockPushEvent.mock.calls
-        .filter((call: any[]) => call[0] === 'faro.session_recording.event')
-        .map((call: any[]) => call[1]);
-    }
-
-    function lifecycleAttributes(eventName: string): Array<Record<string, string>> {
-      return mockPushEvent.mock.calls.filter((call: any[]) => call[0] === eventName).map((call: any[]) => call[1]);
-    }
-
-    function metaEvent() {
-      return {
-        type: EventType.Meta,
-        data: { href: 'https://example.com/', width: 1, height: 1 },
-        timestamp: Date.now(),
-      };
-    }
-
-    function fullSnapshotEvent() {
-      return { type: EventType.FullSnapshot, data: {}, timestamp: Date.now() };
-    }
-
-    function incrementalEvent(data: Record<string, unknown> = {}) {
-      return { type: EventType.IncrementalSnapshot, data, timestamp: Date.now() };
-    }
-
-    it.each([
-      ['session-b', 'true'],
-      ['test-session', 'false'],
-    ])('discards an event invalidated inside beforeSend (%s, %s)', async (id, isSampled) => {
-      let rotate = false;
-      instrumentation = initSampled({
-        beforeSend: (event) => {
-          if (rotate) {
-            mockGetSession.mockReturnValue({ id, attributes: { isSampled } });
-            metaListener!();
-          }
-          return event;
-        },
-      });
-      emitCallback(metaEvent());
-      const original = replayAttributes()[0]!;
-      rotate = true;
-      emitCallback(metaEvent());
-      expect(replayAttributes()).toEqual([original]);
-      rotate = false;
-      await Promise.resolve();
-      if (isSampled === 'true') {
-        emitCallback(metaEvent());
-        expect(replayAttributes()[1]).toMatchObject({ seq: '0', gen: '0' });
-        expect(replayAttributes()[1]!['recording_id']).not.toBe(original['recording_id']);
-      }
-    });
-
-    it('exposes an unserializable accepted Meta as a gap in the new generation', () => {
-      instrumentation = initSampled();
-      emitCallback(metaEvent());
-      emitCallback(fullSnapshotEvent());
-      const circular: Record<string, unknown> = {};
-      circular['self'] = circular;
-      emitCallback({ ...metaEvent(), data: circular });
-      emitCallback(fullSnapshotEvent());
-      expect(replayAttributes().map((attrs) => [attrs['seq'], attrs['gen']])).toEqual([
-        ['0', '0'],
-        ['1', '0'],
-        ['3', '1'],
-      ]);
-    });
-
-    it('stamps an event with the gen captured before serialization re-enters with a later Meta', () => {
-      instrumentation = initSampled({
-        beforeSend: (event: any) =>
-          event.data?.['reenter'] === true
-            ? {
-                ...event,
-                data: {
-                  toJSON: () => {
-                    emitCallback(metaEvent());
-                    return { reentered: true };
-                  },
-                },
-              }
-            : event,
-      });
-
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent({ reenter: true }));
-
-      // The nested Meta is pushed before the outer event finishes, but the outer event was
-      // accepted first and must keep the generation that was open when it reserved its seq.
-      expect(replayAttributes().map((attrs) => [JSON.parse(attrs['event']!).type, attrs['seq'], attrs['gen']])).toEqual(
-        [
-          [EventType.Meta, '0', '0'],
-          [EventType.Meta, '2', '1'],
-          [EventType.IncrementalSnapshot, '1', '0'],
-        ]
-      );
-    });
-
-    it('should stamp events with a stable recording_id, gen 0, and a contiguous seq', () => {
-      instrumentation = initSampled();
-
-      emitCallback(metaEvent());
-      emitCallback(fullSnapshotEvent());
-      emitCallback(incrementalEvent());
-      emitCallback(incrementalEvent());
-
-      const attrs = replayAttributes();
-      expect(attrs).toHaveLength(4);
-
-      const recordingId = attrs[0]!['recording_id'];
-      expect(recordingId).toEqual(expect.any(String));
-      expect(recordingId!.length).toBeGreaterThan(0);
-      expect(attrs.every((a) => a['recording_id'] === recordingId)).toBe(true);
-
-      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0', '0']);
-      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3']);
-    });
-
-    it('should advance gen on each emitted Meta and keep seq contiguous across the checkout', () => {
-      instrumentation = initSampled();
-
-      emitCallback(metaEvent());
-      emitCallback(fullSnapshotEvent());
-      emitCallback(incrementalEvent());
-
-      // A scheduled checkout emits Meta and FullSnapshot, both flagged isCheckout=true.
-      // The flag must be irrelevant: only the Meta event advances gen.
-      emitCallback(metaEvent(), true);
-      emitCallback(fullSnapshotEvent(), true);
-      emitCallback(incrementalEvent());
-
-      const attrs = replayAttributes();
-      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0', '1', '1', '1']);
-      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3', '4', '5']);
-    });
-
-    it('should not advance gen or consume seq for events dropped by beforeSend', () => {
-      instrumentation = initSampled({
-        beforeSend: (event: any) => (event.data?.['drop'] === true ? null : event),
-      });
-
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent({ drop: true }));
-      emitCallback(incrementalEvent());
-      emitCallback({ ...metaEvent(), data: { drop: true } });
-      emitCallback(incrementalEvent());
-
-      const attrs = replayAttributes();
-      expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '0']);
-      expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2']);
-    });
-
-    it('should keep identity attributes intact when beforeSend mutates the event', () => {
-      instrumentation = initSampled({
-        beforeSend: (event: any) => ({ ...event, data: { mutated: true } }),
-      });
-
-      emitCallback(incrementalEvent({ original: true }));
-
-      const attrs = replayAttributes();
-      expect(attrs).toHaveLength(1);
-      expect(JSON.parse(attrs[0]!['event']!).data).toEqual({ mutated: true });
-      expect(attrs[0]!['recording_id']).toEqual(expect.any(String));
-      expect(attrs[0]!['gen']).toBe('0');
-      expect(attrs[0]!['seq']).toBe('0');
-    });
-
-    it('should increment gen with no seq gap across an inactivity pause and resume', () => {
-      jest.useFakeTimers();
-      try {
-        instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-
-        emitCallback(metaEvent());
-        emitCallback(fullSnapshotEvent());
-
-        jest.advanceTimersByTime(5_000);
-        expect(instrumentation['isPaused']).toBe(true);
-
-        document.dispatchEvent(new Event('pointerdown'));
-        expect(instrumentation['isPaused']).toBe(false);
-
-        // The resume restarted rrweb; drive its fresh snapshot through the new emit.
-        emitCallback(metaEvent());
-        emitCallback(fullSnapshotEvent());
-
-        const attrs = replayAttributes();
-        expect(attrs.map((a) => a['gen'])).toEqual(['0', '0', '1', '1']);
-        expect(attrs.map((a) => a['seq'])).toEqual(['0', '1', '2', '3']);
-        expect(new Set(attrs.map((a) => a['recording_id'])).size).toBe(1);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('should stamp lifecycle events with recording_id and no gen or seq', () => {
-      jest.useFakeTimers();
-      try {
-        instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-
-        jest.advanceTimersByTime(5_000);
-        document.dispatchEvent(new Event('pointerdown'));
-
-        for (const eventName of [
-          'faro.session_recording.started',
-          'faro.session_recording.paused',
-          'faro.session_recording.resumed',
-        ]) {
-          const attrs = lifecycleAttributes(eventName);
-          expect(attrs.length).toBeGreaterThan(0);
-          for (const a of attrs) {
-            expect(a['recording_id']).toEqual(expect.any(String));
-            expect(a).not.toHaveProperty('gen');
-            expect(a).not.toHaveProperty('seq');
-          }
-        }
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('should mint a new recording_id and reset gen and seq when the session rotates', async () => {
-      instrumentation = initSampled({}, 'session-a');
-
-      emitCallback(metaEvent());
-      const firstRecordingId = replayAttributes()[0]!['recording_id'];
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-      metaListener!();
-
-      // The stop is synchronous; the restart is deferred out of the listener call stack.
-      expect(instrumentation['isRecording']).toBe(false);
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(instrumentation['isRecording']).toBe(true);
-
-      const startedAttrs = lifecycleAttributes('faro.session_recording.started');
-      expect(startedAttrs).toHaveLength(2);
-      expect(startedAttrs[1]!['recording_id']).not.toBe(startedAttrs[0]!['recording_id']);
-
-      emitCallback(metaEvent());
-      const attrs = replayAttributes();
-      const rotatedEvent = attrs[attrs.length - 1]!;
-      expect(rotatedEvent['recording_id']).not.toBe(firstRecordingId);
-      expect(rotatedEvent['gen']).toBe('0');
-      expect(rotatedEvent['seq']).toBe('0');
-    });
-
-    it('should ignore the transient no-session notification from setSession', async () => {
-      instrumentation = initSampled();
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-
-      // Core setSession removes the session meta before re-adding it, so listeners
-      // transiently observe a state with no session.
-      mockGetSession.mockReturnValue(undefined);
-      metaListener!();
-
-      expect(instrumentation['isRecording']).toBe(true);
-
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
-      metaListener!();
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(1);
-    });
-
-    it('should not restart recording when a session notification carries an unchanged id', async () => {
-      instrumentation = initSampled();
-
-      metaListener!();
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(1);
-    });
-
-    it('should coalesce a burst of rotations into one restart bound to the latest session', async () => {
-      instrumentation = initSampled({}, 'session-a');
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-      metaListener!();
-      mockGetSession.mockReturnValue({ id: 'session-c', attributes: { isSampled: 'true' } });
-      metaListener!();
-
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(2);
-
-      // The recording is bound to the latest session: another session-c notification
-      // is a no-op.
-      metaListener!();
-      await Promise.resolve();
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(2);
-    });
-
-    it('should keep recording identity when sampling flips off and back on for the same session', async () => {
-      instrumentation = initSampled();
-      const firstStarted = lifecycleAttributes('faro.session_recording.started')[0]!;
-      emitCallback(metaEvent());
-
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'false' } });
-      metaListener!();
-      expect(instrumentation['isRecording']).toBe(false);
-
-      mockGetSession.mockReturnValue({ id: 'test-session', attributes: { isSampled: 'true' } });
-      metaListener!();
-      await Promise.resolve();
-
-      const started = lifecycleAttributes('faro.session_recording.started');
-      expect(started).toHaveLength(2);
-      expect(started[1]!['recording_id']).toBe(firstStarted['recording_id']);
-
-      emitCallback(metaEvent());
-      const attrs = replayAttributes();
-      const latest = attrs[attrs.length - 1]!;
-      expect(latest['recording_id']).toBe(started[1]!['recording_id']);
-      expect(latest['gen']).toBe('1');
-      expect(latest['seq']).toBe('1');
-    });
-
-    it('should stop a deferred start when sampling flips off while it is starting', async () => {
-      const initialStop = jest.fn();
-      const restartedStop = jest.fn();
-      mockRecord.mockReturnValueOnce(initialStop).mockReturnValueOnce(restartedStop);
-      instrumentation = initSampled({}, 'session-a');
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-      metaListener!();
-      expect(initialStop).toHaveBeenCalledTimes(1);
-
-      let samplingFlipTriggered = false;
-      mockPushEvent.mockImplementation((eventName: string) => {
-        if (eventName === 'faro.session_recording.started' && !samplingFlipTriggered) {
-          samplingFlipTriggered = true;
-          mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'false' } });
-          metaListener!();
-        }
-      });
-
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(restartedStop).toHaveBeenCalledTimes(1);
-    });
-
-    it('should clear recording state when the rrweb stop function throws', () => {
-      const stopError = new Error('rrweb stop failed');
-      mockRecord.mockReturnValueOnce(
-        jest.fn(() => {
-          throw stopError;
-        })
-      );
-      instrumentation = initSampled();
-      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'false' } });
-
-      expect(() => metaListener!()).not.toThrow();
-      expect(instrumentation['isRecording']).toBe(false);
-      expect(instrumentation['stopFn']).toBeNull();
-      expect(logWarnSpy).toHaveBeenCalledWith('Failed to stop session replay', stopError);
-    });
-
-    it.each([
-      ['a sampled new session', 'session-b', 'true', 2],
-      ['an unsampled new session', 'session-b', 'false', 1],
-      ['the same session becoming unsampled', 'session-a', 'false', 1],
-    ])(
-      'should reconcile an initial started-event rotation to %s',
-      async (_scenario, nextSessionId, isSampled, expectedStarts) => {
-        const stops: jest.Mock[] = [];
-        mockRecord.mockImplementation(() => {
-          const stop = jest.fn();
-          stops.push(stop);
-          return stop;
-        });
-
-        let rotationTriggered = false;
-        mockPushEvent.mockImplementation((eventName: string) => {
-          if (eventName === 'faro.session_recording.started' && !rotationTriggered) {
-            rotationTriggered = true;
-            mockGetSession.mockReturnValue({ id: nextSessionId, attributes: { isSampled } });
-            metaListener!();
-          }
-        });
-
-        instrumentation = initSampled({}, 'session-a');
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(stops[0]).toHaveBeenCalledTimes(1);
-        expect(mockRecord).toHaveBeenCalledTimes(expectedStarts);
-        if (expectedStarts === 2) {
-          expect(stops[1]).not.toHaveBeenCalled();
-        }
-      }
-    );
-
-    it('should restart with a new recording id when the session rotates while paused', async () => {
-      jest.useFakeTimers();
-      try {
-        instrumentation = initSampled({ inactivityThresholdMs: 5_000 }, 'session-a');
-        emitCallback(metaEvent());
-
-        jest.advanceTimersByTime(5_000);
-        expect(instrumentation['isPaused']).toBe(true);
-
-        mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-        metaListener!();
-        await Promise.resolve();
-
-        expect(instrumentation['isPaused']).toBe(false);
-        const started = lifecycleAttributes('faro.session_recording.started');
-        expect(started).toHaveLength(2);
-        expect(started[1]!['recording_id']).not.toBe(started[0]!['recording_id']);
-
-        emitCallback(metaEvent());
-        const attrs = replayAttributes();
-        expect(attrs[attrs.length - 1]!['recording_id']).toBe(started[1]!['recording_id']);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('should stop recording when the session is deliberately cleared', () => {
-      instrumentation = initSampled();
-      expect(instrumentation['isRecording']).toBe(true);
-
-      // resetSession()/setSession(undefined) re-adds a session meta WITHOUT an id —
-      // unlike the transient mid-rotation state, where no session meta exists at all.
-      mockGetSession.mockReturnValue({});
-      metaListener!();
-
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should not restart recording after destroy even with a pending start', async () => {
-      instrumentation = initSampled({}, 'session-a');
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-      metaListener!();
-      instrumentation.destroy();
-
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should emit no started marker for a declined start and one ordered marker when retry succeeds', async () => {
-      const successfulStop = jest.fn();
-      mockRecord
-        .mockImplementationOnce(() => undefined)
-        .mockImplementationOnce((opts: any) => {
-          emitCallback = opts.emit;
-          opts.emit(metaEvent());
-          return successfulStop;
-        });
-
-      instrumentation = initSampled();
-
-      expect(lifecycleAttributes('faro.session_recording.started')).toHaveLength(0);
-      expect(replayAttributes()).toHaveLength(0);
-
-      metaListener!();
-      await Promise.resolve();
-
-      const names = mockPushEvent.mock.calls.map((call: any[]) => call[0]);
-      expect(names).toEqual(['faro.session_recording.started', 'faro.session_recording.event']);
-      expect(successfulStop).not.toHaveBeenCalled();
-    });
-
-    it.each([0, 2])(
-      'should emit one resumed marker before the fresh snapshot after %s declined attempts',
-      (declinedAttempts) => {
-        jest.useFakeTimers();
-        try {
-          instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-          jest.advanceTimersByTime(5_000);
-          mockPushEvent.mockClear();
-
-          for (let attempt = 0; attempt < declinedAttempts; attempt++) {
-            mockRecord.mockReturnValueOnce(undefined);
-            document.dispatchEvent(new Event('pointerdown'));
-            expect(mockPushEvent).not.toHaveBeenCalled();
-          }
-          mockRecord.mockImplementationOnce((opts: { emit: (event: unknown) => void }) => {
-            // rrweb can emit its fresh snapshot synchronously inside record().
-            opts.emit(metaEvent());
-            return jest.fn();
-          });
-          document.dispatchEvent(new Event('pointerdown'));
-
-          expect(mockPushEvent.mock.calls.map((call) => call[0])).toEqual([
-            'faro.session_recording.resumed',
-            'faro.session_recording.event',
-          ]);
-        } finally {
-          jest.useRealTimers();
-        }
-      }
-    );
-
-    it('should mint distinct recording ids for two concurrent instances', () => {
-      const emits: Array<(event: any, isCheckout?: boolean) => void> = [];
-      mockRecord.mockImplementation((opts: any) => {
-        emits.push(opts.emit);
-        return jest.fn();
-      });
-
-      instrumentation = initSampled();
-      const secondInstrumentation = initSampled();
-
-      try {
-        emits[0]!(metaEvent());
-        emits[1]!(metaEvent());
-
-        const attrs = replayAttributes();
-        expect(attrs).toHaveLength(2);
-        expect(attrs[0]!['recording_id']).not.toBe(attrs[1]!['recording_id']);
-        expect(attrs.map((a) => a['seq'])).toEqual(['0', '0']);
-      } finally {
-        secondInstrumentation.destroy();
-      }
-    });
-
-    it('should deliver the new recording events when a rotation is detected mid-flush', async () => {
-      jest.useFakeTimers();
-      try {
-        const transport = new BatchedBodyTransport();
-        instrumentation = new ReplayInstrumentation();
-
-        let rotated = false;
-        const { api } = initializeFaro(
-          mockConfig({
-            instrumentations: [instrumentation],
-            transports: [transport],
-            batching: {
-              enabled: true,
-              sendTimeout: 1,
-              itemLimit: 10,
-            },
-            // Simulates the session instrumentation's transport hook rotating the
-            // session while the batch executor is flushing: items pushed synchronously
-            // during a flush are discarded by the executor's buffer reset.
-            beforeSend: (item) => {
-              if (!rotated) {
-                rotated = true;
-                api.setSession({ id: 'rotated-session', attributes: { isSampled: 'true' } });
-              }
-              return item;
-            },
-          })
-        );
-
-        api.setSession({ id: 'first-session', attributes: { isSampled: 'true' } });
-        await Promise.resolve();
-        expect(mockRecord).toHaveBeenCalledTimes(1);
-
-        // First flush: sends the first recording's started event and triggers the
-        // rotation from inside the flush.
-        jest.advanceTimersByTime(1);
-        const firstStarted = transport.sentBodies
-          .flatMap((body) => body.events ?? [])
-          .find((event) => event.name === 'faro.session_recording.started');
-        expect(firstStarted).toBeDefined();
-        transport.sentBodies = [];
-
-        // The restart is deferred out of the flush call stack, so the new recording's
-        // events land in the next batch instead of being wiped.
-        await Promise.resolve();
-        expect(mockRecord).toHaveBeenCalledTimes(2);
-
-        emitCallback({
-          type: EventType.Meta,
-          data: { href: 'https://example.com/', width: 1, height: 1 },
-          timestamp: Date.now(),
-        });
-        emitCallback({ type: EventType.FullSnapshot, data: {}, timestamp: Date.now() });
-        jest.advanceTimersByTime(1);
-
-        const sentEvents = transport.sentBodies.flatMap((body) => body.events ?? []);
-        const started = sentEvents.find((event) => event.name === 'faro.session_recording.started');
-        const replayEvents = sentEvents.filter((event) => event.name === 'faro.session_recording.event');
-
-        expect(started).toBeDefined();
-        expect(started!.attributes!['recording_id']).not.toBe(firstStarted!.attributes!['recording_id']);
-        expect(replayEvents).toHaveLength(2);
-        expect(
-          replayEvents.every((event) => event.attributes!['recording_id'] === started!.attributes!['recording_id'])
-        ).toBe(true);
-        expect(replayEvents.map((event) => event.attributes!['gen'])).toEqual(['0', '0']);
-        expect(replayEvents.map((event) => event.attributes!['seq'])).toEqual(['0', '1']);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it('should continue recording identity across a clean full-page navigation', () => {
-      window.sessionStorage.clear();
-      const firstInstrumentation = initSampled({}, 'session-a');
-
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent());
-      const firstPageEvents = replayAttributes();
-      const recordingId = firstPageEvents[0]!['recording_id'];
-
-      window.dispatchEvent(new Event('pagehide'));
-      firstInstrumentation.destroy();
-      mockPushEvent.mockClear();
-
-      instrumentation = initSampled({}, 'session-a');
-      expect(lifecycleAttributes('faro.session_recording.started')).toEqual([
-        expect.objectContaining({ recording_id: recordingId }),
-      ]);
-      emitCallback(metaEvent());
-
-      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
-    });
-
-    it('should mint a recovery recording instead of reusing an active handoff', () => {
-      const firstDocument = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      const firstRecordingId = replayAttributes()[0]!['recording_id'];
-      mockPushEvent.mockClear();
-
-      instrumentation = initSampled({}, 'session-a');
-      try {
-        emitCallback(metaEvent());
-
-        expect(replayAttributes()).toEqual([expect.objectContaining({ gen: '0', seq: '0' })]);
-        expect(replayAttributes()[0]!['recording_id']).not.toBe(firstRecordingId);
-      } finally {
-        firstDocument.destroy();
-      }
-    });
-
-    it('should not write recording state while assigning replay event identity', () => {
-      window.sessionStorage.clear();
-      const storageSpy = jest.spyOn(Storage.prototype, 'setItem');
-      instrumentation = initSampled({}, 'session-a');
-      storageSpy.mockClear();
-
-      emitCallback(metaEvent());
-      for (let i = 0; i < 100; i++) {
-        emitCallback(incrementalEvent());
-      }
-
-      expect(storageSpy).not.toHaveBeenCalled();
-    });
-
-    it('should rehydrate the latest clean handoff when restored from BFCache', () => {
-      window.sessionStorage.clear();
-      const firstDocument = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      const recordingId = replayAttributes()[0]!['recording_id'];
-      window.dispatchEvent(new Event('pagehide'));
-
-      const secondDocument = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent());
-      window.dispatchEvent(new Event('pagehide'));
-      secondDocument.destroy();
-
-      instrumentation = firstDocument;
-      mockPushEvent.mockClear();
-      const pageShowEvent = new Event('pageshow');
-      Object.defineProperty(pageShowEvent, 'persisted', { value: true });
-      window.dispatchEvent(pageShowEvent);
-      emitCallback(metaEvent());
-
-      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '2', seq: '3' })]);
-    });
-
-    it('should not run a pending session restart after pagehide seals the recording', async () => {
-      window.sessionStorage.clear();
-      instrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-
-      mockGetSession.mockReturnValue({ id: 'session-b', attributes: { isSampled: 'true' } });
-      metaListener!();
-      window.dispatchEvent(new Event('pagehide'));
-      await Promise.resolve();
-
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not run a pending initial start after pagehide', async () => {
-      mockGetSession.mockReturnValue({ id: 'session-a', attributes: { isSampled: 'false' } });
-      instrumentation = new ReplayInstrumentation();
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-      instrumentation.initialize();
-
-      mockGetSession.mockReturnValue({ id: 'session-a', attributes: { isSampled: 'true' } });
-      instrumentation['metasListener']();
-      window.dispatchEvent(new Event('pagehide'));
-      await Promise.resolve();
-
-      expect(mockRecord).not.toHaveBeenCalled();
-    });
-
-    it('should not force an rrweb checkpoint for SPA navigation', () => {
-      instrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      emitCallback(fullSnapshotEvent());
-
-      window.history.pushState({}, '', '/spa-navigation');
-
-      expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-      const attrs = replayAttributes();
-      expect(attrs.map((event) => event['gen'])).toEqual(['0', '0']);
-      expect(attrs.map((event) => event['seq'])).toEqual(['0', '1']);
-    });
-
-    it('should reconcile rotations after the same instance is removed and re-added', async () => {
-      instrumentation = new ReplayInstrumentation();
-      const faro = initializeFaro(
-        mockConfig({
-          instrumentations: [instrumentation],
-          batching: { enabled: false },
-        })
-      );
-
-      try {
-        faro.api.setSession({ id: 'session-a', attributes: { isSampled: 'true' } });
-        await Promise.resolve();
-        expect(mockRecord).toHaveBeenCalledTimes(1);
-
-        faro.instrumentations.remove(instrumentation);
-        faro.instrumentations.add(instrumentation);
-        expect(mockRecord).toHaveBeenCalledTimes(2);
-
-        faro.api.setSession({ id: 'session-b', attributes: { isSampled: 'true' } });
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(mockRecord).toHaveBeenCalledTimes(3);
-      } finally {
-        faro.instrumentations.remove(instrumentation);
-      }
-    });
-
-    it('should continue recording identity when the instance is replaced in the same document', () => {
-      window.sessionStorage.clear();
-      const firstInstrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent());
-      const recordingId = replayAttributes()[0]!['recording_id'];
-
-      firstInstrumentation.destroy();
-      mockPushEvent.mockClear();
-      instrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-
-      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
-    });
-
-    it('should continue recording identity across a same-document replacement when localStorage writes fail', () => {
-      window.sessionStorage.clear();
-      const originalSetItem = Storage.prototype.setItem;
-      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
-        if (this === window.localStorage) {
-          throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
-        }
-        originalSetItem.call(this, key, value);
-      });
-
-      const firstInstrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-      emitCallback(incrementalEvent());
-      const recordingId = replayAttributes()[0]!['recording_id'];
-      firstInstrumentation.destroy();
-      mockPushEvent.mockClear();
-
-      instrumentation = initSampled({}, 'session-a');
-      emitCallback(metaEvent());
-
-      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '1', seq: '2' })]);
-      expect(window.localStorage.length).toBe(0);
-    });
-
-    it.each([
-      { handoff: 'active', pointerWrites: 'available' },
-      { handoff: 'clean', pointerWrites: 'available' },
-      { handoff: 'clean', pointerWrites: 'blocked' },
-      { handoff: 'clean', pointerWrites: 'recover' },
-    ])(
-      'should abandon a foreign $handoff checkpoint across replacement (pointer writes: $pointerWrites)',
-      ({ handoff, pointerWrites }) => {
-        instrumentation = initSampled({}, 'session-a');
-        const ownerNamespace = instrumentation['recordingOwnerNamespace'];
-        emitCallback(metaEvent());
-        emitCallback(incrementalEvent());
-        emitCallback(metaEvent());
-        emitCallback(fullSnapshotEvent());
-        const recordingId = replayAttributes()[0]!['recording_id'];
-        const key = `${replayRecordingCheckpointKeyPrefix}${ownerNamespace}:${recordingId}`;
-        const foreignClaim = {
-          ...JSON.parse(window.localStorage.getItem(key)!),
-          documentId: 'other-document',
-          handoff,
-          nextSeq: 1,
-          gen: 0,
-        };
-        window.localStorage.setItem(key, JSON.stringify(foreignClaim));
-        let blockPointerWrites = pointerWrites !== 'available';
-        if (blockPointerWrites) {
-          const originalSetItem = Storage.prototype.setItem;
-          jest.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
-            if (blockPointerWrites && this === window.sessionStorage) {
-              throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
-            }
-            originalSetItem.call(this, key, value);
-          });
-        }
-        mockPushEvent.mockClear();
-
-        window.dispatchEvent(
-          new StorageEvent('storage', { key, newValue: JSON.stringify(foreignClaim), storageArea: window.localStorage })
-        );
-        emitCallback(metaEvent());
-        const recoveryRecordingId = replayAttributes()[0]!['recording_id'];
-        expect(recoveryRecordingId).not.toBe(recordingId);
-        expect(replayAttributes()).toEqual([
-          expect.objectContaining({ recording_id: recoveryRecordingId, gen: '0', seq: '0' }),
-        ]);
-        expect(lifecycleAttributes('faro.session_recording.started')).toEqual([
-          expect.objectContaining({ recording_id: recoveryRecordingId }),
-        ]);
-        expect(JSON.parse(window.localStorage.getItem(key)!)).toEqual(foreignClaim);
-
-        instrumentation.destroy();
-        blockPointerWrites = pointerWrites === 'blocked';
-        mockPushEvent.mockClear();
-        instrumentation = initSampled({}, 'session-a');
-        emitCallback(metaEvent());
-        expect(replayAttributes()).toEqual([
-          expect.objectContaining({ recording_id: recoveryRecordingId, gen: '1', seq: '1' }),
-        ]);
-        window.dispatchEvent(new Event('pagehide'));
-        if (!blockPointerWrites) {
-          // Navigation has no same-document handoff: it must use the repaired pointer.
-          instrumentation.destroy();
-          mockPushEvent.mockClear();
-          instrumentation = initSampled({}, 'session-a');
-          emitCallback(metaEvent());
-          expect(replayAttributes()).toEqual([
-            expect.objectContaining({ recording_id: recoveryRecordingId, gen: '2', seq: '2' }),
-          ]);
-        }
-        expect(JSON.parse(window.localStorage.getItem(key)!)).toEqual(foreignClaim);
-      }
-    );
-
-    it.each([
-      ['a removal of its checkpoint', (key: string) => ({ key, newValue: null })],
-      ['another recording checkpoint', (key: string) => ({ key: `${key}-other`, newValue: '{"documentId":"x"}' })],
-      ['a write under its own document', (key: string) => ({ key, newValue: window.localStorage.getItem(key) })],
-    ])('should keep recording on a storage event for %s', (_scenario, makeEvent) => {
-      window.sessionStorage.clear();
-      instrumentation = initSampled({}, 'session-a');
-      const ownerNamespace = instrumentation['recordingOwnerNamespace'];
-      emitCallback(metaEvent());
-      const recordingId = replayAttributes()[0]!['recording_id'];
-      const key = `${replayRecordingCheckpointKeyPrefix}${ownerNamespace}:${recordingId}`;
-      mockPushEvent.mockClear();
-
-      window.dispatchEvent(new StorageEvent('storage', { ...makeEvent(key), storageArea: window.localStorage }));
-      emitCallback(incrementalEvent());
-
-      expect(lifecycleAttributes('faro.session_recording.started')).toEqual([]);
-      expect(replayAttributes()).toEqual([expect.objectContaining({ recording_id: recordingId, gen: '0', seq: '1' })]);
-    });
-  });
-
-  describe('destroy', () => {
-    it('should stop recording and clean up when destroyed', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = new ReplayInstrumentation();
-
-      // Mock sampled session
-      mockGetSession.mockReturnValue({
-        id: 'test-session',
-        attributes: { isSampled: 'true' },
-      });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(instrumentation['isRecording']).toBe(true);
-
-      instrumentation.destroy();
-
-      expect(stopFn).toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
-      expect(instrumentation['stopFn']).toBeNull();
-    });
-
-    it('should handle destroy when not recording', () => {
-      instrumentation = new ReplayInstrumentation();
-
-      expect(() => instrumentation.destroy()).not.toThrow();
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-  });
-
-  describe('inactivity tracking', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    it('should pause recording after inactivity threshold elapses', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-      expect(instrumentation['isPaused']).toBe(false);
-
-      jest.advanceTimersByTime(5_000);
-
-      expect(stopFn).toHaveBeenCalled();
-      expect(instrumentation['isPaused']).toBe(true);
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.paused', {
-        recording_id: expect.any(String),
-      });
-    });
-
-    it('should resume recording with a fresh checkpoint when user interacts after pause', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-
-      jest.advanceTimersByTime(5_000);
-      expect(instrumentation['isPaused']).toBe(true);
-      expect(mockRecord).toHaveBeenCalledTimes(1);
-
-      mockRecord.mockReturnValue(jest.fn());
+  it('keeps the lease across inactivity, coalesces overlapping resumes, and emits every completed transition', async () => {
+    await start({ inactivityThresholdMs: 1000 });
+    emit(metaEvent());
+    const id = recordings()[0]!['recording_id'];
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+    expect((await navigator.locks.query()).held).toEqual([
+      { name: recordingLockName(namespace, id!), mode: 'exclusive' },
+    ]);
+    mockRecord.mockImplementationOnce((options) => {
       document.dispatchEvent(new Event('pointerdown'));
-
-      expect(instrumentation['isPaused']).toBe(false);
-      expect(mockRecord).toHaveBeenCalledTimes(2);
-      expect(mockPushEvent).toHaveBeenCalledWith('faro.session_recording.resumed', {
-        recording_id: expect.any(String),
-      });
+      options.emit(metaEvent());
+      const stop = jest.fn();
+      attempts.push({ options, stop });
+      return stop;
     });
-
-    it('should not pause when inactivityThresholdMs is 0', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = initSampled({ inactivityThresholdMs: 0 });
-
-      jest.advanceTimersByTime(120_000);
-
-      expect(instrumentation['isPaused']).toBe(false);
-      expect(stopFn).not.toHaveBeenCalled();
-    });
-
-    it('should not pause when inactivityThresholdMs is undefined', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = initSampled({ inactivityThresholdMs: undefined });
-
-      jest.advanceTimersByTime(120_000);
-
-      expect(instrumentation['isPaused']).toBe(false);
-      expect(stopFn).not.toHaveBeenCalled();
-    });
-
-    it('should remove DOM listeners on stopRecording', () => {
-      const removeSpy = jest.spyOn(document, 'removeEventListener');
-
-      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-      instrumentation.destroy();
-
-      const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
-      expect(removedEvents).toContain('pointermove');
-      expect(removedEvents).toContain('pointerdown');
-      expect(removedEvents).toContain('scroll');
-      expect(removedEvents).toContain('keydown');
-      expect(removedEvents).toContain('input');
-    });
-
-    it('should keep DOM listeners attached across pauseRecording', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-      const removeSpy = jest.spyOn(document, 'removeEventListener');
-
-      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-
-      jest.advanceTimersByTime(5_000);
-      expect(instrumentation['isPaused']).toBe(true);
-
-      const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
-      expect(removedEvents).not.toContain('pointermove');
-      expect(removedEvents).not.toContain('pointerdown');
-
-      mockRecord.mockReturnValue(jest.fn());
-      document.dispatchEvent(new Event('scroll'));
-      expect(instrumentation['isPaused']).toBe(false);
-    });
-
-    it('should reset the inactivity timer on user interaction', () => {
-      const stopFn = jest.fn();
-      mockRecord.mockReturnValue(stopFn);
-
-      instrumentation = initSampled({ inactivityThresholdMs: 5_000 });
-
-      jest.advanceTimersByTime(4_000);
-      document.dispatchEvent(new Event('keydown'));
-
-      jest.advanceTimersByTime(4_000);
-      expect(instrumentation['isPaused']).toBe(false);
-
-      jest.advanceTimersByTime(1_000);
-      expect(instrumentation['isPaused']).toBe(true);
-    });
+    document.dispatchEvent(new Event('pointerdown'));
+    document.dispatchEvent(new Event('input'));
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(recordings().map((item) => [item['recording_id'], item['seq'], item['gen']])).toEqual([
+      [id, '0', '0'],
+      [id, '1', '1'],
+    ]);
+    await jest.advanceTimersByTimeAsync(1000);
+    document.dispatchEvent(new Event('keydown'));
+    await flush();
+    expect(
+      events()
+        .filter((item) => item.payload.name !== 'faro.session_recording.event')
+        .map((item) => item.payload.name)
+    ).toEqual([
+      'faro.session_recording.started',
+      'faro.session_recording.paused',
+      'faro.session_recording.resumed',
+      'faro.session_recording.paused',
+      'faro.session_recording.resumed',
+    ]);
   });
 
-  describe('samplingRate', () => {
-    // session-1 hashes to ≈ 0.142 — falls below 0.2 (included) and above 0.1 (excluded)
-    // session-100 hashes to ≈ 0.827 — falls above 0.5 (excluded)
-    // These values are derived from the djb2-style hash in hashSessionId().
-
-    it('should record all sampled sessions when samplingRate is 1 (default)', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: 1 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(true);
-    });
-
-    it('should never record when samplingRate is 0', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).not.toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should record when session hash falls below samplingRate', () => {
-      // session-1 hash ≈ 0.142 which is below 0.2
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0.2 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(true);
-    });
-
-    it('should not record when session hash falls above samplingRate', () => {
-      // session-1 hash ≈ 0.142 which is above 0.1
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0.1 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).not.toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should produce the same decision across page reloads for the same session ID', () => {
-      // Simulates a page reload by creating a fresh instance with the same session ID.
-      // The hash-based approach must produce the same outcome both times.
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0.2 });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-      instrumentation.initialize();
-      const firstDecision = instrumentation['isRecording'];
-
-      const instrumentation2 = new ReplayInstrumentation({ samplingRate: 0.2 });
-      instrumentation2['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation2['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-      instrumentation2.initialize();
-      const secondDecision = instrumentation2['isRecording'];
-      instrumentation2.destroy();
-
-      expect(firstDecision).toBe(secondDecision);
-    });
-
-    it('should clamp negative samplingRate to 0 and log a warning', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: -0.5 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-
-      instrumentation.initialize();
-
-      expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('clamping to'));
-      expect(mockRecord).not.toHaveBeenCalled();
-    });
-
-    it('should clamp samplingRate > 1 to 1 and log a warning', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: 1.5 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      const logWarnSpy = jest.spyOn(instrumentation as any, 'logWarn');
-
-      instrumentation.initialize();
-
-      expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('clamping to'));
-      expect(mockRecord).toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(true);
-    });
-
-    it('should re-evaluate the sampling decision when session ID changes', () => {
-      // session-1 hash ≈ 0.142 → included at 0.5; session-100 hash ≈ 0.827 → excluded at 0.5
-      let metaListener: () => void;
-      mockAddListener.mockImplementation((cb: () => void) => {
-        metaListener = cb;
-      });
-
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0.5 });
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-      expect(instrumentation['isRecording']).toBe(true);
-
-      mockGetSession.mockReturnValue({ id: 'session-100', attributes: { isSampled: 'true' } });
-      metaListener!();
-
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should not record when both global sampling and samplingRate are inactive', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: 0 });
-
-      mockGetSession.mockReturnValue({ id: 'session-1', attributes: { isSampled: 'false' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
-
-      instrumentation.initialize();
-
-      expect(mockRecord).not.toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
-    });
-
-    it('should keep hash values evenly distributed across multiple genShortID seeds', () => {
-      const numBuckets = 10;
-      const seeds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-      const samplesPerSeed = 10_000;
-      const numSamples = seeds.length * samplesPerSeed;
-      const buckets = new Array(numBuckets).fill(0);
-      const maxAllowedChiSquared = 21.67;
-      const originalCrypto = globalThis.crypto;
-      Object.defineProperty(globalThis, 'crypto', {
-        configurable: true,
-        value: {},
-      });
-      const randomSpy = jest.spyOn(Math, 'random');
-
-      try {
-        const inst = new ReplayInstrumentation();
-        for (const seed of seeds) {
-          randomSpy.mockImplementation(createSeededRandom(seed));
-
-          for (let i = 0; i < samplesPerSeed; i++) {
-            const hash = inst['hashSessionId'](genShortID());
-            const bucket = Math.min(Math.floor(hash * numBuckets), numBuckets - 1);
-            buckets[bucket]++;
-          }
-        }
-
-        // Seed Math.random with several fixed seeds so the real genShortID() exercises a broader,
-        // deterministic corpus. This uses chi-squared as a regression score, not as a p-value-based test.
-        const expected = numSamples / numBuckets;
-        const chiSquared = buckets.reduce((sum, observed) => {
-          return sum + (observed - expected) ** 2 / expected;
-        }, 0);
-
-        expect(randomSpy).toHaveBeenCalled();
-        expect(chiSquared).toBeLessThan(maxAllowedChiSquared);
-      } finally {
-        randomSpy.mockRestore();
-        Object.defineProperty(globalThis, 'crypto', {
-          configurable: true,
-          value: originalCrypto,
-        });
+  it.each(['no-stop', 'throw'])('returns a failed resume to Paused for the next interaction: %s', async (failure) => {
+    await start({ inactivityThresholdMs: 1000 });
+    emit(metaEvent());
+    const id = recordings()[0]!['recording_id'];
+    await jest.advanceTimersByTimeAsync(1000);
+    mockRecord.mockImplementationOnce(() => {
+      if (failure === 'throw') {
+        throw new Error('resume failed');
       }
+      return undefined;
     });
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(events('resumed')).toHaveLength(0);
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(events('resumed')).toHaveLength(1);
+    emit(metaEvent());
+    expect(recordings()[1]).toMatchObject({ recording_id: id, seq: '1', gen: '1' });
+  });
 
-    it('should not start recording when session ID is null', () => {
-      instrumentation = new ReplayInstrumentation({ samplingRate: 1 });
+  it('pauses even when metadata capture fails and retries resume once capture recovers', async () => {
+    await start({ inactivityThresholdMs: 1000 });
+    const fail = () => {
+      throw new Error('capture failed');
+    };
+    sdk.metas.addCaptureListener!(fail);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+    expect(events('paused')).toHaveLength(0);
+    sdk.metas.removeCaptureListener!(fail);
+    document.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(events('resumed')).toHaveLength(1);
+  });
 
-      mockGetSession.mockReturnValue({ id: undefined, attributes: { isSampled: 'true' } });
-      instrumentation['api'] = { getSession: mockGetSession, pushEvent: mockPushEvent } as any;
-      instrumentation['metas'] = { addListener: mockAddListener, capture: mockCapture } as any;
+  it.each([0, undefined])('does not pause when inactivity tracking is disabled: %s', async (threshold) => {
+    await start({ inactivityThresholdMs: threshold });
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(attempts[0]!.stop).not.toHaveBeenCalled();
+  });
 
-      instrumentation.initialize();
+  it('refreshes the inactivity deadline on interaction', async () => {
+    await start({ inactivityThresholdMs: 1000 });
+    await jest.advanceTimersByTimeAsync(900);
+    document.dispatchEvent(new Event('scroll'));
+    await jest.advanceTimersByTimeAsync(900);
+    expect(attempts[0]!.stop).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(100);
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+  });
 
-      expect(mockRecord).not.toHaveBeenCalled();
-      expect(instrumentation['isRecording']).toBe(false);
+  it('continues a completed same-document replacement without per-event checkpoint writes', async () => {
+    const replay = await start();
+    const writes = jest.spyOn(Storage.prototype, 'setItem');
+    emit(metaEvent());
+    emit(changeEvent());
+    const id = recordings()[0]!['recording_id'];
+    expect(writes).not.toHaveBeenCalled();
+    sdk.instrumentations.remove(replay);
+    await flush();
+    expect(JSON.parse(window.sessionStorage.getItem(key)!)).toMatchObject({
+      recordingId: id,
+      handoff: 'clean',
+      nextSeq: 2,
     });
+    await start();
+    emit(metaEvent());
+    expect(recordings()[2]).toMatchObject({ recording_id: id, seq: '2', gen: '1' });
+  });
+
+  it('releases at pageswap, cancels departure work, and rereads the current checkpoint on restoration', async () => {
+    await start();
+    emit(metaEvent());
+    const id = recordings()[0]!['recording_id'];
+    window.dispatchEvent(new Event('pageswap'));
+    expect(JSON.parse(window.sessionStorage.getItem(key)!).handoff).toBe('clean');
+    window.dispatchEvent(new Event('pagehide'));
+    document.dispatchEvent(new Event('freeze'));
+    await flush();
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+    expect((await navigator.locks.query()).held).toEqual([]);
+    const updated = { ...JSON.parse(window.sessionStorage.getItem(key)!), nextSeq: 30, gen: 5, documentId: 'outgoing' };
+    window.sessionStorage.setItem(key, JSON.stringify(updated));
+    document.dispatchEvent(new Event('resume'));
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    emit(metaEvent());
+    expect(recordings()[1]).toMatchObject({ recording_id: id, seq: '30', gen: '6' });
+  });
+
+  it('does not release a lease for background visibility alone', async () => {
+    await start();
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flush();
+    expect(attempts[0]!.stop).not.toHaveBeenCalled();
+    expect((await navigator.locks.query()).held).toHaveLength(1);
+  });
+
+  it('does not infer an abandoned navigation from synthetic input or a navigation error', async () => {
+    await start();
+    window.dispatchEvent(new Event('pageswap'));
+    document.dispatchEvent(new Event('pointerdown'));
+    window.dispatchEvent(new Event('navigateerror'));
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    expect((await navigator.locks.query()).held).toEqual([]);
+  });
+
+  it('coalesces session rotations and rejects callbacks from the old attempt', async () => {
+    await start();
+    emit(metaEvent());
+    const first = recordings()[0]!['recording_id'];
+    setSession('B');
+    setSession('C');
+    await flush();
+    emit(changeEvent('stale'), 0);
+    emit(metaEvent());
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(events('event').map((item) => item.meta.session?.id)).toEqual(['A', 'C']);
+    expect(recordings()[1]!['recording_id']).not.toBe(first);
+    expect(recordings()[1]).toMatchObject({ seq: '0', gen: '0' });
+  });
+
+  it('preserves identity when sampling is disabled and enabled in the same session', async () => {
+    await start();
+    emit(metaEvent());
+    const id = recordings()[0]!['recording_id'];
+    setSession('A', false);
+    await flush();
+    setSession('A');
+    await flush();
+    emit(metaEvent());
+    expect(recordings()[1]).toMatchObject({ recording_id: id, seq: '1', gen: '1' });
+  });
+
+  it.each(['initial', 'rotated'])(
+    'retries %s startup on interaction after a one-time capture failure',
+    async (phase) => {
+      if (phase === 'rotated') {
+        await start();
+      }
+      const fail = () => {
+        throw new Error('capture failed');
+      };
+      sdk.metas.addCaptureListener!(fail);
+      if (phase === 'initial') {
+        await start();
+      } else {
+        setSession('B');
+        await flush();
+      }
+      const starts = mockRecord.mock.calls.length;
+      await jest.advanceTimersByTimeAsync(10_000);
+      expect(mockRecord).toHaveBeenCalledTimes(starts);
+      sdk.metas.removeCaptureListener!(fail);
+      document.dispatchEvent(new Event('pointerdown'));
+      document.dispatchEvent(new Event('keydown'));
+      await flush();
+      expect(mockRecord).toHaveBeenCalledTimes(starts + 1);
+      expect(events('started').at(-1)!.meta.session?.id).toBe(phase === 'initial' ? 'A' : 'B');
+    }
+  );
+
+  it('never retries a removed initialization from its queued callbacks', async () => {
+    const replay = await start();
+    setSession('B');
+    sdk.instrumentations.remove(replay);
+    sdk.instrumentations.add(replay);
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(2);
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a conflicting producer without disturbing the existing recorder', async () => {
+    await start();
+    const other = initializeFaro(mockConfig());
+    other.api.setSession({ id: 'other', attributes: { isSampled: 'true' } });
+    await expect(start({}, other)).rejects.toThrow('already has a Replay producer');
+    emit(metaEvent());
+    expect(recordings()).toHaveLength(1);
+    expect(attempts[0]!.stop).not.toHaveBeenCalled();
+  });
+
+  it('releases registration when configuration assembly fails', async () => {
+    Object.defineProperty(sdk.config.app, 'name', {
+      configurable: true,
+      get: () => {
+        throw new Error('invalid config');
+      },
+    });
+    await expect(start()).rejects.toThrow('invalid config');
+    const other = initializeFaro(mockConfig());
+    other.api.setSession({ id: 'other', attributes: { isSampled: 'true' } });
+    await expect(start({}, other)).resolves.toBeInstanceOf(ReplayInstrumentation);
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [1, 'session-1', true],
+    [0, 'session-1', false],
+    [0.2, 'session-1', true],
+    [0.1, 'session-1', false],
+    [0.5, 'session-100', false],
+    [-1, 'session-1', false],
+    [2, 'session-1', true],
+  ] as const)(
+    'keeps the deterministic sampling decision at rate %s for %s',
+    async (samplingRate, sessionId, expected) => {
+      setSession(sessionId);
+      const replay = await start({ samplingRate });
+      expect(mockRecord).toHaveBeenCalledTimes(expected ? 1 : 0);
+      sdk.instrumentations.remove(replay);
+      await flush();
+      await start({ samplingRate });
+      expect(mockRecord).toHaveBeenCalledTimes(expected ? 2 : 0);
+    }
+  );
+
+  it('waits for session initialization and stops after a completed clear', async () => {
+    sdk.api.resetSession();
+    await start();
+    expect(mockRecord).not.toHaveBeenCalled();
+    setSession('A');
+    await flush();
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    sdk.api.resetSession();
+    await flush();
+    expect(attempts[0]!.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes privacy options and guards the custom input masker', async () => {
+    const maskInputFn = jest.fn(() => 'custom');
+    await start({
+      maskAllInputs: false,
+      maskInputOptions: { password: true, email: true },
+      maskInputFn,
+      maskTextSelector: '.private',
+      blockSelector: '.blocked',
+      ignoreSelector: '.ignored',
+      collectFonts: true,
+      inlineImages: true,
+      inlineStylesheet: true,
+      recordCanvas: true,
+      recordCrossOriginIframes: true,
+      recordAfter: 'DOMContentLoaded',
+    });
+    expect(attempts[0]!.options).toMatchObject({
+      maskAllInputs: false,
+      maskInputOptions: { password: true, email: true },
+      maskTextSelector: '.private',
+      blockSelector: '.blocked',
+      ignoreSelector: '.ignored',
+      maskTextClass: 'grafana-mask',
+      blockClass: 'grafana-block',
+      ignoreClass: 'grafana-ignore',
+      collectFonts: true,
+      inlineImages: true,
+      inlineStylesheet: true,
+      recordCanvas: true,
+      recordCrossOriginIframes: true,
+      recordAfter: 'DOMContentLoaded',
+    });
+    expect(attempts[0]!.options.maskInputFn!('private', document.createElement('input'))).toBe('custom');
+    expect(maskInputFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses fixed-length masking by default, including an explicitly undefined masker', async () => {
+    await start({ maskInputFn: undefined });
+    const mask = attempts[0]!.options.maskInputFn!;
+    const input = document.createElement('input');
+    expect([mask('short', input), mask('a much longer secret', input), mask('', input)]).toEqual([
+      '******',
+      '******',
+      '',
+    ]);
+    expect(defaultMaskInputFn('', input)).toBe('');
+  });
+
+  it('sanitizes Meta URLs both before and after the Replay filter', async () => {
+    const beforeSend = jest.fn((event: eventWithTime) =>
+      event.type === EventType.Meta
+        ? { ...event, data: { ...event.data, href: 'https://other:secret@example.net/new?q=private#token' } }
+        : event
+    );
+    await start({ beforeSend });
+    emit(metaEvent());
+    expect((beforeSend.mock.calls[0]![0] as ReturnType<typeof metaEvent>).data).toMatchObject({
+      href: 'https://example.com/path',
+    });
+    expect(JSON.parse(recordings()[0]!['event']!).data.href).toBe('https://example.net/new');
+  });
+
+  it.each(['not a URL', 'file:///some/path'])('preserves harmless or malformed Meta hrefs: %s', async (href) => {
+    await start();
+    emit(metaEvent(href));
+    expect(JSON.parse(recordings()[0]!['event']!).data.href).toBe(href);
+  });
+
+  it('allows explicit URL sanitation opt-out', async () => {
+    await start({ sanitizeMetaHref: false });
+    const href = 'https://example.com/?token=private#secret';
+    emit(metaEvent(href));
+    expect(JSON.parse(recordings()[0]!['event']!).data.href).toBe(href);
   });
 });

--- a/experimental/instrumentation-replay/src/instrumentation.ts
+++ b/experimental/instrumentation-replay/src/instrumentation.ts
@@ -3,363 +3,585 @@ import { record, type recordOptions } from '@grafana/rrweb';
 import { EventType, type eventWithTime } from '@grafana/rrweb-types';
 
 import { defaultMaskInputFn, defaultReplayInstrumentationOptions } from './const';
-import { createMemoryStorage, type ReplayRecordingState, ReplayRecordingStateStore } from './recordingState';
+import { getRecordingDocument, type RecordingDocument } from './documentLifecycle';
+import { type RecordingLease, ReplayRecordingStateStore } from './recordingState';
+import { finishRrweb, registerReplayProducer, runInRrweb, waitForRrwebCleanup } from './rrwebRuntime';
 import type { ReplayInstrumentationOptions } from './types';
 
-const faroSessionReplayEventName = 'faro.session_recording.event';
-const faroSessionReplayStartedEventName = 'faro.session_recording.started';
-const faroSessionReplayPausedEventName = 'faro.session_recording.paused';
-const faroSessionReplayResumedEventName = 'faro.session_recording.resumed';
+const replayEvent = 'faro.session_recording.event';
+const startedEvent = 'faro.session_recording.started';
+const pausedEvent = 'faro.session_recording.paused';
+const resumedEvent = 'faro.session_recording.resumed';
+const interactionEvents = ['pointermove', 'pointerdown', 'scroll', 'keydown', 'input'];
 
-// When localStorage cannot be accessed or written, checkpoints live only as long as this
-// Document: same-document replacement still continues, cross-Document navigation starts a
-// recovery recording.
-let documentLocalCheckpointStorage: Storage | undefined;
-const sharedStorageProbeKey = 'com.grafana.faro.replay.probe';
-
-interface ActiveRecordingHandoff {
-  sessionId: string;
-  recordingId: string;
+interface RecorderAttempt {
+  lease: RecordingLease;
+  activation: object;
+  fallback: 'idle' | 'paused';
+  buffer?: eventWithTime[];
+  stop?: () => void;
 }
 
-interface RecordingOwnerState {
-  handoff?: ActiveRecordingHandoff;
-  abandonedRecordingIds: Set<string>;
+type RecorderState = { phase: 'idle' | 'paused' } | { phase: 'starting' | 'recording'; attempt: RecorderAttempt };
+
+interface Acquisition {
+  controller: AbortController;
+  activation: object;
+  sessionId?: string;
+  finished: Promise<void>;
+  finish: () => void;
 }
 
-const recordingOwners = new WeakMap<Document, Map<string, RecordingOwnerState>>();
-
-function getRecordingOwnerState(namespace: string): RecordingOwnerState {
-  let owners = recordingOwners.get(document);
-  if (!owners) {
-    owners = new Map();
-    recordingOwners.set(document, owners);
-  }
-  let owner = owners.get(namespace);
-  if (!owner) {
-    owner = { abandonedRecordingIds: new Set() };
-    owners.set(namespace, owner);
-  }
-  return owner;
+interface Initialization {
+  document: RecordingDocument;
+  activation: object;
+  store: ReplayRecordingStateStore;
+  recorder: RecorderState;
+  unregisterProducer: () => void;
+  disposers: Array<() => void>;
+  acquisition?: Acquisition;
+  lease?: RecordingLease;
+  startTask?: object;
+  supersededActivation?: object;
+  inactivityTimer?: ReturnType<typeof setTimeout>;
+  removeInteractions?: () => void;
 }
-
-function takeActiveRecordingHandoff(namespace: string): ActiveRecordingHandoff | undefined {
-  const owner = getRecordingOwnerState(namespace);
-  const handoff = owner.handoff;
-  delete owner.handoff;
-  return handoff;
-}
-
-type RrwebEmit = (event: eventWithTime) => void;
-
-// DOM events that signal a human is present.  Aligned with rrweb's
-// IncrementalSource 1-5 (MouseMove, MouseInteraction, Scroll,
-// ViewportResize, Input).  We use pointer* instead of mouse*/touch*
-// because modern browsers fire PointerEvents for all input devices.
-const USER_INTERACTION_EVENTS: readonly string[] = [
-  'pointermove', // MouseMove / TouchMove
-  'pointerdown', // MouseInteraction (click, dblclick, etc.)
-  'scroll', // Scroll
-  'keydown', // Input
-  'input', // Input (covers typing without keydown, e.g. autofill)
-];
 
 export class ReplayInstrumentation extends BaseInstrumentation {
   readonly name = '@grafana/faro-instrumentation-replay';
   readonly version: string = VERSION;
-
-  private stopFn: { (): void } | null = null;
-  private isRecording: boolean = false;
-  private isPaused: boolean = false;
-  private options: ReplayInstrumentationOptions = defaultReplayInstrumentationOptions;
-  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
-  private boundOnUserInteraction: (() => void) | null = null;
-
-  private recordingState: ReplayRecordingState | undefined;
-  private pageHidden = false;
-  private recordingStateStore: ReplayRecordingStateStore | undefined;
-  private recordingOwnerNamespace!: string;
-
-  // record() may notify listeners before returning its stop function.
-  private isStarting: boolean = false;
-  // Coalesce re-entrant session changes into one deferred start.
-  private pendingStart: boolean = false;
-  private destroyed: boolean = false;
-  // Deferred starts belong to the lifecycle that scheduled them.
-  private lifecycle = 0;
-  // Prevent an invalidated attempt from reviving if the same session returns.
-  private attemptRevision = 0;
-
-  private readonly metasListener = (): void => {
-    this.checkAndUpdateRecording(true);
-  };
-
-  private readonly pageHideListener = (): void => {
-    if (this.destroyed) {
-      return;
-    }
-    this.pageHidden = true;
-    if (!this.recordingState) {
-      return;
-    }
-    this.stopRecording();
-    this.recordingStateStore?.seal(this.recordingState);
-  };
-
-  private readonly pageShowListener = (event: PageTransitionEvent): void => {
-    if (this.destroyed || !event.persisted || !this.pageHidden) {
-      return;
-    }
-    this.pageHidden = false;
-    this.recordingState = undefined;
-    this.checkAndUpdateRecording(false);
-  };
-
-  // A competing claim can arrive after that Document has already sealed its checkpoint.
-  // Revoke this identity before restarting, rather than adopting its now-clean counters.
-  private readonly storageListener = (event: StorageEvent): void => {
-    if (this.destroyed || this.pageHidden || !this.recordingState) {
-      return;
-    }
-    if (
-      !this.recordingStateStore?.hasLostOwnership(
-        this.recordingState.recordingId,
-        event.key,
-        event.newValue,
-        event.storageArea
-      )
-    ) {
-      return;
-    }
-    this.logDebug('Recording checkpoint was claimed by another document, starting a recovery recording');
-    this.recordingStateStore.abandon(this.recordingState.recordingId);
-    this.stopRecording();
-    this.recordingState = undefined;
-    this.checkAndUpdateRecording(false);
-  };
+  private readonly options: ReplayInstrumentationOptions;
+  private readonly samplingRate: number;
+  private initialization?: Initialization;
 
   constructor(options: ReplayInstrumentationOptions = {}) {
     super();
-
-    this.options = {
-      ...defaultReplayInstrumentationOptions,
-      ...options,
-    };
-
+    this.options = { ...defaultReplayInstrumentationOptions, ...options };
     this.options.maskInputFn ??= defaultMaskInputFn;
+    this.samplingRate = clampSamplingRate(this.options.samplingRate ?? 1);
   }
 
   initialize(): void {
-    this.destroyed = false;
-    this.pageHidden = false;
-    // Owner identity excludes deployment versions so navigation can cross releases.
-    this.recordingOwnerNamespace = JSON.stringify([
-      this.config.globalObjectKey,
-      this.config.app?.name ?? '',
-      this.config.app?.namespace ?? '',
-      this.config.app?.environment ?? '',
-    ]);
-    this.recordingStateStore = new ReplayRecordingStateStore({
-      tabStorage: this.getSessionStorage(),
-      sharedStorage: this.getSharedCheckpointStorage(),
-      ownerNamespace: this.recordingOwnerNamespace,
-      documentId: genShortID(),
+    this.destroy();
+    if (this.initialization) {
+      return;
+    }
+    const unregisterProducer = registerReplayProducer({});
+    try {
+      const recordingDocument = getRecordingDocument();
+      const namespace = JSON.stringify([
+        this.config.globalObjectKey,
+        this.config.app?.name ?? '',
+        this.config.app?.namespace ?? '',
+        this.config.app?.environment ?? '',
+      ]);
+      const init: Initialization = {
+        document: recordingDocument,
+        activation: recordingDocument.activation,
+        store: this.createStore(recordingDocument, namespace),
+        recorder: { phase: 'idle' },
+        unregisterProducer,
+        disposers: [],
+      };
+      this.initialization = init;
+      try {
+        const metas = this.metas;
+        const listener = () => this.reconcile(init);
+        this.register(
+          init,
+          () => metas.addListener(listener),
+          () => metas.removeListener(listener)
+        );
+        if (!this.current(init)) {
+          return;
+        }
+        init.disposers.push(
+          recordingDocument.subscribe(() => {
+            if (!this.current(init)) {
+              return;
+            }
+            if (recordingDocument.phase !== 'active') {
+              init.startTask = undefined;
+              this.cancelAcquisition(init);
+              this.endLease(init);
+              return;
+            }
+            if (init.activation !== recordingDocument.activation) {
+              init.activation = recordingDocument.activation;
+              init.store = this.createStore(recordingDocument, namespace);
+            }
+            this.scheduleStart(init);
+          })
+        );
+
+        const recover = (event: Event) => {
+          if (!this.current(init)) {
+            return;
+          }
+          if (recordingDocument.phase === 'pageswap') {
+            // Navigation errors and transition promises also occur on successful
+            // navigation. Trusted input is an explicit retained-page retry trigger.
+            if (event.isTrusted && document.visibilityState === 'visible') {
+              recordingDocument.resumeRetainedActivation();
+            }
+          } else if (recordingDocument.phase === 'active' && init.recorder.phase === 'idle') {
+            this.scheduleStart(init);
+          }
+        };
+        for (const name of ['pointerdown', 'keydown']) {
+          this.register(
+            init,
+            () => document.addEventListener(name, recover, { capture: true, passive: true }),
+            () => document.removeEventListener(name, recover, { capture: true })
+          );
+        }
+        if ((this.options.samplingRate ?? 1) !== this.samplingRate) {
+          this.logWarn(
+            `samplingRate ${this.options.samplingRate} is out of range [0, 1], clamping to ${this.samplingRate}`
+          );
+        }
+        this.scheduleStart(init);
+      } catch (error) {
+        if (this.current(init)) {
+          this.destroy();
+        }
+        throw error;
+      }
+    } catch (error) {
+      unregisterProducer();
+      throw error;
+    }
+  }
+
+  private createStore(recordingDocument: RecordingDocument, namespace: string): ReplayRecordingStateStore {
+    let storage: Storage | undefined;
+    try {
+      storage = window.sessionStorage;
+    } catch {
+      // The same native lease protocol also owns document-local counters.
+    }
+    return new ReplayRecordingStateStore({
+      storage,
+      ownerNamespace: namespace,
+      documentId: recordingDocument.id,
+      documentState: recordingDocument.state(namespace),
       generateRecordingId: genShortID,
-      abandonedRecordingIds: getRecordingOwnerState(this.recordingOwnerNamespace).abandonedRecordingIds,
-    });
-    this.recordingStateStore.removeLegacyState();
-    this.lifecycle++;
-    // A listener already being notified can still queue work after destroy().
-    this.pendingStart = false;
-
-    // Listen for session changes. Starts triggered from the listener are deferred out
-    // of the call stack (see scheduleStartRecording).
-    this.metas.addListener(this.metasListener);
-    window.addEventListener('pagehide', this.pageHideListener, { capture: true });
-    window.addEventListener('pageshow', this.pageShowListener, { capture: true });
-    window.addEventListener('storage', this.storageListener);
-
-    this.checkAndUpdateRecording(false);
-  }
-
-  private getSessionStorage(): Storage | undefined {
-    try {
-      return typeof window === 'undefined' ? undefined : window.sessionStorage;
-    } catch {
-      return undefined;
-    }
-  }
-
-  private getSharedCheckpointStorage(): Storage | undefined {
-    try {
-      if (typeof window !== 'undefined' && window.localStorage) {
-        const storage = window.localStorage;
-        // Access can succeed while writes fail, for example once the origin's quota is
-        // full. Probe once so a broken storage degrades to the Document-local fallback
-        // instead of failing every checkpoint.
-        storage.setItem(sharedStorageProbeKey, '1');
-        storage.removeItem(sharedStorageProbeKey);
-        return storage;
-      }
-    } catch {
-      // Fall through to the Document-local fallback.
-    }
-
-    documentLocalCheckpointStorage ??= createMemoryStorage();
-    return documentLocalCheckpointStorage;
-  }
-
-  private checkAndUpdateRecording(deferStart: boolean): void {
-    if (this.pageHidden) {
-      return;
-    }
-
-    // A notification can arrive synchronously while rrweb's record() is still executing,
-    // before the stop function is installed. Reconcile once the current call stack has
-    // finished so the start attempt can finish setting up its state.
-    if (this.isStarting) {
-      const session = this.api.getSession();
-      if (session !== undefined && !this.isRecordingSessionEligible()) {
-        this.attemptRevision++;
-      }
-      this.scheduleStartRecording();
-      return;
-    }
-
-    const session = this.api.getSession();
-
-    // Core's setSession removes and re-adds the session meta, notifying listeners on
-    // each step, so mid-rotation the listener transiently observes NO session meta at
-    // all. Acting on that transient notification would stop and restart recording on
-    // every setSession call; the follow-up notification carries the session to act on.
-    // A deliberate session clear (resetSession / setSession(undefined)) is different:
-    // it re-adds a session meta WITHOUT an id, which must stop recording below.
-    if (session === undefined) {
-      this.logDebug('No session meta present, awaiting the next session meta notification');
-      return;
-    }
-
-    const sessionId = this.currentEligibleSessionId();
-
-    if (sessionId === null) {
-      if (this.isRecording) {
-        this.logDebug('Session is not eligible for replay (unsampled or missing id), stopping recording');
-        this.stopRecording();
-      } else {
-        this.logDebug('Session is not sampled, recording not started');
-      }
-      return;
-    }
-
-    if (this.isRecording) {
-      if (this.recordingState?.sessionId === sessionId) {
-        return;
-      }
-
-      // The session rotated while recording: a recording belongs to exactly one
-      // session, so end this one now (stopping pushes no events, making it safe inside
-      // the listener call stack) and start the new session's recording deferred.
-      this.logDebug('Session changed, restarting recording for the new session');
-      this.stopRecording();
-    }
-
-    if (deferStart) {
-      this.scheduleStartRecording();
-    } else {
-      this.startRecording(sessionId);
-    }
-  }
-
-  // Defer starts out of re-entrant metadata callbacks and transport hooks.
-  // Re-evaluate the latest session when the coalesced start executes.
-  private scheduleStartRecording(): void {
-    if (this.pendingStart) {
-      return;
-    }
-    this.pendingStart = true;
-    const lifecycle = this.lifecycle;
-
-    void Promise.resolve().then(() => {
-      if (lifecycle !== this.lifecycle) {
-        return;
-      }
-      this.pendingStart = false;
-      if (this.destroyed) {
-        return;
-      }
-
-      this.checkAndUpdateRecording(false);
     });
   }
 
-  // Passive eligibility check; capture reconciliation is explicit at the caller.
-  private currentEligibleSessionId(): string | null {
+  private current(init: Initialization): boolean {
+    return this.initialization === init;
+  }
+
+  private active(init: Initialization): boolean {
+    return (
+      this.current(init) &&
+      init.document.phase === 'active' &&
+      init.activation === init.document.activation &&
+      init.supersededActivation !== init.activation
+    );
+  }
+
+  private eligibleSessionId(): string | null {
     const session = this.api.getSession();
-    if (session === undefined) {
+    if (!session?.id || session.attributes?.['isSampled'] !== 'true' || !this.shouldReplaySample(session.id)) {
       return null;
     }
-
-    const sessionId = session.id ?? null;
-    const isSampled = session.attributes?.['isSampled'] === 'true';
-
-    if (sessionId === null || !isSampled || !this.shouldReplaySample(sessionId)) {
-      return null;
-    }
-
-    return sessionId;
+    return session.id;
   }
 
   private shouldReplaySample(sessionId: string): boolean {
-    const samplingRate = this.options.samplingRate ?? 1;
-    const clampedSamplingRate = clampSamplingRate(samplingRate);
-
-    if (samplingRate !== clampedSamplingRate) {
-      this.logWarn(`samplingRate ${samplingRate} is out of range [0, 1], clamping to ${clampedSamplingRate}`);
+    if (this.samplingRate === 0 || this.samplingRate === 1) {
+      return this.samplingRate === 1;
     }
+    let hash = 0;
+    for (let index = 0; index < sessionId.length; index++) {
+      hash = (hash * 31 + sessionId.charCodeAt(index)) >>> 0;
+    }
+    return hash / 0xffffffff < this.samplingRate;
+  }
 
-    if (clampedSamplingRate === 0) {
+  private reconcile(init: Initialization): void {
+    if (!this.current(init)) {
+      return;
+    }
+    const sessionId = this.eligibleSessionId();
+    if (!this.current(init)) {
+      return;
+    }
+    if (init.acquisition?.sessionId && init.acquisition.sessionId !== sessionId) {
+      this.cancelAcquisition(init);
+    }
+    if (init.lease) {
+      const ownership = init.lease.ownership();
+      if (!this.current(init)) {
+        return;
+      }
+      if (ownership === 'superseded') {
+        init.supersededActivation = init.activation;
+      }
+      if (this.active(init) && ownership === 'owned' && init.lease.state.sessionId === sessionId) {
+        return;
+      }
+      this.endLease(init);
+    }
+    if (sessionId) {
+      this.scheduleStart(init);
+    }
+  }
+
+  private scheduleStart(init: Initialization): void {
+    if (
+      !this.active(init) ||
+      init.startTask ||
+      init.acquisition ||
+      init.recorder.phase === 'starting' ||
+      init.recorder.phase === 'recording'
+    ) {
+      return;
+    }
+    const task = {};
+    init.startTask = task;
+    void Promise.resolve().then(async () => {
+      await waitForRrwebCleanup();
+      if (!this.active(init) || init.startTask !== task) {
+        return;
+      }
+      init.startTask = undefined;
+      if (init.lease) {
+        this.resume(init);
+      } else {
+        this.acquire(init);
+      }
+    });
+  }
+
+  private acquire(init: Initialization): void {
+    if (!this.active(init) || init.acquisition) {
+      return;
+    }
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const acquisition: Acquisition = {
+      controller: new AbortController(),
+      activation: init.activation,
+      finished,
+      finish,
+    };
+    init.acquisition = acquisition;
+    void this.acquireRecording(init, acquisition);
+  }
+
+  private ownsAcquisition(init: Initialization, acquisition: Acquisition): boolean {
+    return (
+      this.active(init) &&
+      init.acquisition === acquisition &&
+      acquisition.activation === init.activation &&
+      !acquisition.controller.signal.aborted
+    );
+  }
+
+  private async acquireRecording(init: Initialization, acquisition: Acquisition): Promise<void> {
+    try {
+      captureMetas(this.metas);
+      if (!this.ownsAcquisition(init, acquisition)) {
+        return;
+      }
+      const sessionId = this.eligibleSessionId();
+      if (!sessionId || !this.ownsAcquisition(init, acquisition)) {
+        return;
+      }
+      acquisition.sessionId = sessionId;
+      const lease = await init.store.acquire(sessionId, acquisition.controller.signal, () => {
+        if (!this.ownsAcquisition(init, acquisition)) {
+          return null;
+        }
+        captureMetas(this.metas);
+        return this.ownsAcquisition(init, acquisition) ? this.eligibleSessionId() : null;
+      });
+      if (!lease) {
+        return;
+      }
+      if (!this.ownsAcquisition(init, acquisition)) {
+        lease.release();
+        await lease.released;
+        return;
+      }
+      init.acquisition = undefined;
+      // Install lease ownership before capture or rrweb can call application code.
+      init.lease = lease;
+      try {
+        captureMetas(this.metas, () => {
+          if (this.active(init) && init.lease === lease && this.eligibleSessionId() === lease.state.sessionId) {
+            this.startAttempt(init, lease, 'idle');
+          }
+        });
+        if (init.lease === lease && init.recorder.phase === 'idle') {
+          this.endLease(init);
+        }
+      } catch (error) {
+        if (init.lease === lease) {
+          this.endLease(init);
+        }
+        throw error;
+      }
+    } catch (error) {
+      if (this.current(init) && !acquisition.controller.signal.aborted) {
+        this.logWarn('Failed to start session replay', error);
+      }
+    } finally {
+      if (init.acquisition === acquisition) {
+        init.acquisition = undefined;
+      }
+      acquisition.finish();
+    }
+  }
+
+  private cancelAcquisition(init: Initialization): void {
+    const acquisition = init.acquisition;
+    if (acquisition) {
+      init.acquisition = undefined;
+      acquisition.controller.abort();
+      finishRrweb(() => acquisition.finished);
+    }
+  }
+
+  private ownsAttempt(init: Initialization, attempt: RecorderAttempt): boolean {
+    return (
+      this.active(init) &&
+      init.lease === attempt.lease &&
+      init.activation === attempt.activation &&
+      (init.recorder.phase === 'starting' || init.recorder.phase === 'recording') &&
+      init.recorder.attempt === attempt
+    );
+  }
+
+  private currentAttempt(init: Initialization, attempt: RecorderAttempt): boolean {
+    if (!this.ownsAttempt(init, attempt)) {
       return false;
     }
-
-    if (clampedSamplingRate === 1) {
-      return true;
+    const sessionId = this.eligibleSessionId();
+    const ownership = attempt.lease.ownership();
+    if (!this.ownsAttempt(init, attempt)) {
+      return false;
     }
-
-    return this.hashSessionId(sessionId) < clampedSamplingRate;
-  }
-
-  // Produces a deterministic float in [0, 1] from a session ID string so that the
-  // replay sampling decision is stable across page reloads for the same session.
-  //
-  // The >>> 0 (unsigned right-shift by zero) coerces the intermediate value to an
-  // unsigned 32-bit integer. Without it, JS bitwise ops return signed 32-bit ints,
-  // so values above 2,147,483,647 flip negative (e.g. 3,389,167,832 → -905,799,464)
-  // and the final division would produce a negative number, breaking the comparison.
-
-  private hashSessionId(sessionId: string): number {
-    let hash = 0;
-    for (let i = 0; i < sessionId.length; i++) {
-      hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
+    if (sessionId !== attempt.lease.state.sessionId || ownership !== 'owned') {
+      if (ownership === 'superseded') {
+        init.supersededActivation = init.activation;
+      }
+      this.endLease(init);
+      if (sessionId) {
+        this.scheduleStart(init);
+      }
+      return false;
     }
-    return hash / 0xffffffff;
+    return true;
   }
 
-  private stopRecording(): void {
-    this.teardownInactivityTracking();
-    this.stopRrweb();
-    this.isRecording = false;
-    this.isPaused = false;
-    this.logDebug('Session replay stopped');
+  private startAttempt(init: Initialization, lease: RecordingLease, fallback: 'idle' | 'paused'): void {
+    // Eligibility getters can dispose or replace the caller's initialization.
+    if (!this.active(init) || init.lease !== lease) {
+      return;
+    }
+    const attempt: RecorderAttempt = { lease, activation: init.activation, fallback, buffer: [] };
+    init.recorder = { phase: 'starting', attempt };
+    try {
+      runInRrweb(() => {
+        const stop = record(this.recordOptions(init, attempt));
+        attempt.stop = stop;
+        if (!this.currentAttempt(init, attempt)) {
+          // The stale handle belongs only to this attempt. A queued finalizer
+          // can now stop it after record()/checkout/deferred setup has returned.
+          finishRrweb(() => this.stopAttempt(attempt));
+          return;
+        }
+        if (!stop) {
+          this.failAttempt(init, attempt);
+          return;
+        }
+        init.recorder = { phase: 'recording', attempt };
+        this.pushLifecycle(init, lease, fallback === 'paused' ? resumedEvent : startedEvent);
+        const buffer = attempt.buffer!;
+        for (let index = 0; index < buffer.length; index++) {
+          if (!this.currentAttempt(init, attempt)) {
+            return;
+          }
+          this.handleEvent(init, attempt, buffer[index]!);
+        }
+        if (this.currentAttempt(init, attempt)) {
+          attempt.buffer = undefined;
+          this.trackInteractions(init);
+          this.resetInactivityTimer(init);
+        }
+      });
+    } catch (error) {
+      this.failAttempt(init, attempt);
+      this.logWarn('Failed to start session replay', error);
+    }
   }
 
-  private buildRecordOptions(emit: RrwebEmit): recordOptions<eventWithTime> {
+  private failAttempt(init: Initialization, attempt: RecorderAttempt): void {
+    if (!this.ownsAttempt(init, attempt)) {
+      return;
+    }
+    attempt.buffer = undefined;
+    if (attempt.fallback === 'paused') {
+      init.recorder = { phase: 'paused' };
+      finishRrweb(() => this.stopAttempt(attempt));
+    } else {
+      this.endLease(init);
+    }
+  }
+
+  private stopAttempt(attempt?: RecorderAttempt): void {
+    const stop = attempt?.stop;
+    if (attempt) {
+      attempt.stop = undefined;
+      attempt.buffer?.splice(0);
+      attempt.buffer = undefined;
+    }
+    if (stop) {
+      try {
+        runInRrweb(stop);
+      } catch (error) {
+        this.logWarn('Failed to stop session replay', error);
+      }
+    }
+  }
+
+  private endLease(init: Initialization): void {
+    const lease = init.lease;
+    const attempt =
+      init.recorder.phase === 'starting' || init.recorder.phase === 'recording' ? init.recorder.attempt : undefined;
+    init.lease = undefined;
+    init.recorder = { phase: 'idle' };
+    this.removeInteractionTracking(init);
+    if (lease) {
+      finishRrweb(() => {
+        try {
+          this.stopAttempt(attempt);
+        } finally {
+          lease.release();
+        }
+        return lease.released;
+      });
+    }
+  }
+
+  private pause(init: Initialization): void {
+    if (!this.active(init) || init.recorder.phase !== 'recording' || !init.lease) {
+      return;
+    }
+    const { attempt } = init.recorder;
+    const lease = init.lease;
+    init.recorder = { phase: 'paused' };
+    clearTimeout(init.inactivityTimer);
+    init.inactivityTimer = undefined;
+    finishRrweb(() => {
+      this.stopAttempt(attempt);
+      if (this.active(init) && init.lease === lease && init.recorder.phase === 'paused') {
+        this.pushLifecycle(init, lease, pausedEvent);
+      }
+    });
+  }
+
+  private resume(init: Initialization): void {
+    const lease = init.lease;
+    if (!lease || init.recorder.phase !== 'paused') {
+      return;
+    }
+    try {
+      captureMetas(this.metas, () => {
+        if (!this.active(init) || init.lease !== lease || init.recorder.phase !== 'paused') {
+          return;
+        }
+        if (this.eligibleSessionId() !== lease.state.sessionId || lease.ownership() !== 'owned') {
+          this.reconcile(init);
+          return;
+        }
+        this.startAttempt(init, lease, 'paused');
+      });
+    } catch (error) {
+      this.logWarn('Failed to resume session replay', error);
+    }
+  }
+
+  private pushLifecycle(init: Initialization, lease: RecordingLease, name: string): void {
+    try {
+      captureMetas(this.metas, () => {
+        if (this.active(init) && init.lease === lease && this.eligibleSessionId() === lease.state.sessionId) {
+          this.api.pushEvent(name, { recording_id: lease.state.recordingId }, undefined, { skipDedupe: true });
+        }
+      });
+    } catch (error) {
+      this.logWarn(`Failed to push ${name} event`, error);
+    }
+  }
+
+  private trackInteractions(init: Initialization): void {
+    if (init.removeInteractions || !(this.options.inactivityThresholdMs! > 0)) {
+      return;
+    }
+    const interact = () => {
+      if (!this.active(init)) {
+        return;
+      }
+      if (init.recorder.phase === 'paused') {
+        this.scheduleStart(init);
+      } else if (init.recorder.phase === 'recording') {
+        this.resetInactivityTimer(init);
+      }
+    };
+    init.removeInteractions = () => {
+      for (const name of interactionEvents) {
+        document.removeEventListener(name, interact, { capture: true });
+      }
+    };
+    for (const name of interactionEvents) {
+      document.addEventListener(name, interact, { capture: true, passive: true });
+    }
+  }
+
+  private resetInactivityTimer(init: Initialization): void {
+    const threshold = this.options.inactivityThresholdMs;
+    if (!threshold || threshold <= 0 || init.recorder.phase !== 'recording') {
+      return;
+    }
+    clearTimeout(init.inactivityTimer);
+    init.inactivityTimer = setTimeout(() => this.pause(init), threshold);
+  }
+
+  private removeInteractionTracking(init: Initialization): void {
+    clearTimeout(init.inactivityTimer);
+    init.inactivityTimer = undefined;
+    const remove = init.removeInteractions;
+    init.removeInteractions = undefined;
+    remove?.();
+  }
+
+  private recordOptions(init: Initialization, attempt: RecorderAttempt): recordOptions<eventWithTime> {
     return {
-      emit,
-      checkoutEveryNms: 300_000, // 5 minutes
+      emit: (event) =>
+        runInRrweb(() => {
+          if (!this.ownsAttempt(init, attempt)) {
+            return;
+          }
+          if (attempt.buffer) {
+            attempt.buffer.push(event);
+          } else {
+            this.handleEvent(init, attempt, event);
+          }
+        }),
+      checkoutEveryNms: 300_000,
       recordCrossOriginIframes: this.options.recordCrossOriginIframes,
       maskAllInputs: this.options.maskAllInputs,
       maskInputOptions: this.options.maskInputOptions,
-      maskInputFn: this.options.maskInputFn,
+      maskInputFn: (text, element) =>
+        runInRrweb(() =>
+          this.ownsAttempt(init, attempt) ? this.options.maskInputFn!(text, element) : defaultMaskInputFn(text, element)
+        ),
       maskTextClass: 'grafana-mask',
       blockClass: 'grafana-block',
       ignoreClass: 'grafana-ignore',
@@ -372,390 +594,99 @@ export class ReplayInstrumentation extends BaseInstrumentation {
       recordDOM: true,
       inlineStylesheet: this.options.inlineStylesheet,
       recordAfter: this.options.recordAfter,
-      errorHandler: (err) => {
-        this.logError('Error occurred during session replay', err);
-      },
-    };
-  }
-
-  // Passive: capture reconciliation must happen before validating the attempt.
-  private isRecordingSessionEligible(): boolean {
-    if (this.destroyed || this.pageHidden || !this.recordingState) {
-      return false;
-    }
-
-    const session = this.api.getSession();
-    return (
-      session?.id === this.recordingState.sessionId &&
-      session.attributes?.['isSampled'] === 'true' &&
-      this.shouldReplaySample(this.recordingState.sessionId)
-    );
-  }
-
-  // rrweb can emit snapshots synchronously before returning its stop function.
-  // Publish only after startup succeeds and the attempt remains eligible.
-  private startRrweb(lifecycleEventName: string): boolean {
-    const state = this.recordingState!;
-    const bufferedEvents: eventWithTime[] = [];
-    const attempt: { phase: 'buffering' | 'active' | 'discarded' } = { phase: 'buffering' };
-    const revision = this.attemptRevision;
-    const isValid = (): boolean =>
-      attempt.phase !== 'discarded' && revision === this.attemptRevision && this.isRecordingSessionEligible();
-    const wasRecording = this.isRecording;
-    const wasPaused = this.isPaused;
-    const discardAttempt = (): void => {
-      attempt.phase = 'discarded';
-      bufferedEvents.length = 0;
-    };
-
-    this.isStarting = true;
-    let stop: (() => void) | undefined;
-    try {
-      stop = record(
-        this.buildRecordOptions((event) => {
-          if (attempt.phase === 'buffering') {
-            bufferedEvents.push(event);
-          } else if (attempt.phase === 'active') {
-            this.handleEvent(event, isCurrentAttempt);
+      errorHandler: (error) =>
+        runInRrweb(() => {
+          if (this.ownsAttempt(init, attempt)) {
+            this.logError('Error occurred during session replay', error);
           }
-        })
-      );
-    } catch (err) {
-      discardAttempt();
-      throw err;
-    } finally {
-      this.isStarting = false;
-    }
-
-    if (!stop) {
-      discardAttempt();
-      return false;
-    }
-
-    if (!isValid()) {
-      // Stop before publishing anything from an invalidated startup.
-      discardAttempt();
-      try {
-        stop();
-      } catch (err) {
-        this.logWarn('Failed to stop session replay', err);
-      } finally {
-        this.stopRecording();
-      }
-      this.logDebug('Recorder start attempt invalidated');
-      return false;
-    }
-
-    const stopAttempt = (): void => {
-      discardAttempt();
-      stop!();
+        }),
     };
-    const recordingId = state.recordingId;
-    const isCurrentAttempt = (): boolean =>
-      isValid() && this.isRecording && this.stopFn === stopAttempt && this.recordingState === state;
-
-    this.stopFn = stopAttempt;
-    this.isRecording = true;
-    this.isPaused = false;
-
-    // Telemetry failure does not undo a successfully installed recorder.
-    try {
-      this.api.pushEvent(lifecycleEventName, { recording_id: recordingId });
-    } catch (err) {
-      this.logWarn(`Failed to push ${lifecycleEventName} event`, err);
-    }
-
-    try {
-      for (const event of bufferedEvents) {
-        if (!isCurrentAttempt()) {
-          discardAttempt();
-          return true;
-        }
-        this.handleEvent(event, isCurrentAttempt);
-      }
-
-      if (!isCurrentAttempt()) {
-        discardAttempt();
-        return true;
-      }
-
-      bufferedEvents.length = 0;
-      attempt.phase = 'active';
-      return true;
-    } catch (err) {
-      if (this.stopFn === stopAttempt) {
-        this.stopRrweb();
-        this.isRecording = wasRecording;
-        this.isPaused = wasPaused;
-      }
-      throw err;
-    }
-  }
-
-  private stopRrweb(): void {
-    this.attemptRevision++;
-    const stop = this.stopFn;
-    this.stopFn = null;
-
-    if (stop) {
-      try {
-        stop();
-      } catch (err) {
-        this.logWarn('Failed to stop session replay', err);
-      }
-    }
-  }
-
-  private startRecording(sessionId: string): void {
-    try {
-      captureMetas(this.metas, () => {
-        // A capture listener may have reinitialized and started this instrumentation.
-        if (this.isRecording) {
-          return;
-        }
-
-        const eligibleSessionId = this.currentEligibleSessionId();
-        if (this.destroyed || this.pageHidden || eligibleSessionId === null || eligibleSessionId !== sessionId) {
-          this.logDebug('Session changed during reconciliation, deferring recording start');
-          return;
-        }
-
-        if (this.recordingState?.sessionId !== sessionId) {
-          const handoff = takeActiveRecordingHandoff(this.recordingOwnerNamespace);
-          this.recordingState = this.recordingStateStore!.claim(
-            sessionId,
-            handoff?.sessionId === sessionId ? handoff.recordingId : undefined
-          );
-        }
-
-        if (!this.startRrweb(faroSessionReplayStartedEventName)) {
-          // Not marked as recording, so a later session notification can retry.
-          this.logWarn('Failed to start session replay: rrweb did not start');
-          return;
-        }
-
-        if (!this.isRecording) {
-          return;
-        }
-
-        this.logDebug('Session replay started');
-
-        this.setupInactivityTracking();
-      });
-    } catch (err) {
-      this.logWarn('Failed to start session replay', err);
-    }
-  }
-
-  private pauseRecording(): void {
-    if (!this.isRecording || this.isPaused) {
-      return;
-    }
-
-    if (this.inactivityTimer !== null) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
-
-    // Metadata reconciliation must not prevent the local inactivity pause.
-    this.stopRrweb();
-    this.isPaused = true;
-    this.logDebug('Session replay paused due to inactivity');
-
-    try {
-      captureMetas(this.metas, () => {
-        if (!this.isRecording || !this.isPaused || !this.isRecordingSessionEligible()) {
-          return;
-        }
-
-        this.api.pushEvent(faroSessionReplayPausedEventName, { recording_id: this.recordingState!.recordingId });
-      });
-    } catch (err) {
-      this.logWarn('Failed to push session replay paused event', err);
-    }
-  }
-
-  private resumeRecording(): void {
-    if (!this.isPaused) {
-      return;
-    }
-
-    try {
-      captureMetas(this.metas, () => {
-        // A capture listener may have installed a fresh recorder.
-        if (this.isRecording && !this.isPaused) {
-          return;
-        }
-
-        if (!this.isRecording || !this.isPaused || !this.isRecordingSessionEligible()) {
-          this.logDebug('Recording session no longer eligible, stopping instead of resuming');
-          this.stopRecording();
-          return;
-        }
-
-        if (!this.startRrweb(faroSessionReplayResumedEventName)) {
-          // Stays paused, so the next user interaction can retry the resume.
-          this.logWarn('Failed to resume session replay: rrweb did not start');
-          return;
-        }
-
-        if (!this.isRecording || this.isPaused) {
-          return;
-        }
-
-        this.logDebug('Session replay resumed after user interaction');
-
-        this.resetInactivityTimer();
-      });
-    } catch (err) {
-      this.logWarn('Failed to resume session replay', err);
-    }
-  }
-
-  private setupInactivityTracking(): void {
-    // Defensive: a re-entrant stop/start cycle must never leak a previous closure's
-    // document listeners.
-    this.teardownInactivityTracking();
-
-    const threshold = this.options.inactivityThresholdMs;
-    if (!threshold || threshold <= 0) {
-      return;
-    }
-
-    this.boundOnUserInteraction = () => {
-      if (this.isPaused) {
-        this.resumeRecording();
-      } else {
-        this.resetInactivityTimer();
-      }
-    };
-
-    for (const eventName of USER_INTERACTION_EVENTS) {
-      document.addEventListener(eventName, this.boundOnUserInteraction, { capture: true, passive: true });
-    }
-
-    this.resetInactivityTimer();
-  }
-
-  private teardownInactivityTracking(): void {
-    if (this.inactivityTimer !== null) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
-
-    if (this.boundOnUserInteraction) {
-      for (const eventName of USER_INTERACTION_EVENTS) {
-        document.removeEventListener(eventName, this.boundOnUserInteraction, { capture: true });
-      }
-      this.boundOnUserInteraction = null;
-    }
-  }
-
-  private resetInactivityTimer(): void {
-    const threshold = this.options.inactivityThresholdMs;
-    if (!threshold || threshold <= 0) {
-      return;
-    }
-
-    clearTimeout(this.inactivityTimer ?? undefined);
-
-    this.inactivityTimer = setTimeout(() => {
-      this.pauseRecording();
-    }, threshold);
   }
 
   private sanitizeMetaHref(event: eventWithTime): void {
     if (event.type !== EventType.Meta || this.options.sanitizeMetaHref === false) {
       return;
     }
-
     const data = event.data;
-    if (data == null || typeof data !== 'object' || !('href' in data) || typeof data.href !== 'string') {
+    if (!data || typeof data !== 'object' || !('href' in data) || typeof data.href !== 'string') {
       return;
     }
-
-    data.href = this.sanitizeUrl(data.href);
-  }
-
-  private sanitizeUrl(href: string): string {
     try {
-      const url = new URL(href);
+      const url = new URL(data.href);
       url.username = '';
       url.password = '';
       url.search = '';
       url.hash = '';
-      return url.href;
+      data.href = url.href;
     } catch {
-      // Malformed URL — leave as-is rather than risk breaking the event.
-      return href;
+      // Preserve malformed URLs rather than corrupting the event.
     }
   }
 
-  private handleEvent(event: eventWithTime, isCurrentAttempt: () => boolean): void {
-    const state = this.recordingState;
+  private handleEvent(init: Initialization, attempt: RecorderAttempt, event: eventWithTime): void {
     try {
       captureMetas(this.metas, () => {
-        if (!state || !isCurrentAttempt()) {
+        if (!this.currentAttempt(init, attempt)) {
           return;
         }
-
         this.sanitizeMetaHref(event);
-
-        // Apply beforeSend transformation if provided
-        let processedEvent: eventWithTime | null | undefined = event;
-        if (this.options.beforeSend) {
-          processedEvent = this.options.beforeSend(event);
-          if (processedEvent === null || processedEvent === undefined) {
-            return;
-          }
-          this.sanitizeMetaHref(processedEvent);
-        }
-
-        // beforeSend is user code and may itself synchronously rotate the session or
-        // otherwise invalidate this attempt; re-validate after it runs, not just before.
-        if (!isCurrentAttempt()) {
+        const processed = this.options.beforeSend ? this.options.beforeSend(event) : event;
+        if (!processed) {
           return;
         }
-
-        if (processedEvent.type === EventType.Meta) {
-          state.gen++;
-        }
-        // Reserve after acceptance but before serialization: a failed event leaves
-        // a detectable gap, without moving its snapshot back to the previous gen.
-        // Capture gen alongside seq: serialization runs user code (toJSON) that may
-        // re-enter with a later Meta and advance state.gen before we read it.
-        const seq = state.nextSeq++;
-        const gen = Math.max(state.gen, 0);
-        const serializedEvent = JSON.stringify(processedEvent);
-        if (!isCurrentAttempt()) {
+        this.sanitizeMetaHref(processed);
+        if (!this.currentAttempt(init, attempt)) {
           return;
         }
-        this.api.pushEvent(faroSessionReplayEventName, {
-          event: serializedEvent,
-          recording_id: state.recordingId,
-          gen: String(gen),
-          seq: String(seq),
+        const reservation = attempt.lease.reserve(processed.type === EventType.Meta);
+        if (!reservation) {
+          this.endLease(init);
+          this.scheduleStart(init);
+          return;
+        }
+        const serialized = JSON.stringify(processed);
+        if (!this.currentAttempt(init, attempt)) {
+          return;
+        }
+        this.api.pushEvent(replayEvent, {
+          event: serialized,
+          recording_id: reservation.recordingId,
+          gen: String(reservation.gen),
+          seq: String(reservation.seq),
         });
       });
-    } catch (err) {
-      this.logWarn(`Failed to push ${faroSessionReplayEventName} event`, err);
+    } catch (error) {
+      this.logWarn(`Failed to push ${replayEvent} event`, error);
+    }
+  }
+
+  private register(init: Initialization, add: () => void, remove: () => void): void {
+    if (!this.current(init)) {
+      return;
+    }
+    init.disposers.push(remove);
+    add();
+    if (!this.current(init)) {
+      remove();
     }
   }
 
   destroy(): void {
-    this.destroyed = true;
-    this.pendingStart = false;
-    this.metas.removeListener?.(this.metasListener);
-    window.removeEventListener('pagehide', this.pageHideListener, { capture: true });
-    window.removeEventListener('pageshow', this.pageShowListener, { capture: true });
-    window.removeEventListener('storage', this.storageListener);
-    this.stopRecording();
-    const state = this.recordingState;
-    if (state) {
-      if (this.recordingStateStore?.checkpoint(state)) {
-        getRecordingOwnerState(this.recordingOwnerNamespace).handoff = state;
+    const init = this.initialization;
+    if (!init) {
+      return;
+    }
+    this.initialization = undefined;
+    init.startTask = undefined;
+    init.unregisterProducer();
+    this.cancelAcquisition(init);
+    this.endLease(init);
+    for (const dispose of init.disposers) {
+      try {
+        dispose();
+      } catch (error) {
+        this.logWarn('Failed to dispose session replay resource', error);
       }
-      this.recordingState = undefined;
     }
   }
 }

--- a/experimental/instrumentation-replay/src/recordingState.test.ts
+++ b/experimental/instrumentation-replay/src/recordingState.test.ts
@@ -1,529 +1,240 @@
 import {
-  createMemoryStorage,
-  legacyReplayRecordingStorageKeyPrefix,
-  MAX_RECORDING_CHECKPOINT_AGE_MS,
-  MAX_RETAINED_RECORDING_CHECKPOINTS,
-  replayRecordingCheckpointKeyPrefix,
-  replayRecordingPointerKeyPrefix,
+  type DocumentRecordingState,
+  type RecordingLease,
+  recordingLockName,
   ReplayRecordingStateStore,
+  replayRecordingStorageKeyPrefix,
+  type TabRecordingState,
 } from './recordingState';
 
-describe('ReplayRecordingStateStore', () => {
-  const owner = '["faro","app","","production"]';
-  const pointerKey = `${replayRecordingPointerKeyPrefix}${owner}`;
-  const checkpointKey = (recordingId: string) => `${replayRecordingCheckpointKeyPrefix}${owner}:${recordingId}`;
-  const checkpointKeys = (storage: Storage) =>
-    Array.from({ length: storage.length }, (_, index) => storage.key(index)!).filter((key) =>
-      key.startsWith(`${replayRecordingCheckpointKeyPrefix}${owner}:`)
-    );
+const namespace = '["faro","app","","production"]';
+const key = `${replayRecordingStorageKeyPrefix}${namespace}`;
+const checkpoint: TabRecordingState = {
+  sessionId: 'A',
+  recordingId: 'R',
+  nextSeq: 10,
+  gen: 2,
+  documentId: 'previous',
+  handoff: 'clean',
+};
 
-  function makeStore(
-    tabStorage: Storage | undefined,
-    sharedStorage: Storage | undefined,
-    documentId: string,
-    recoveryRecordingId: string,
-    now?: () => number
-  ): ReplayRecordingStateStore {
-    return new ReplayRecordingStateStore({
-      tabStorage,
-      sharedStorage,
-      ownerNamespace: owner,
-      documentId,
-      generateRecordingId: () => recoveryRecordingId,
-      now,
-    });
-  }
+function storage(initial: Record<string, string> = {}): Storage {
+  const entries = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return entries.size;
+    },
+    key: (index) => [...entries.keys()][index] ?? null,
+    getItem: (key) => entries.get(key) ?? null,
+    setItem: (key, value) => {
+      entries.set(key, value);
+    },
+    removeItem: (key) => {
+      entries.delete(key);
+    },
+    clear: () => entries.clear(),
+  };
+}
 
-  // A browser derives a new tab by copying the whole sessionStorage area.
-  function cloneTab(tabStorage: Storage): Storage {
-    const copy: Record<string, string> = {};
-    for (let index = 0; index < tabStorage.length; index++) {
-      const key = tabStorage.key(index)!;
-      copy[key] = tabStorage.getItem(key)!;
-    }
-    return createMemoryStorage(copy);
-  }
-
-  function readCheckpoint(shared: Storage, recordingId: string) {
-    return JSON.parse(shared.getItem(checkpointKey(recordingId))!);
-  }
-
-  describe('single tab', () => {
-    it('continues the recording the tab points at when its checkpoint is clean', () => {
-      const tab = createMemoryStorage();
-      const shared = createMemoryStorage();
-      const first = makeStore(tab, shared, 'doc-1', 'recording-a', () => 1_000);
-      const state = first.claim('session-a');
-      expect(state).toEqual({ sessionId: 'session-a', recordingId: 'recording-a', nextSeq: 0, gen: -1 });
-      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recording-a' });
-      expect(first.seal({ ...state, nextSeq: 42, gen: 3 })).toBe(true);
-      expect(readCheckpoint(shared, 'recording-a')).toEqual({
-        sessionId: 'session-a',
-        nextSeq: 42,
-        gen: 3,
-        handoff: 'clean',
-        documentId: 'doc-1',
-        updatedAt: 1_000,
-      });
-
-      const next = makeStore(tab, shared, 'doc-2', 'unused', () => 2_000);
-      expect(next.claim('session-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recording-a',
-        nextSeq: 42,
-        gen: 3,
-      });
-      expect(readCheckpoint(shared, 'recording-a')).toEqual(
-        expect.objectContaining({ handoff: 'active', documentId: 'doc-2', updatedAt: 2_000 })
-      );
-    });
-
-    it('continues an active checkpoint only with the explicit in-memory handoff for that recording', () => {
-      const tab = createMemoryStorage();
-      const shared = createMemoryStorage();
-      const state = makeStore(tab, shared, 'doc-1', 'recording-a').claim('session-a');
-      expect(makeStore(tab, shared, 'doc-1', 'recording-a').checkpoint({ ...state, nextSeq: 5, gen: 0 })).toBe(true);
-
-      const withoutHandoff = makeStore(tab, shared, 'doc-2', 'recovery-1');
-      expect(withoutHandoff.claim('session-a').recordingId).toBe('recovery-1');
-
-      const shared2 = createMemoryStorage();
-      const tab2 = createMemoryStorage();
-      const owned = makeStore(tab2, shared2, 'doc-1', 'recording-a').claim('session-a');
-      makeStore(tab2, shared2, 'doc-1', 'recording-a').checkpoint({ ...owned, nextSeq: 5, gen: 0 });
-      const replacement = makeStore(tab2, shared2, 'doc-2', 'recovery-2');
-      expect(replacement.claim('session-a', 'recording-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recording-a',
-        nextSeq: 5,
-        gen: 0,
-      });
-      expect(replacement.claim('session-a', 'other-recording').recordingId).toBe('recovery-2');
-    });
-
-    it('seals and checkpoints exact counters only while the document owns the active entry', () => {
-      const tab = createMemoryStorage();
-      const shared = createMemoryStorage();
-      const ownerStore = makeStore(tab, shared, 'owner-document', 'recording-a');
-      const state = ownerStore.claim('session-a');
-
-      expect(ownerStore.checkpoint({ ...state, nextSeq: 58, gen: 2 })).toBe(true);
-      expect(readCheckpoint(shared, 'recording-a')).toEqual(
-        expect.objectContaining({ nextSeq: 58, gen: 2, handoff: 'active' })
-      );
-
-      const stale = makeStore(tab, shared, 'stale-document', 'unused');
-      expect(stale.seal({ ...state, nextSeq: 100, gen: 3 })).toBe(false);
-      expect(stale.checkpoint({ ...state, nextSeq: 100, gen: 3 })).toBe(false);
-      expect(ownerStore.seal({ ...state, sessionId: 'session-b', nextSeq: 100, gen: 3 })).toBe(false);
-
-      expect(ownerStore.seal({ ...state, nextSeq: 60, gen: 2 })).toBe(true);
-      expect(readCheckpoint(shared, 'recording-a')).toEqual(expect.objectContaining({ nextSeq: 60, handoff: 'clean' }));
-      // A sealed entry is no longer owned by anyone.
-      expect(ownerStore.checkpoint({ ...state, nextSeq: 61, gen: 2 })).toBe(false);
-    });
-
-    it('rewrites the pointer to the recovery recording', () => {
-      const tab = createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'gone' }) });
-      const shared = createMemoryStorage();
-      expect(makeStore(tab, shared, 'doc-1', 'recovery').claim('session-a').recordingId).toBe('recovery');
-      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recovery' });
-      expect(readCheckpoint(shared, 'recovery')).toEqual(
-        expect.objectContaining({ handoff: 'active', documentId: 'doc-1' })
-      );
-    });
+function store(tab: Storage | undefined, documentId: string, documentState: DocumentRecordingState = {}) {
+  let sequence = 0;
+  return new ReplayRecordingStateStore({
+    storage: tab,
+    ownerNamespace: namespace,
+    documentId,
+    documentState,
+    generateRecordingId: () => `${documentId}-${++sequence}`,
   });
+}
 
-  describe('cloned tabs', () => {
-    function dormantOriginal() {
-      const tab = createMemoryStorage();
-      const shared = createMemoryStorage();
-      const store = makeStore(tab, shared, 'doc-a1', 'recording-a');
-      const state = store.claim('session-a');
-      expect(store.seal({ ...state, nextSeq: 42, gen: 3 })).toBe(true);
-      return { tab, shared, clone: cloneTab(tab) };
-    }
+const acquire = (owner: ReplayRecordingStateStore, signal = new AbortController().signal) =>
+  owner.acquire('A', signal, () => 'A');
 
-    it('lets the clone continue when it claims first and makes the original recover', () => {
-      const { tab, shared, clone } = dormantOriginal();
+async function release(lease: RecordingLease | undefined) {
+  lease?.release();
+  await lease?.released;
+}
 
-      const cloneClaim = makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a');
-      const originalClaim = makeStore(tab, shared, 'doc-a2', 'recovery-original').claim('session-a');
+it('writes counters at lease boundaries and continues the completed checkpoint in another document', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const write = jest.spyOn(tab, 'setItem');
+  const lease = (await acquire(store(tab, 'next')))!;
+  expect(JSON.parse(tab.getItem(key)!)).toEqual({ ...checkpoint, documentId: 'next', handoff: 'active' });
+  expect(lease.reserve(true)).toEqual({ recordingId: 'R', seq: 10, gen: 3 });
+  expect(lease.reserve(false)).toEqual({ recordingId: 'R', seq: 11, gen: 3 });
+  expect(write).toHaveBeenCalledTimes(1);
+  await release(lease);
+  lease.release();
+  expect(write).toHaveBeenCalledTimes(2);
+  expect(JSON.parse(tab.getItem(key)!)).toEqual({ ...checkpoint, documentId: 'next', nextSeq: 12, gen: 3 });
+  expect(lease.reserve(false)).toBeUndefined();
 
-      expect(cloneClaim).toEqual({ sessionId: 'session-a', recordingId: 'recording-a', nextSeq: 42, gen: 3 });
-      expect(originalClaim).toEqual({ sessionId: 'session-a', recordingId: 'recovery-original', nextSeq: 0, gen: -1 });
-      expect(JSON.parse(tab.getItem(pointerKey)!)).toEqual({ recordingId: 'recovery-original' });
-      expect(JSON.parse(clone.getItem(pointerKey)!)).toEqual({ recordingId: 'recording-a' });
-    });
+  const next = (await acquire(store(tab, 'restored')))!;
+  expect(next.reserve(true)).toEqual({ recordingId: 'R', seq: 12, gen: 4 });
+  await release(next);
+});
 
-    it('makes the clone recover when the original claims first', () => {
-      const { tab, shared, clone } = dormantOriginal();
+it('waits for the source lease, rereads its completed counters, and never holds two recording locks', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const source = (await acquire(store(tab, 'source')))!;
+  const waiting = acquire(store(tab, 'target'));
+  await Promise.resolve();
+  expect((await navigator.locks.query()).held).toEqual([
+    { name: recordingLockName(namespace, 'R'), mode: 'exclusive' },
+  ]);
+  expect(source.reserve(true)).toEqual({ recordingId: 'R', seq: 10, gen: 3 });
+  await release(source);
+  const target = (await waiting)!;
+  expect(target.reserve(true)).toEqual({ recordingId: 'R', seq: 11, gen: 4 });
+  await release(target);
+});
 
-      const originalClaim = makeStore(tab, shared, 'doc-a2', 'recovery-original').claim('session-a');
-      const cloneClaim = makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a');
-
-      expect(originalClaim.recordingId).toBe('recording-a');
-      expect(cloneClaim).toEqual({ sessionId: 'session-a', recordingId: 'recovery-clone', nextSeq: 0, gen: -1 });
-    });
-
-    it('makes the clone recover after the winner navigated and reclaimed in between', () => {
-      const { tab, shared, clone } = dormantOriginal();
-
-      const second = makeStore(tab, shared, 'doc-a2', 'unused');
-      const state = second.claim('session-a');
-      expect(second.seal({ ...state, nextSeq: 50, gen: 4 })).toBe(true);
-      const third = makeStore(tab, shared, 'doc-a3', 'unused');
-      expect(third.claim('session-a')).toEqual(expect.objectContaining({ recordingId: 'recording-a', nextSeq: 50 }));
-
-      expect(makeStore(clone, shared, 'doc-c1', 'recovery-clone').claim('session-a').recordingId).toBe(
-        'recovery-clone'
-      );
-    });
-
-    it('makes the clone recover when it claims while the winner is dormant again, without stale counters', () => {
-      const { tab, shared, clone } = dormantOriginal();
-
-      const second = makeStore(tab, shared, 'doc-a2', 'unused');
-      const state = second.claim('session-a');
-      expect(second.seal({ ...state, nextSeq: 50, gen: 4 })).toBe(true);
-
-      // The clone wins the dormant checkpoint, but from its latest sealed counters, never
-      // from the copied ones.
-      expect(makeStore(clone, shared, 'doc-c1', 'unused').claim('session-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recording-a',
-        nextSeq: 50,
-        gen: 4,
-      });
-      expect(makeStore(tab, shared, 'doc-a3', 'recovery-original').claim('session-a').recordingId).toBe(
-        'recovery-original'
-      );
-    });
-
-    it('lets both claimants of one replication race detect the other write and nothing else', () => {
-      const { tab, shared, clone } = dormantOriginal();
-      // Each renderer process reads its own replica of localStorage during the race window.
-      const replicaOriginal = cloneTab(shared);
-      const replicaClone = cloneTab(shared);
-      const original = makeStore(tab, replicaOriginal, 'doc-a2', 'recovery-original');
-      const cloned = makeStore(clone, replicaClone, 'doc-c1', 'recovery-clone');
-
-      const originalClaim = original.claim('session-a');
-      const cloneClaim = cloned.claim('session-a');
-      expect(cloneClaim).toEqual(originalClaim);
-
-      // The browser then delivers each write to the other Document as a storage event.
-      const key = checkpointKey('recording-a');
-      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)).toBe(true);
-      expect(cloned.hasLostOwnership('recording-a', key, replicaOriginal.getItem(key), null)).toBe(true);
-
-      // Own writes, other recordings, removals, malformed values, and other areas are not evidence.
-      expect(original.hasLostOwnership('recording-a', key, replicaOriginal.getItem(key), null)).toBe(false);
-      expect(
-        original.hasLostOwnership('recording-a', checkpointKey('recording-b'), replicaClone.getItem(key), null)
-      ).toBe(false);
-      expect(original.hasLostOwnership('recording-a', key, null, null)).toBe(false);
-      expect(original.hasLostOwnership('recording-a', key, 'not json', null)).toBe(false);
-      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), createMemoryStorage())).toBe(
-        false
-      );
-      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), replicaOriginal)).toBe(true);
-      expect(
-        makeStore(tab, undefined, 'doc-x', 'x').hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)
-      ).toBe(false);
-
-      // A sealed entry under the other Document is equally foreign.
-      expect(cloned.seal({ ...cloneClaim, nextSeq: 50, gen: 4 })).toBe(true);
-      expect(original.hasLostOwnership('recording-a', key, replicaClone.getItem(key), null)).toBe(true);
-    });
-
-    it('gives both tabs continuity again after a split', () => {
-      const { tab, shared, clone } = dormantOriginal();
-
-      const cloneStore = makeStore(clone, shared, 'doc-c1', 'unused');
-      const cloneState = cloneStore.claim('session-a');
-      const originalStore = makeStore(tab, shared, 'doc-a2', 'recovery-original');
-      const originalState = originalStore.claim('session-a');
-
-      expect(cloneStore.seal({ ...cloneState, nextSeq: 45, gen: 4 })).toBe(true);
-      expect(originalStore.seal({ ...originalState, nextSeq: 7, gen: 0 })).toBe(true);
-
-      expect(makeStore(clone, shared, 'doc-c2', 'unused').claim('session-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recording-a',
-        nextSeq: 45,
-        gen: 4,
-      });
-      expect(makeStore(tab, shared, 'doc-a3', 'unused').claim('session-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recovery-original',
-        nextSeq: 7,
-        gen: 0,
-      });
-    });
+it('keeps an active copied checkpoint waiting, then starts a fresh recording after the source releases', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const source = (await acquire(store(tab, 'source')))!;
+  const copy = storage({ [key]: tab.getItem(key)! });
+  let granted = false;
+  const waiting = acquire(store(copy, 'copy')).then((lease) => {
+    granted = true;
+    return lease;
   });
+  await Promise.resolve();
+  expect(granted).toBe(false);
+  await release(source);
+  const copied = (await waiting)!;
+  expect(copied.reserve(true)).toEqual({ recordingId: 'copy-1', seq: 0, gen: 0 });
+  expect((await navigator.locks.query()).held).toEqual([
+    { name: recordingLockName(namespace, 'copy-1'), mode: 'exclusive' },
+  ]);
+  await release(copied);
+});
 
-  describe('fail closed', () => {
-    const validCheckpoint = JSON.stringify({
-      sessionId: 'session-a',
-      nextSeq: 42,
-      gen: 3,
-      handoff: 'clean',
-      documentId: 'old-document',
-      updatedAt: 1_000,
-    });
+it('documents the accepted collision from independently copied stale clean state', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const copy = storage({ [key]: tab.getItem(key)! });
+  const source = (await acquire(store(tab, 'source')))!;
+  const original = source.reserve(true);
+  await release(source);
+  const copied = (await acquire(store(copy, 'copy')))!;
+  expect(original).toEqual({ recordingId: 'R', seq: 10, gen: 3 });
+  expect(copied.reserve(true)).toEqual(original);
+  await release(copied);
+});
 
-    it.each<[string, () => { tab: Storage | undefined; shared: Storage | undefined }]>([
-      [
-        'a missing pointer',
-        () => ({
-          tab: createMemoryStorage(),
-          shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }),
-        }),
-      ],
-      [
-        'a malformed pointer',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: '{"recordingId":42}' }),
-          shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }),
-        }),
-      ],
-      [
-        'a pointer to a missing checkpoint',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: createMemoryStorage(),
-        }),
-      ],
-      [
-        'a malformed checkpoint',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: createMemoryStorage({
-            [checkpointKey('recording-a')]: '{"sessionId":"session-a","handoff":"clean"}',
-          }),
-        }),
-      ],
-      [
-        'a checkpoint without updatedAt',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: createMemoryStorage({
-            [checkpointKey('recording-a')]: JSON.stringify({ ...JSON.parse(validCheckpoint), updatedAt: undefined }),
-          }),
-        }),
-      ],
-      [
-        'a checkpoint of another session',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: createMemoryStorage({
-            [checkpointKey('recording-a')]: JSON.stringify({ ...JSON.parse(validCheckpoint), sessionId: 'session-b' }),
-          }),
-        }),
-      ],
-      [
-        'unreadable shared storage',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: {
-            ...createMemoryStorage(),
-            getItem: () => {
-              throw new DOMException('Storage is not readable', 'SecurityError');
-            },
-          } as Storage,
-        }),
-      ],
-      [
-        'unwritable shared storage',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: {
-            ...createMemoryStorage(),
-            getItem: () => validCheckpoint,
-            setItem: () => {
-              throw new DOMException('Storage is not writable', 'SecurityError');
-            },
-          } as Storage,
-        }),
-      ],
-      [
-        'no tab storage',
-        () => ({ tab: undefined, shared: createMemoryStorage({ [checkpointKey('recording-a')]: validCheckpoint }) }),
-      ],
-      [
-        'no shared storage',
-        () => ({
-          tab: createMemoryStorage({ [pointerKey]: JSON.stringify({ recordingId: 'recording-a' }) }),
-          shared: undefined,
-        }),
-      ],
-    ])('mints a recovery recording for %s', (_scenario, setup) => {
-      const { tab, shared } = setup();
-      expect(makeStore(tab, shared, 'new-document', 'recovery').claim('session-a')).toEqual({
-        sessionId: 'session-a',
-        recordingId: 'recovery',
-        nextSeq: 0,
-        gen: -1,
-      });
-    });
+it('cancels a queued acquisition without publishing or replacing the source checkpoint', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const source = (await acquire(store(tab, 'source')))!;
+  const controller = new AbortController();
+  const waiting = acquire(store(tab, 'target'), controller.signal);
+  controller.abort();
+  expect(await waiting).toBeUndefined();
+  expect(JSON.parse(tab.getItem(key)!).documentId).toBe('source');
+  await release(source);
+});
 
-    it('does not adopt a legacy checkpoint and removes it', () => {
-      const legacyKey = `${legacyReplayRecordingStorageKeyPrefix}${owner}`;
-      const tab = createMemoryStorage({
-        [legacyKey]: JSON.stringify({
-          sessionId: 'session-a',
-          recordingId: 'legacy-recording',
-          nextSeq: 42,
-          gen: 3,
-          handoff: 'clean',
-          documentId: 'old-document',
-        }),
-        'unrelated-key': 'kept',
-      });
-      const store = makeStore(tab, createMemoryStorage(), 'doc-1', 'recovery');
-      store.removeLegacyState();
+it('releases an obsolete grant when its session changes at the grant boundary', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const owner = store(tab, 'next');
+  const lease = await owner.acquire('A', new AbortController().signal, () => 'B');
+  expect(lease).toBeUndefined();
+  expect(tab.getItem(key)).toBe(JSON.stringify(checkpoint));
+  expect((await navigator.locks.query()).held).toEqual([]);
+});
 
-      expect(tab.getItem(legacyKey)).toBeNull();
-      expect(tab.getItem('unrelated-key')).toBe('kept');
-      expect(store.claim('session-a').recordingId).toBe('recovery');
-    });
+it('releases the old lock before adopting a different current recording after grant', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  let unblock!: () => void;
+  const blocker = navigator.locks.request(
+    recordingLockName(namespace, 'R'),
+    () =>
+      new Promise<void>((resolve) => {
+        unblock = resolve;
+      })
+  );
+  await Promise.resolve();
+  const waiting = acquire(store(tab, 'next'));
+  tab.setItem(key, JSON.stringify({ ...checkpoint, recordingId: 'replacement', nextSeq: 20 }));
+  unblock();
+  await blocker;
+  const lease = (await waiting)!;
+  expect(lease.reserve(true)).toEqual({ recordingId: 'replacement', seq: 20, gen: 3 });
+  expect((await navigator.locks.query()).held).toEqual([
+    { name: recordingLockName(namespace, 'replacement'), mode: 'exclusive' },
+  ]);
+  await release(lease);
+});
+
+it.each([
+  null,
+  '{',
+  '{}',
+  JSON.stringify({ ...checkpoint, sessionId: 'other' }),
+  JSON.stringify({ ...checkpoint, handoff: 'active' }),
+  JSON.stringify({ ...checkpoint, nextSeq: -1 }),
+  JSON.stringify({ ...checkpoint, nextSeq: Number.MAX_SAFE_INTEGER }),
+])('recovers unusable continuation state under a fresh locked identity: %s', async (value) => {
+  const tab = storage(value === null ? {} : { [key]: value });
+  const lease = (await acquire(store(tab, 'fresh')))!;
+  expect(lease.reserve(true)).toEqual({ recordingId: 'fresh-1', seq: 0, gen: 0 });
+  await release(lease);
+});
+
+it('does not overwrite a superseding document or admit a stale lease reservation', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const lease = (await acquire(store(tab, 'first')))!;
+  const replacement = JSON.stringify({ ...checkpoint, recordingId: 'replacement', documentId: 'other' });
+  tab.setItem(key, replacement);
+  expect(lease.ownership()).toBe('superseded');
+  expect(lease.reserve(true)).toBeUndefined();
+  await release(lease);
+  expect(tab.getItem(key)).toBe(replacement);
+});
+
+it('splits before publishing when an existing clean identity cannot receive its active marker', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const memory: DocumentRecordingState = {};
+  jest.spyOn(tab, 'setItem').mockImplementation(() => {
+    throw new Error('quota');
   });
+  const lease = (await acquire(store(tab, 'document', memory)))!;
+  expect(lease.reserve(true)).toEqual({ recordingId: 'document-1', seq: 0, gen: 0 });
+  expect(tab.getItem(key)).toBe(JSON.stringify(checkpoint));
+  await release(lease);
 
-  describe('pruning', () => {
-    function seedCheckpoints(shared: Storage, count: number, at: (index: number) => number) {
-      for (let index = 0; index < count; index++) {
-        makeStore(createMemoryStorage(), shared, `doc-${index}`, `recording-${index}`, () => at(index)).claim(
-          'session-a'
-        );
-      }
-    }
+  const replacement = (await acquire(store(tab, 'document', memory)))!;
+  expect(replacement.reserve(true)).toEqual({ recordingId: 'document-1', seq: 1, gen: 1 });
+  await release(replacement);
+});
 
-    it('removes checkpoints older than the age bound but never the claiming tab entry', () => {
-      const shared = createMemoryStorage();
-      const base = 1_000_000;
-      seedCheckpoints(shared, 3, () => base);
-      const tab = createMemoryStorage();
-      const dormant = makeStore(tab, shared, 'doc-old', 'recording-old', () => base);
-      expect(dormant.seal({ ...dormant.claim('session-a'), nextSeq: 9, gen: 1 })).toBe(true);
-
-      const later = base + MAX_RECORDING_CHECKPOINT_AGE_MS + 1;
-      const claim = makeStore(tab, shared, 'doc-new', 'unused', () => later).claim('session-a');
-
-      expect(claim).toEqual(expect.objectContaining({ recordingId: 'recording-old', nextSeq: 9 }));
-      expect(checkpointKeys(shared)).toEqual([checkpointKey('recording-old')]);
-    });
-
-    it.each([5_000, 500])('keeps the claiming entry and newest active checkpoints when claimed at %i', (now) => {
-      const shared = createMemoryStorage();
-      const total = MAX_RETAINED_RECORDING_CHECKPOINTS + 5;
-      seedCheckpoints(shared, total, (index) => 1_000 + index);
-
-      const claim = makeStore(createMemoryStorage(), shared, 'doc-new', 'recording-new', () => now).claim('session-a');
-
-      expect(claim.recordingId).toBe('recording-new');
-      const keys = checkpointKeys(shared);
-      expect(keys).toHaveLength(MAX_RETAINED_RECORDING_CHECKPOINTS);
-      expect(keys).toContain(checkpointKey('recording-new'));
-      for (let index = 0; index < total; index++) {
-        expect(keys.includes(checkpointKey(`recording-${index}`))).toBe(
-          index >= total - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1)
-        );
-      }
-    });
-
-    it('preserves navigation continuity while other tabs repeatedly record and close', () => {
-      const tab = createMemoryStorage();
-      const shared = createMemoryStorage();
-      let now = 1_000;
-      const active = makeStore(tab, shared, 'doc-active', 'recording-active', () => now);
-      const state = active.claim('session-a');
-      const total = MAX_RETAINED_RECORDING_CHECKPOINTS + 5;
-
-      for (let index = 0; index < total; index++) {
-        now++;
-        const other = makeStore(createMemoryStorage(), shared, `doc-${index}`, `recording-${index}`, () => now);
-        expect(other.seal(other.claim('session-a'))).toBe(true);
-        expect(checkpointKeys(shared)).toHaveLength(Math.min(index + 2, MAX_RETAINED_RECORDING_CHECKPOINTS));
-      }
-
-      const keys = checkpointKeys(shared);
-      expect(keys).toContain(checkpointKey('recording-active'));
-      for (let index = 0; index < total; index++) {
-        expect(keys.includes(checkpointKey(`recording-${index}`))).toBe(
-          index >= total - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1)
-        );
-      }
-
-      now++;
-      const finalState = { ...state, nextSeq: 42, gen: 3 };
-      expect(active.seal(finalState)).toBe(true);
-      const nextPage = makeStore(tab, shared, 'doc-next', 'recovery', () => now + 1);
-      expect(nextPage.claim('session-a')).toEqual(finalState);
-    });
-
-    it('evicts clean checkpoints oldest first before falling back to the oldest active checkpoint', () => {
-      const shared = createMemoryStorage();
-      const activeCount = MAX_RETAINED_RECORDING_CHECKPOINTS - 2;
-      seedCheckpoints(shared, activeCount, (index) => 1_000 + index);
-      for (let index = 0; index < 2; index++) {
-        const clean = makeStore(
-          createMemoryStorage(),
-          shared,
-          `doc-clean-${index}`,
-          `clean-${index}`,
-          () => 2_000 + index
-        );
-        expect(clean.seal(clean.claim('session-a'))).toBe(true);
-      }
-
-      for (let index = 0; index < 3; index++) {
-        makeStore(createMemoryStorage(), shared, `doc-new-${index}`, `new-${index}`, () => 3_000 + index).claim(
-          'session-a'
-        );
-
-        const keys = checkpointKeys(shared);
-        expect(keys).toHaveLength(MAX_RETAINED_RECORDING_CHECKPOINTS);
-        expect(keys).not.toContain(checkpointKey('clean-0'));
-        expect(keys.includes(checkpointKey('clean-1'))).toBe(index === 0);
-        expect(keys.includes(checkpointKey('recording-0'))).toBe(index < 2);
-        for (let activeIndex = 1; activeIndex < activeCount; activeIndex++) {
-          expect(keys).toContain(checkpointKey(`recording-${activeIndex}`));
-        }
-        for (let newIndex = 0; newIndex <= index; newIndex++) {
-          expect(keys).toContain(checkpointKey(`new-${newIndex}`));
-        }
-      }
-    });
-
-    it('removes malformed entries under the owner prefix and leaves other keys alone', () => {
-      const shared = createMemoryStorage({
-        [checkpointKey('broken')]: 'not json',
-        [`${replayRecordingCheckpointKeyPrefix}["other-owner"]:recording`]: 'not json',
-        'com.grafana.faro.session': 'kept',
-      });
-
-      makeStore(createMemoryStorage(), shared, 'doc-1', 'recording-a', () => 1_000).claim('session-a');
-
-      expect(shared.getItem(checkpointKey('broken'))).toBeNull();
-      expect(shared.getItem(`${replayRecordingCheckpointKeyPrefix}["other-owner"]:recording`)).toBe('not json');
-      expect(shared.getItem('com.grafana.faro.session')).toBe('kept');
-    });
-
-    it('makes a pruned dormant tab recover instead of continuing', () => {
-      const shared = createMemoryStorage();
-      const base = 1_000_000;
-      const tab = createMemoryStorage();
-      const dormant = makeStore(tab, shared, 'doc-old', 'recording-old', () => base);
-      expect(dormant.seal({ ...dormant.claim('session-a'), nextSeq: 9, gen: 1 })).toBe(true);
-
-      const later = base + MAX_RECORDING_CHECKPOINT_AGE_MS + 1;
-      makeStore(createMemoryStorage(), shared, 'doc-other', 'recording-other', () => later).claim('session-a');
-      expect(shared.getItem(checkpointKey('recording-old'))).toBeNull();
-
-      expect(makeStore(tab, shared, 'doc-new', 'recovery', () => later + 1).claim('session-a').recordingId).toBe(
-        'recovery'
-      );
-    });
+it('retains known counters after failed final persistence while another document splits', async () => {
+  const tab = storage({ [key]: JSON.stringify(checkpoint) });
+  const memory: DocumentRecordingState = {};
+  const lease = (await acquire(store(tab, 'document', memory)))!;
+  lease.reserve(true);
+  const write = jest.spyOn(tab, 'setItem').mockImplementation(() => {
+    throw new Error('quota');
   });
+  await release(lease);
+  expect(JSON.parse(tab.getItem(key)!)).toMatchObject({ handoff: 'active', nextSeq: 10, gen: 2 });
+
+  const replacement = (await acquire(store(tab, 'document', memory)))!;
+  expect(replacement.reserve(true)).toEqual({ recordingId: 'R', seq: 11, gen: 4 });
+  await release(replacement);
+  write.mockRestore();
+  const next = (await acquire(store(tab, 'another')))!;
+  expect(next.reserve(true)).toEqual({ recordingId: 'another-1', seq: 0, gen: 0 });
+  await release(next);
+});
+
+it('uses the same native lease protocol for document-local replacement without storage', async () => {
+  const memory: DocumentRecordingState = {};
+  const lease = (await acquire(store(undefined, 'document', memory)))!;
+  lease.reserve(true);
+  await release(lease);
+  const replacement = (await acquire(store(undefined, 'document', memory)))!;
+  expect(replacement.reserve(true)).toEqual({ recordingId: 'document-1', seq: 1, gen: 1 });
+  await release(replacement);
+  const next = (await acquire(store(undefined, 'another')))!;
+  expect(next.reserve(true)).toEqual({ recordingId: 'another-1', seq: 0, gen: 0 });
+  await release(next);
 });

--- a/experimental/instrumentation-replay/src/recordingState.ts
+++ b/experimental/instrumentation-replay/src/recordingState.ts
@@ -1,337 +1,336 @@
-export interface ReplayRecordingState {
+export interface TabRecordingState {
   sessionId: string;
   recordingId: string;
   nextSeq: number;
   gen: number;
-}
-
-interface PersistedReplayRecordingState extends Omit<ReplayRecordingState, 'recordingId'> {
-  handoff: 'active' | 'clean';
   documentId: string;
-  updatedAt: number;
+  handoff: 'active' | 'clean';
 }
 
-interface PersistedRecordingPointer {
-  recordingId: string;
+interface CompletedRecording {
+  state: TabRecordingState;
+  local: boolean;
+  anchor: string | null | undefined;
 }
 
-export interface ReplayRecordingStateStoreOptions {
-  // Tab-scoped storage (sessionStorage) holding only a pointer to the current recording.
-  // A browser may copy it into a derived tab; that is harmless because it carries no counters.
-  tabStorage: Storage | undefined;
-  // Origin-shared storage (localStorage) holding one checkpoint per recording. Every tab that
-  // references a recording reads and writes the same entry, so ownership is unambiguous.
-  sharedStorage: Storage | undefined;
+/** Shared only by replacements within one document activation. */
+export interface DocumentRecordingState {
+  owner?: object;
+  handoff?: CompletedRecording;
+}
+
+export interface RecordingLease {
+  readonly state: TabRecordingState;
+  readonly released: Promise<void>;
+  ownership: () => 'owned' | 'lost' | 'superseded';
+  reserve: (meta: boolean) => { recordingId: string; seq: number; gen: number } | undefined;
+  release: () => void;
+}
+
+interface StorageSnapshot {
+  available: boolean;
+  serialized?: string | null;
+  state?: TabRecordingState;
+}
+
+interface Candidate extends CompletedRecording {
+  source: 'fresh' | 'memory' | 'storage';
+}
+
+interface StoreOptions {
+  storage: Storage | undefined;
   ownerNamespace: string;
   documentId: string;
+  documentState: DocumentRecordingState;
   generateRecordingId: () => string;
-  now?: () => number;
-  // Shared by replacement stores for the same owner in one Document.
-  abandonedRecordingIds?: Set<string>;
 }
 
-export const replayRecordingPointerKeyPrefix = 'com.grafana.faro.replay.tab:';
-export const replayRecordingCheckpointKeyPrefix = 'com.grafana.faro.replay.rec:';
-// Pre-v3 builds kept a copyable checkpoint under this key. It is removed, never adopted.
-export const legacyReplayRecordingStorageKeyPrefix = 'com.grafana.faro.replay:';
+export const replayRecordingStorageKeyPrefix = 'com.grafana.faro.replay.current:';
 
-// Pruning only costs continuity, for a dormant tab or for a live tab beyond the bounds whose
-// entry is refreshed only at Document boundaries; it can never enable a collision.
-export const MAX_RETAINED_RECORDING_CHECKPOINTS: number = 16;
-export const MAX_RECORDING_CHECKPOINT_AGE_MS: number = 24 * 60 * 60 * 1000;
-
-export function createMemoryStorage(initial: Record<string, string> = {}): Storage {
-  const entries = new Map(Object.entries(initial));
-  return {
-    get length() {
-      return entries.size;
-    },
-    key: (index: number) => Array.from(entries.keys())[index] ?? null,
-    getItem: (key: string) => entries.get(key) ?? null,
-    setItem: (key: string, value: string) => void entries.set(key, String(value)),
-    removeItem: (key: string) => void entries.delete(key),
-    clear: () => entries.clear(),
-  };
+export function recordingLockName(ownerNamespace: string, recordingId: string): string {
+  return `com.grafana.faro.replay.lock:${JSON.stringify([ownerNamespace, recordingId])}`;
 }
 
 export class ReplayRecordingStateStore {
-  private readonly tabStorage: Storage | undefined;
-  private readonly sharedStorage: Storage | undefined;
-  private readonly documentId: string;
-  private readonly generateRecordingId: () => string;
-  private readonly now: () => number;
-  private readonly pointerKey: string;
-  private readonly checkpointKeyPrefix: string;
-  private readonly legacyKey: string;
-  private readonly abandonedRecordingIds: Set<string>;
+  private readonly key: string;
 
-  constructor(options: ReplayRecordingStateStoreOptions) {
-    this.tabStorage = options.tabStorage;
-    this.sharedStorage = options.sharedStorage;
-    this.documentId = options.documentId;
-    this.generateRecordingId = options.generateRecordingId;
-    this.now = options.now ?? (() => Date.now());
-    this.pointerKey = `${replayRecordingPointerKeyPrefix}${options.ownerNamespace}`;
-    this.checkpointKeyPrefix = `${replayRecordingCheckpointKeyPrefix}${options.ownerNamespace}:`;
-    this.legacyKey = `${legacyReplayRecordingStorageKeyPrefix}${options.ownerNamespace}`;
-    this.abandonedRecordingIds = options.abandonedRecordingIds ?? new Set();
+  constructor(private readonly options: StoreOptions) {
+    this.key = `${replayRecordingStorageKeyPrefix}${options.ownerNamespace}`;
   }
 
-  // Prefer the one-time same-document handoff over a possibly stale tab pointer.
-  // Continue only a clean checkpoint or the explicitly handed-off active checkpoint.
-  // Missing, invalid, or abandoned state fails closed into a recovery recording.
-  claim(sessionId: string, activeHandoffRecordingId?: string): ReplayRecordingState {
-    const recordingId = activeHandoffRecordingId ?? this.readPointer();
-    if (recordingId !== undefined && !this.abandonedRecordingIds.has(recordingId)) {
-      const persisted = this.readCheckpoint(recordingId);
-      if (
-        persisted?.sessionId === sessionId &&
-        (persisted.handoff === 'clean' || (persisted.handoff === 'active' && recordingId === activeHandoffRecordingId))
-      ) {
-        const continuedState: ReplayRecordingState = {
-          sessionId,
-          recordingId,
-          nextSeq: persisted.nextSeq,
-          gen: persisted.gen,
-        };
-        if (this.writeCheckpoint(continuedState, 'active')) {
-          if (activeHandoffRecordingId !== undefined) {
-            this.writePointer(recordingId);
-          }
-          this.prune(recordingId);
-          return continuedState;
-        }
-      }
-    }
-
-    const recoveryState: ReplayRecordingState = {
-      sessionId,
-      recordingId: this.generateRecordingId(),
-      nextSeq: 0,
-      gen: -1,
-    };
-    this.writeCheckpoint(recoveryState, 'active');
-    // A claimant that lost points at its own recording from now on and stops touching the
-    // winner's entry, so both tabs regain continuity after a split.
-    this.writePointer(recoveryState.recordingId);
-    this.prune(recoveryState.recordingId);
-    return recoveryState;
-  }
-
-  // Revocation must survive failed pointer writes and later clean checkpoints.
-  abandon(recordingId: string): void {
-    this.abandonedRecordingIds.add(recordingId);
-  }
-
-  checkpoint(state: ReplayRecordingState): boolean {
-    return this.transition(state, 'active');
-  }
-
-  // Whether a `storage` event from another Document shows that this recording's entry now
-  // belongs to a different Document. Two claimants can both read a clean checkpoint inside the
-  // browser's cross-process replication window; the browser then delivers the other claimant's
-  // write as a `storage` event, which is the positive evidence this Document lost the race.
-  // A removed entry is not evidence of a claimant, so it only costs continuity later.
-  hasLostOwnership(
-    recordingId: string,
-    key: string | null,
-    newValue: string | null,
-    storageArea: Storage | null
-  ): boolean {
-    if (!this.sharedStorage || key !== this.checkpointKey(recordingId)) {
-      return false;
-    }
-
-    if (storageArea !== null && storageArea !== this.sharedStorage) {
-      return false;
-    }
-
-    const persisted = this.parseCheckpoint(newValue);
-    return persisted !== undefined && persisted.documentId !== this.documentId;
-  }
-
-  seal(state: ReplayRecordingState): boolean {
-    return this.transition(state, 'clean');
-  }
-
-  removeLegacyState(): void {
-    try {
-      this.tabStorage?.removeItem(this.legacyKey);
-    } catch {
-      // Best effort: the legacy key is never read, so leaving it behind is harmless.
-    }
-  }
-
-  private transition(state: ReplayRecordingState, handoff: PersistedReplayRecordingState['handoff']): boolean {
-    const persisted = this.readCheckpoint(state.recordingId);
-    if (
-      persisted?.handoff !== 'active' ||
-      persisted.documentId !== this.documentId ||
-      persisted.sessionId !== state.sessionId
-    ) {
-      return false;
-    }
-
-    return this.writeCheckpoint(state, handoff);
-  }
-
-  // Remove other recordings' checkpoints past the age bound, then evict the oldest clean
-  // checkpoints before active ones to meet the cap.
-  // The claiming tab's own entry is exempt. Malformed entries under our prefix can never be
-  // claimed, so they are removed as well.
-  private prune(exemptRecordingId: string): void {
-    const storage = this.sharedStorage;
-    if (!storage) {
-      return;
-    }
-
-    try {
-      const exemptKey = this.checkpointKey(exemptRecordingId);
-      const candidates: string[] = [];
-      for (let index = 0; index < storage.length; index++) {
-        const key = storage.key(index);
-        if (key === null || key === exemptKey || !key.startsWith(this.checkpointKeyPrefix)) {
-          continue;
-        }
-        candidates.push(key);
-      }
-
-      const now = this.now();
-      const retained: Array<{
-        key: string;
-        updatedAt: number;
-        handoff: PersistedReplayRecordingState['handoff'];
-      }> = [];
-      for (const key of candidates) {
-        const state = this.parseCheckpoint(storage.getItem(key));
-        if (state === undefined || now - state.updatedAt > MAX_RECORDING_CHECKPOINT_AGE_MS) {
-          storage.removeItem(key);
-        } else {
-          retained.push({ key, updatedAt: state.updatedAt, handoff: state.handoff });
-        }
-      }
-
-      retained.sort((a, b) => {
-        if (a.handoff !== b.handoff) {
-          return a.handoff === 'clean' ? -1 : 1;
-        }
-        return a.updatedAt - b.updatedAt;
+  /** Resolves on grant. The native request promise remains pending until release. */
+  async acquire(
+    sessionId: string,
+    signal: AbortSignal,
+    currentSessionId: () => string | null
+  ): Promise<RecordingLease | undefined> {
+    let candidate = this.select(sessionId);
+    while (!signal.aborted) {
+      type Grant = { lease: RecordingLease } | { retry: Candidate } | undefined;
+      let resolveGrant!: (grant: Grant) => void;
+      let rejectGrant!: (error: unknown) => void;
+      const granted = new Promise<Grant>((resolve, reject) => {
+        resolveGrant = resolve;
+        rejectGrant = reject;
       });
-      const excess = Math.max(0, retained.length - (MAX_RETAINED_RECORDING_CHECKPOINTS - 1));
-      for (const stale of retained.slice(0, excess)) {
-        storage.removeItem(stale.key);
+      let completeRelease!: () => void;
+      const released = new Promise<void>((resolve) => {
+        completeRelease = resolve;
+      });
+      try {
+        const request = navigator.locks.request(
+          recordingLockName(this.options.ownerNamespace, candidate.state.recordingId),
+          { mode: 'exclusive', signal },
+          () => {
+            if (signal.aborted || currentSessionId() !== sessionId || signal.aborted) {
+              resolveGrant(undefined);
+              return;
+            }
+
+            const latest = this.select(sessionId, candidate.source === 'fresh' ? candidate : undefined);
+            if (signal.aborted) {
+              resolveGrant(undefined);
+              return;
+            }
+            if (latest.state.recordingId !== candidate.state.recordingId) {
+              resolveGrant({ retry: latest });
+              return;
+            }
+            if (latest.source === 'storage' && latest.state.handoff === 'active') {
+              resolveGrant({ retry: this.fresh(sessionId, this.read()) });
+              return;
+            }
+
+            const state: TabRecordingState = {
+              ...latest.state,
+              documentId: this.options.documentId,
+              handoff: 'active',
+            };
+            let local = latest.local;
+            let anchor = latest.anchor;
+            if (!local) {
+              if (this.write(state)) {
+                anchor = JSON.stringify(state);
+              } else if (latest.source !== 'fresh') {
+                // A clean stored identity must not remain redeemable while its
+                // counters advance without an active marker.
+                resolveGrant({ retry: this.fresh(sessionId, this.read(), true) });
+                return;
+              } else {
+                local = true;
+                anchor = this.read().serialized ?? anchor;
+              }
+            }
+
+            let release!: () => void;
+            const held = new Promise<void>((resolve) => {
+              release = resolve;
+            });
+            const lease = this.createLease(state, local, anchor, release, released);
+            if (signal.aborted) {
+              lease.release();
+            }
+            resolveGrant({ lease });
+            return held;
+          }
+        );
+        void request.then(completeRelease, (error) => {
+          completeRelease();
+          rejectGrant(error);
+        });
+        const grant = await granted;
+        if (grant && 'lease' in grant) {
+          return grant.lease;
+        }
+        // This promise settles after native ownership ends. Never queue another
+        // recording lock while still holding the rejected candidate's lock.
+        await request;
+        if (!grant) {
+          return undefined;
+        }
+        candidate = grant.retry;
+      } catch (error) {
+        if (signal.aborted) {
+          return undefined;
+        }
+        throw error;
       }
-    } catch {
-      // Pruning is best effort and must never affect the claim that triggered it.
     }
+    return undefined;
   }
 
-  private checkpointKey(recordingId: string): string {
-    return `${this.checkpointKeyPrefix}${recordingId}`;
-  }
+  private createLease(
+    state: TabRecordingState,
+    local: boolean,
+    anchor: string | null | undefined,
+    releaseLock: () => void,
+    releasedLock: Promise<void>
+  ): RecordingLease {
+    const documentState = this.options.documentState;
+    const owner = {};
+    documentState.owner = owner;
+    documentState.handoff = undefined;
+    let released = false;
 
-  private readPointer(): string | undefined {
-    if (!this.tabStorage) {
-      return undefined;
-    }
+    const owns = (snapshot: StorageSnapshot): boolean =>
+      local
+        ? snapshot.serialized === anchor
+        : snapshot.state?.recordingId === state.recordingId &&
+          snapshot.state.sessionId === state.sessionId &&
+          snapshot.state.documentId === state.documentId &&
+          snapshot.state.handoff === 'active';
 
-    try {
-      const serialized = this.tabStorage.getItem(this.pointerKey);
-      if (!serialized) {
-        return undefined;
+    const ownership: RecordingLease['ownership'] = () => {
+      if (released || documentState.owner !== owner) {
+        return 'superseded';
       }
+      const snapshot = this.read();
+      if (!snapshot.available || owns(snapshot)) {
+        return 'owned';
+      }
+      return snapshot.state ? 'superseded' : 'lost';
+    };
 
-      const value: unknown = JSON.parse(serialized);
-      return this.isPointer(value) ? value.recordingId : undefined;
-    } catch {
-      return undefined;
-    }
+    return {
+      state,
+      released: releasedLock,
+      ownership,
+      reserve: (meta) => {
+        if (
+          ownership() !== 'owned' ||
+          !Number.isSafeInteger(state.nextSeq + 1) ||
+          !Number.isSafeInteger(state.gen + (meta ? 1 : 0))
+        ) {
+          return undefined;
+        }
+        if (meta) {
+          state.gen++;
+        }
+        return { recordingId: state.recordingId, seq: state.nextSeq++, gen: Math.max(0, state.gen) };
+      },
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        try {
+          if (documentState.owner !== owner) {
+            return;
+          }
+          const snapshot = this.read();
+          if (snapshot.available && !owns(snapshot) && snapshot.state) {
+            return;
+          }
+          const clean: TabRecordingState = { ...state, handoff: 'clean' };
+          const persisted = !local && snapshot.available && owns(snapshot) && this.write(clean);
+          documentState.handoff = {
+            state: clean,
+            local: !persisted,
+            anchor: persisted ? JSON.stringify(clean) : snapshot.available ? snapshot.serialized : anchor,
+          };
+        } finally {
+          if (documentState.owner === owner) {
+            documentState.owner = undefined;
+          }
+          releaseLock();
+        }
+      },
+    };
   }
 
-  private writePointer(recordingId: string): void {
-    if (!this.tabStorage) {
-      return;
-    }
-
-    try {
-      const pointer: PersistedRecordingPointer = { recordingId };
-      this.tabStorage.setItem(this.pointerKey, JSON.stringify(pointer));
-    } catch {
-      // The in-memory recording remains usable even if its pointer cannot be persisted.
-    }
-  }
-
-  private readCheckpoint(recordingId: string): PersistedReplayRecordingState | undefined {
-    if (!this.sharedStorage) {
-      return undefined;
-    }
-
-    try {
-      return this.parseCheckpoint(this.sharedStorage.getItem(this.checkpointKey(recordingId)));
-    } catch {
-      return undefined;
-    }
-  }
-
-  private parseCheckpoint(serialized: string | null): PersistedReplayRecordingState | undefined {
-    if (!serialized) {
-      return undefined;
-    }
-
-    try {
-      const value: unknown = JSON.parse(serialized);
-      return this.isPersistedState(value) ? value : undefined;
-    } catch {
-      return undefined;
-    }
-  }
-
-  private writeCheckpoint(state: ReplayRecordingState, handoff: PersistedReplayRecordingState['handoff']): boolean {
-    if (!this.sharedStorage) {
-      return false;
-    }
-
-    try {
-      const persisted: PersistedReplayRecordingState = {
-        sessionId: state.sessionId,
-        nextSeq: state.nextSeq,
-        gen: state.gen,
-        handoff,
-        documentId: this.documentId,
-        updatedAt: this.now(),
+  private select(sessionId: string, prepared?: Candidate): Candidate {
+    const snapshot = this.read();
+    if (
+      prepared &&
+      (!snapshot.available ||
+        snapshot.serialized === prepared.anchor ||
+        (prepared.anchor === undefined && !snapshot.state))
+    ) {
+      return {
+        ...prepared,
+        local: prepared.local || !snapshot.available,
+        anchor: snapshot.available ? snapshot.serialized : prepared.anchor,
       };
-      this.sharedStorage.setItem(this.checkpointKey(state.recordingId), JSON.stringify(persisted));
+    }
+    const handoff = this.options.documentState.handoff;
+    if (
+      handoff?.state.sessionId === sessionId &&
+      this.valid(handoff.state) &&
+      ((!snapshot.available && handoff.local) || (snapshot.available && snapshot.serialized === handoff.anchor))
+    ) {
+      return { ...handoff, source: 'memory' };
+    }
+    if (snapshot.state?.sessionId === sessionId) {
+      return { state: snapshot.state, source: 'storage', local: false, anchor: snapshot.serialized };
+    }
+    return this.fresh(sessionId, snapshot);
+  }
+
+  private fresh(sessionId: string, snapshot: StorageSnapshot, local = false): Candidate {
+    return {
+      state: {
+        sessionId,
+        recordingId: this.options.generateRecordingId(),
+        nextSeq: 0,
+        gen: -1,
+        documentId: this.options.documentId,
+        handoff: 'clean',
+      },
+      source: 'fresh',
+      local: local || !snapshot.available,
+      anchor: snapshot.serialized,
+    };
+  }
+
+  private read(): StorageSnapshot {
+    if (!this.options.storage) {
+      return { available: false };
+    }
+    try {
+      const serialized = this.options.storage.getItem(this.key);
+      let state: unknown;
+      try {
+        state = serialized ? JSON.parse(serialized) : undefined;
+      } catch {
+        // Malformed current state cannot supply counters.
+      }
+      return { available: true, serialized, state: this.valid(state) ? state : undefined };
+    } catch {
+      return { available: false };
+    }
+  }
+
+  private write(state: TabRecordingState): boolean {
+    try {
+      if (!this.options.storage) {
+        return false;
+      }
+      this.options.storage.setItem(this.key, JSON.stringify(state));
       return true;
     } catch {
       return false;
     }
   }
 
-  private isPointer(value: unknown): value is PersistedRecordingPointer {
-    return (
-      value != null &&
-      typeof value === 'object' &&
-      typeof (value as Partial<PersistedRecordingPointer>).recordingId === 'string' &&
-      (value as PersistedRecordingPointer).recordingId.length > 0
-    );
-  }
-
-  private isPersistedState(value: unknown): value is PersistedReplayRecordingState {
-    if (value == null || typeof value !== 'object') {
+  private valid(value: unknown): value is TabRecordingState {
+    if (!value || typeof value !== 'object') {
       return false;
     }
-
-    const state = value as Partial<PersistedReplayRecordingState>;
+    const state = value as Partial<TabRecordingState>;
     return (
       typeof state.sessionId === 'string' &&
+      state.sessionId.length > 0 &&
+      typeof state.recordingId === 'string' &&
+      state.recordingId.length > 0 &&
+      typeof state.documentId === 'string' &&
+      state.documentId.length > 0 &&
       Number.isSafeInteger(state.nextSeq) &&
       state.nextSeq! >= 0 &&
+      state.nextSeq! < Number.MAX_SAFE_INTEGER &&
       Number.isSafeInteger(state.gen) &&
       state.gen! >= -1 &&
-      (state.handoff === 'active' || state.handoff === 'clean') &&
-      typeof state.documentId === 'string' &&
-      Number.isSafeInteger(state.updatedAt) &&
-      state.updatedAt! >= 0
+      state.gen! < Number.MAX_SAFE_INTEGER &&
+      (state.handoff === 'active' || state.handoff === 'clean')
     );
   }
 }

--- a/experimental/instrumentation-replay/src/rrwebRuntime.ts
+++ b/experimental/instrumentation-replay/src/rrwebRuntime.ts
@@ -1,0 +1,60 @@
+let producer: object | undefined;
+let executionDepth = 0;
+let pendingCleanup: Promise<void> | undefined;
+
+export function registerReplayProducer(owner: object): () => void {
+  if (producer) {
+    throw new Error('The shared rrweb runtime already has a Replay producer');
+  }
+  producer = owner;
+  return () => {
+    if (producer === owner) {
+      producer = undefined;
+    }
+  };
+}
+
+/** Also wraps rrweb callbacks reached from checkout or deferred initialization. */
+export function runInRrweb<T>(callback: () => T): T {
+  executionDepth++;
+  try {
+    return callback();
+  } finally {
+    executionDepth--;
+  }
+}
+
+/** Revoke at the caller first; physical cleanup waits for the enclosing rrweb stack. */
+export function finishRrweb(callback: () => void | Promise<void>): void {
+  const previous = pendingCleanup;
+  let complete!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    complete = resolve;
+  });
+  pendingCleanup = finished;
+  const run = () => {
+    try {
+      // Callers report cleanup failures and release leases in finally. A failed
+      // cleanup must still unblock the next producer.
+      void Promise.resolve(callback()).then(complete, complete);
+    } catch {
+      complete();
+    }
+  };
+  if (executionDepth > 0 || previous) {
+    void (previous ?? Promise.resolve()).then(run);
+  } else {
+    run();
+  }
+  void finished.then(() => {
+    if (pendingCleanup === finished) {
+      pendingCleanup = undefined;
+    }
+  });
+}
+
+export async function waitForRrwebCleanup(): Promise<void> {
+  while (pendingCleanup) {
+    await pendingCleanup;
+  }
+}

--- a/experimental/instrumentation-replay/src/session.integration.test.ts
+++ b/experimental/instrumentation-replay/src/session.integration.test.ts
@@ -1,4 +1,4 @@
-import { initializeFaro, type TransportBody } from '@grafana/faro-core';
+import { type Faro, initializeFaro, type TransportBody } from '@grafana/faro-core';
 import { mockConfig } from '@grafana/faro-core/src/testUtils';
 
 import { makeCoreConfig } from '../../../packages/web-sdk/src/config/makeCoreConfig';
@@ -15,12 +15,14 @@ import { ReplayInstrumentation } from './instrumentation';
 describe.each([true, false])('Replay through Fetch with persistent=%s', (persistent) => {
   const originalFetch = globalThis.fetch;
   let replay: ReplayInstrumentation;
+  let sdk: Faro;
   let requests: Array<{ sessionId: string; body: TransportBody }>;
 
   beforeEach(() => {
     jest.useFakeTimers();
     window.sessionStorage.clear();
     window.localStorage.clear();
+    window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
     requests = [];
     globalThis.fetch = jest.fn(async (_url, init) => {
       requests.push({
@@ -31,8 +33,10 @@ describe.each([true, false])('Replay through Fetch with persistent=%s', (persist
     });
   });
 
-  afterEach(() => {
-    replay?.destroy();
+  afterEach(async () => {
+    window.dispatchEvent(new Event('pagehide'));
+    sdk.instrumentations.remove(...sdk.instrumentations.instrumentations);
+    await jest.advanceTimersByTimeAsync(0);
     jest.clearAllTimers();
     jest.useRealTimers();
     globalThis.fetch = originalFetch;
@@ -42,7 +46,7 @@ describe.each([true, false])('Replay through Fetch with persistent=%s', (persist
 
   function start(inactivityThresholdMs: number) {
     replay = new ReplayInstrumentation({ recordAfter: 'DOMContentLoaded', inactivityThresholdMs });
-    return initializeFaro(
+    sdk = initializeFaro(
       makeCoreConfig(
         mockConfig({
           batching: {},
@@ -52,6 +56,7 @@ describe.each([true, false])('Replay through Fetch with persistent=%s', (persist
         })
       )!
     );
+    return sdk;
   }
 
   async function flush() {


### PR DESCRIPTION
## Why

Recording counters and rrweb lifetime need one explicit owner across navigation, BFCache, replacement, and reentrant startup. Replace the shared checkpoint/claim machinery with exclusive Web Locks leases and one tab-local active/clean checkpoint.

## What

- Separate initialization, pending acquisition, lease, and recorder-attempt ownership. Reserve immutable event identity in memory and seal counters before releasing the lock.
- Finalize on pageswap/pagehide/freeze, reread state after native acquisition, and restart restored documents with a fresh snapshot. Recover abandoned navigation on trusted input and retry failed initial/rotated starts on later interaction.
- Keep rrweb cleanup outside its enclosing execution stack, reject stale callbacks/stop handles, and retain the lease through inactivity pause.
- Remove the shared checkpoint pool, pointers, pruning, TTL/claim machinery, legacy readers, storage-event revocation, and independent recorder-status flags. Document filtering, storage failures, copied tabs, and measured event cost.

Validation: 91 Replay unit tests; retained full-SDK tests cover native BFCache in both directions, reload/replacement, freeze/resume, abandoned view transitions, queued cancellation/session changes, and storage failure. Additional Chromium native UI duplication/crash-recovery experiments and Firefox/WebKit navigation checks are documented. The complete stack passes 970 unit tests (one existing skip), all 30 smoke tests, builds/typechecks, lint, and circular-dependency checks. Standards and specification review findings are addressed.

Known limits: stale clean browser copies can still collide; the upstream rrweb partial-startup rollback fix and dependency bump remain separate. Native BFCache restoration was established in Chromium; the Firefox/WebKit driver runs do not establish it for those browsers.

## Links

Follow-up to #2260 and #2256. Fixes #2270.
Upstream cleanup work: grafana/rrweb#59.

[Native validation, cost measurements, and limits](https://github.com/grafana/faro-web-sdk/blob/replay-lifecycle/recording-leases/docs/sources/developer/replay-lifecycle-validation.md)

Draft stack: #2272 (session capture) → #2273 (span ownership) → #2274 (recording leases) → #2275 (send deadline). Review and merge from the bottom.

## Checklist

- [x] Tests added
- [x] Experimental changelog updated
- [x] Documentation updated
