### PR TITLE
fix(fetch): bound each send by one cancellable deadline

### DIFF
--- a/docs/sources/developer/architecture/components/transports.md
+++ b/docs/sources/developer/architecture/components/transports.md
@@ -17,10 +17,29 @@ request's session is still current in memory and storage. Delayed responses cann
 session, including one another tab has established.
 
 The transport retries transient network failures and HTTP 408, 425, 429, 500, 502, 503, and 504
-responses. Defaults are three total attempts, a ten-second request timeout, and exponential
+responses. Defaults are three total attempts, a ten-second send deadline, and exponential
 backoff starting at one second and capped at thirty seconds. Each batch retains its body and
 `Idempotency-Key` across attempts. Collector CORS policies must allow `Idempotency-Key` before
 this SDK version is deployed. The header alone does not guarantee server-side deduplication.
+Retries have at-least-once semantics: a lost acknowledgement can cause already accepted data to
+be sent again. Bounded retries can also exhaust and drop a batch, so delivery is not guaranteed.
+
+`requestTimeoutMs` is one budget starting when `send()` accepts a batch. It includes custom
+promise-buffer scheduling, header resolution, compression, delivery queue waits, network
+requests, keepalive fallback, retries, and backoff. For example, eight seconds of preparation
+leave two seconds of a ten-second budget. Earlier SDK batching is outside that budget. Values
+at or below zero disable the SDK timer; `requestOptions.signal` still cancels the whole send.
+
+Cancellation or expiry releases admission and delivery capacity even when an abandoned callback
+or fetch ignores its abort signal. Late work cannot resume preparation, send again, or process
+session-invalid responses. The SDK checks the budget after synchronous application callbacks,
+which cannot be preempted. An exception from `onSessionChange` after an accepted response is
+logged without retrying that batch.
+
+`Idempotency-Key` and `X-Faro-Session-Id` are managed headers. Custom header names are compared
+case-insensitively and cannot override them. Response-driven renewal checks the expected session
+inside the updater and again before mutation after application callbacks. Persistent-session
+storage remains best-effort across tabs; this check is not a cross-tab atomic transaction.
 
 Package-root `FetchTransport` imports and constructor options remain supported. Advanced callers can
 set `retry` and `requestTimeoutMs` when constructing a transport. The deprecated
@@ -36,6 +55,14 @@ removed deep imports; there is no legacy transport fallback.
 The default `promiseBuffer.add()` shares admission and concurrency with delivery. Tasks submitted
 directly through that API run once; transport requests use the retry policy. Custom buffer replacements
 and decorators retain their own outer scheduling so waiting for delivery cannot deadlock their worker.
+Repeated invocation of a scheduler's producer shares one preparation and delivery lifetime.
+
+Transports can implement optional synchronous `initialize()` and `destroy()` hooks. Core installs
+configuration and metadata before initialization, rolls back failed registration, and revokes a
+registration before calling its disposer. A replacement registered during cleanup remains owned
+by its own registration. Fetch also initializes its browser listeners for standalone constructor
+use. Removal detaches its pagehide/pageshow listeners; re-adding it restores them. Previously
+accepted sends retain their own deadline and may finish after removal.
 
 ## Transports SDK
 

--- a/experimental/instrumentation-replay/src/session.integration.test.ts
+++ b/experimental/instrumentation-replay/src/session.integration.test.ts
@@ -36,6 +36,7 @@ describe.each([true, false])('Replay through Fetch with persistent=%s', (persist
   afterEach(async () => {
     window.dispatchEvent(new Event('pagehide'));
     sdk.instrumentations.remove(...sdk.instrumentations.instrumentations);
+    sdk.transports.remove(...sdk.transports.transports);
     await jest.advanceTimersByTimeAsync(0);
     jest.clearAllTimers();
     jest.useRealTimers();

--- a/packages/core/src/transports/initialize.ts
+++ b/packages/core/src/transports/initialize.ts
@@ -17,7 +17,7 @@ export function initializeTransports(
 ): Transports {
   internalLogger.debug('Initializing transports');
 
-  const transports: Transport[] = [];
+  const registrations: Array<{ transport: Transport }> = [];
 
   // `config.paused` is the single source of truth so that the paused state stays
   // observable through `faro.config.paused` after `faro.pause()` / `faro.unpause()`
@@ -29,7 +29,7 @@ export function initializeTransports(
     newTransports.forEach((newTransport) => {
       internalLogger.debug(`Adding "${newTransport.name}" transport`);
 
-      const exists = transports.some((existingTransport) => existingTransport === newTransport);
+      const exists = registrations.some(({ transport }) => transport === newTransport);
 
       if (exists) {
         internalLogger.warn(`Transport ${newTransport.name} is already added`);
@@ -42,7 +42,22 @@ export function initializeTransports(
       newTransport.config = config;
       newTransport.metas = metas;
 
-      transports.push(newTransport);
+      const registration = { transport: newTransport };
+      registrations.push(registration);
+      try {
+        newTransport.initialize?.();
+      } catch (error) {
+        const index = registrations.indexOf(registration);
+        if (index !== -1) {
+          registrations.splice(index, 1);
+          try {
+            newTransport.destroy?.();
+          } catch (cleanupError) {
+            internalLogger.warn('Failed to clean up transport after initialization failure', cleanupError);
+          }
+        }
+        throw error;
+      }
     });
   };
 
@@ -77,7 +92,7 @@ export function initializeTransports(
       return;
     }
 
-    for (const transport of transports) {
+    for (const { transport } of registrations) {
       internalLogger.debug(`Transporting item using ${transport.name}\n`, filteredItems);
       if (transport.isBatched()) {
         transport.send(filteredItems);
@@ -87,7 +102,7 @@ export function initializeTransports(
 
   const instantSend = (item: TransportItem) => {
     // prevent all beforeSend hooks being executed twice if batching is enabled.
-    if (config.batching?.enabled && transports.every((transport) => transport.isBatched())) {
+    if (config.batching?.enabled && registrations.every(({ transport }) => transport.isBatched())) {
       return;
     }
 
@@ -97,7 +112,7 @@ export function initializeTransports(
       return;
     }
 
-    for (const transport of transports) {
+    for (const { transport } of registrations) {
       internalLogger.debug(`Transporting item using ${transport.name}\n`, filteredItem);
       if (!transport.isBatched()) {
         transport.send(filteredItem);
@@ -173,18 +188,24 @@ export function initializeTransports(
   const remove: Transports['remove'] = (...transportsToRemove) => {
     internalLogger.debug('Removing transports');
 
-    transportsToRemove.forEach((transportToRemove) => {
+    const selected = transportsToRemove.map((transportToRemove) => {
       internalLogger.debug(`Removing "${transportToRemove.name}" transport`);
 
-      const existingTransportIndex = transports.indexOf(transportToRemove);
-
-      if (existingTransportIndex === -1) {
+      const registration = registrations.find(({ transport }) => transport === transportToRemove);
+      if (!registration) {
         internalLogger.warn(`Transport "${transportToRemove.name}" is not added`);
-
+      }
+      return registration;
+    });
+    selected.forEach((registration) => {
+      if (!registration) {
         return;
       }
-
-      transports.splice(existingTransportIndex, 1);
+      const index = registrations.indexOf(registration);
+      if (index !== -1) {
+        registrations.splice(index, 1);
+        registration.transport.destroy?.();
+      }
     });
   };
 
@@ -211,7 +232,7 @@ export function initializeTransports(
     remove,
     removeBeforeSendHooks,
     get transports() {
-      return [...transports];
+      return registrations.map(({ transport }) => transport);
     },
     unpause,
   };

--- a/packages/core/src/transports/lifecycle.test.ts
+++ b/packages/core/src/transports/lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { initializeFaro } from '../initialize';
+import { mockConfig } from '../testUtils';
+
+import { BaseTransport } from './base';
+
+class LifecycleTransport extends BaseTransport {
+  readonly name = 'lifecycle';
+  readonly version = '1';
+  initialize = jest.fn();
+  destroy = jest.fn();
+  send = jest.fn();
+}
+
+it('initializes a configured transport and disposes it before removal completes', () => {
+  const transport = new LifecycleTransport();
+  const sdk = initializeFaro(mockConfig());
+  transport.initialize.mockImplementation(() => {
+    expect(transport.metas).toBe(sdk.metas);
+    expect(transport.config).toBe(sdk.config);
+  });
+  sdk.transports.add(transport);
+  expect(transport.initialize).toHaveBeenCalledTimes(1);
+  sdk.transports.remove(transport);
+  expect(transport.destroy).toHaveBeenCalledTimes(1);
+  sdk.transports.add(transport);
+  expect(transport.initialize).toHaveBeenCalledTimes(2);
+});
+
+it('unwinds a failed transport initialization and permits a retry', () => {
+  const transport = new LifecycleTransport();
+  const sdk = initializeFaro(mockConfig());
+  transport.initialize.mockImplementationOnce(() => {
+    throw new Error('initialization failed');
+  });
+  expect(() => sdk.transports.add(transport)).toThrow('initialization failed');
+  expect(transport.destroy).toHaveBeenCalledTimes(1);
+  expect(sdk.transports.transports).toHaveLength(0);
+  sdk.transports.add(transport);
+  expect(sdk.transports.transports).toEqual([transport]);
+});
+
+it('preserves a transport re-registered during another selected transport cleanup', () => {
+  const first = new LifecycleTransport();
+  const second = new LifecycleTransport();
+  const sdk = initializeFaro(mockConfig({ transports: [first, second] }));
+  first.destroy.mockImplementation(() => {
+    sdk.transports.remove(second);
+    sdk.transports.add(second);
+  });
+  sdk.transports.remove(first, second);
+  expect(sdk.transports.transports).toEqual([second]);
+  expect(second.initialize).toHaveBeenCalledTimes(2);
+  expect(second.destroy).toHaveBeenCalledTimes(1);
+});
+
+it('does not dispose a newer registration when an older initialization fails', () => {
+  const transport = new LifecycleTransport();
+  const sdk = initializeFaro(mockConfig());
+  transport.initialize.mockImplementationOnce(() => {
+    sdk.transports.remove(transport);
+    sdk.transports.add(transport);
+    throw new Error('obsolete initialization');
+  });
+  expect(() => sdk.transports.add(transport)).toThrow('obsolete initialization');
+  expect(sdk.transports.transports).toEqual([transport]);
+  expect(transport.destroy).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/transports/types.ts
+++ b/packages/core/src/transports/types.ts
@@ -17,6 +17,10 @@ export interface TransportItem<P = APIEvent> {
 }
 
 export interface Transport extends Extension {
+  /** Acquire registrations after the SDK has supplied configuration and metadata. */
+  initialize?(): void;
+  /** Release registrations when this transport is removed from the SDK. */
+  destroy?(): void;
   send(items: TransportItem | TransportItem[]): void | Promise<void>;
 
   // returns URLs to be ignored by tracing, to not cause a feedback loop

--- a/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
+++ b/packages/web-sdk/src/instrumentations/session/sessionManager/sessionManagerUtils.ts
@@ -70,7 +70,7 @@ type GetUserSessionUpdaterParams = {
   isActive?: () => boolean;
 };
 
-type UpdateSessionParams = { forceSessionExtend?: boolean; refreshActivity?: boolean };
+type UpdateSessionParams = { forceSessionExtend?: boolean; refreshActivity?: boolean; expectedSessionId?: string };
 
 export function getUserSessionUpdater({
   fetchUserSession,
@@ -83,11 +83,11 @@ export function getUserSessionUpdater({
   return function updateSession({
     forceSessionExtend = false,
     refreshActivity = true,
+    expectedSessionId,
   }: UpdateSessionParams = {}): void {
     if (!isActive()) {
       return;
     }
-
     const now = dateNow();
     if (!forceSessionExtend && now < nextUpdate && nextUpdate - now <= updateInterval) {
       return;
@@ -102,6 +102,12 @@ export function getUserSessionUpdater({
 
     const sessionFromStorage = fetchUserSession();
     if (!isActive()) {
+      return;
+    }
+    if (
+      expectedSessionId != null &&
+      (sessionFromStorage?.sessionId !== expectedSessionId || faro.metas.value.session?.id !== expectedSessionId)
+    ) {
       return;
     }
     // Bound checks by both expiry deadlines. A backward clock adjustment must
@@ -134,12 +140,26 @@ export function getUserSessionUpdater({
         if (!isActive()) {
           return;
         }
-        const newSession = addSessionMetadataToNextSession(
-          createUserSessionObject({ isSampled: sampled }),
-          sessionFromStorage
-        );
+        // Materialize getters and toJSON while still preparing. The final
+        // ownership check must precede a write of callback-free session data.
+        const newSession = JSON.parse(
+          stringifyExternalJson(
+            addSessionMetadataToNextSession(createUserSessionObject({ isSampled: sampled }), sessionFromStorage)
+          )
+        ) as Required<FaroUserSession>;
         if (!isActive()) {
           return;
+        }
+        // Recheck at the mutation point after sampler/generator/metadata
+        // callbacks. Storage is still best-effort across independent tabs.
+        if (expectedSessionId != null) {
+          if (
+            faro.metas.value.session?.id !== expectedSessionId ||
+            fetchUserSession()?.sessionId !== expectedSessionId ||
+            !isActive()
+          ) {
+            return;
+          }
         }
         storeUserSession(newSession);
         if (!isActive()) {

--- a/packages/web-sdk/src/transports/fetch/compatibility.test.ts
+++ b/packages/web-sdk/src/transports/fetch/compatibility.test.ts
@@ -1,4 +1,10 @@
-import { type LogEvent, LogLevel, type TransportItem, TransportItemType } from '@grafana/faro-core';
+import {
+  type LogEvent,
+  LogLevel,
+  type PromiseProducer,
+  type TransportItem,
+  TransportItemType,
+} from '@grafana/faro-core';
 import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
 
 import {
@@ -15,6 +21,7 @@ const originalCompressionStream = globalThis.CompressionStream;
 const originalReadableStream = globalThis.ReadableStream;
 const accepted = () => ({ status: 202, headers: { get: () => null }, text: async () => '' });
 const fetchMock = jest.fn();
+const transports: FetchTransport[] = [];
 const item: TransportItem<LogEvent> = {
   type: TransportItemType.LOG,
   payload: { level: LogLevel.INFO, message: 'hello', timestamp: '2026-09-08T12:00:00Z', context: {} },
@@ -23,6 +30,7 @@ const item: TransportItem<LogEvent> = {
 
 function createTransport(options: Partial<FetchTransportOptions> = {}): FetchTransport {
   const transport = new FetchTransport({ url: 'https://collector.test/collect', requestTimeoutMs: 0, ...options });
+  transports.push(transport);
   transport.internalLogger = mockInternalLogger;
   transport.metas.value = item.meta;
   transport.config = { ignoreUrls: ['https://also-ignored.test'] } as typeof transport.config;
@@ -38,6 +46,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const transport of transports.splice(0)) {
+    transport.destroy();
+  }
   jest.restoreAllMocks();
   jest.clearAllTimers();
   jest.useRealTimers();
@@ -197,6 +208,51 @@ it('honors in-place decorators and admission policies on promiseBuffer.add', asy
   transport.promiseBuffer.add = originalAdd;
   await transport.send([item]);
   expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('recovers the original buffer after a custom wrapper throws synchronously', async () => {
+  const transport = createTransport({ bufferSize: 1, concurrency: 1 });
+  const original = transport.promiseBuffer;
+  let failOnce = true;
+  transport.promiseBuffer = {
+    add: (producer) =>
+      original.add(() => {
+        if (failOnce) {
+          failOnce = false;
+          throw new Error('wrapper failed');
+        }
+        return producer();
+      }),
+  };
+  await transport.send([item]);
+  await transport.send([item]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it('coalesces reentrant scheduling before any preparation callback runs', async () => {
+  let producer!: PromiseProducer<Response | void>;
+  let nested: PromiseLike<Response | void> | undefined;
+  let reenter = true;
+  const header = jest.fn(() => {
+    if (reenter) {
+      reenter = false;
+      nested = producer();
+    }
+    return 'token';
+  });
+  const transport = createTransport({ requestOptions: { headers: { Authorization: header } } });
+  const logError = jest.spyOn(transport, 'logError');
+  transport.promiseBuffer = {
+    add: (next) => {
+      producer = next;
+      return next();
+    },
+  };
+  await transport.send([item]);
+  expect(header).toHaveBeenCalledTimes(1);
+  await nested;
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(logError).not.toHaveBeenCalled();
 });
 
 it.each([

--- a/packages/web-sdk/src/transports/fetch/deadline.integration.test.ts
+++ b/packages/web-sdk/src/transports/fetch/deadline.integration.test.ts
@@ -1,0 +1,356 @@
+import {
+  type LogEvent,
+  LogLevel,
+  type PromiseProducer,
+  type TransportItem,
+  TransportItemType,
+} from '@grafana/faro-core';
+import { mockInternalLogger } from '@grafana/faro-core/src/testUtils';
+
+import { FetchTransport } from './transport';
+import type { FetchTransportOptions } from './types';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = jest.fn();
+const transports: FetchTransport[] = [];
+type TestResponse = Pick<Response, 'status' | 'text'> & { headers: Pick<Headers, 'get'> };
+const accepted = (): TestResponse => ({ status: 202, headers: { get: () => null }, text: async () => '' });
+const item: TransportItem<LogEvent> = {
+  type: TransportItemType.LOG,
+  payload: { level: LogLevel.INFO, message: 'hello', timestamp: new Date(0).toISOString(), context: {} },
+  meta: { session: { id: 'A' } },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((accept, decline) => {
+    resolve = accept;
+    reject = decline;
+  });
+  return { promise, resolve, reject };
+}
+
+function createTransport(options: Partial<FetchTransportOptions> = {}) {
+  const transport = new FetchTransport({ url: 'https://collector.test/collect', requestTimeoutMs: 10, ...options });
+  transports.push(transport);
+  transport.internalLogger = { ...mockInternalLogger, error: jest.fn() };
+  return transport;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  fetchMock.mockReset().mockResolvedValue(accepted());
+  globalThis.fetch = fetchMock;
+});
+
+afterEach(() => {
+  for (const transport of transports.splice(0)) {
+    transport.destroy();
+  }
+  jest.restoreAllMocks();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  globalThis.fetch = originalFetch;
+});
+
+it('ends a hung header at the send deadline, frees admission, and rejects its late continuation', async () => {
+  const pending = deferred<string>();
+  const authorization = jest.fn().mockReturnValueOnce(pending.promise).mockReturnValue('ready');
+  const laterHeader = jest.fn(() => 'later');
+  const transport = createTransport({
+    bufferSize: 1,
+    requestOptions: { headers: { Authorization: authorization, Later: laterHeader } },
+  });
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(9);
+  expect(completed).toBe(false);
+  await jest.advanceTimersByTimeAsync(1);
+  expect(completed).toBe(true);
+  await sending;
+  expect(laterHeader).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
+
+  await transport.send([item]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  pending.resolve('too late');
+  await jest.advanceTimersByTimeAsync(0);
+  expect(laterHeader).toHaveBeenCalledTimes(1);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it('includes custom scheduling and refuses abandoned producers forwarded through the original buffer', async () => {
+  const transport = createTransport({ bufferSize: 1, concurrency: 1 });
+  const original = transport.promiseBuffer;
+  const scheduled = deferred<Response | void>();
+  let producer!: PromiseProducer<Response | void>;
+  transport.promiseBuffer = {
+    add: (next) => {
+      producer = next;
+      return scheduled.promise;
+    },
+  };
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(10);
+  expect(completed).toBe(true);
+  await sending;
+  expect(fetchMock).not.toHaveBeenCalled();
+  transport.promiseBuffer = original;
+  await expect(original.add(producer)).rejects.toThrow('deadline');
+  scheduled.resolve(undefined);
+  await transport.send([item]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it('frees a timed-out fetch worker even when fetch ignores abort and ignores its late response', async () => {
+  const pending = deferred<ReturnType<typeof accepted>>();
+  fetchMock.mockImplementationOnce(() => pending.promise);
+  const transport = createTransport({ bufferSize: 2, concurrency: 1 });
+  let firstDone = false;
+  let secondDone = false;
+  const first = transport.send([item]).then(() => {
+    firstDone = true;
+  });
+  await jest.advanceTimersByTimeAsync(5);
+  const second = transport.send([item]).then(() => {
+    secondDone = true;
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  await jest.advanceTimersByTimeAsync(5);
+  expect(firstDone).toBe(true);
+  expect(secondDone).toBe(true);
+  await Promise.all([first, second]);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(fetchMock.mock.calls[0]![1].signal.aborted).toBe(true);
+  const getStatus = jest.fn(() => 'invalid');
+  pending.resolve({ ...accepted(), headers: { get: getStatus } });
+  await jest.advanceTimersByTimeAsync(0);
+  expect(getStatus).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('leaves only the original remaining budget after header preparation', async () => {
+  const header = deferred<string>();
+  fetchMock.mockImplementation(() => new Promise(() => {}));
+  const transport = createTransport({ requestOptions: { headers: { Authorization: () => header.promise } } });
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(8);
+  header.resolve('ready');
+  await jest.advanceTimersByTimeAsync(0);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  await jest.advanceTimersByTimeAsync(1);
+  expect(completed).toBe(false);
+  await jest.advanceTimersByTimeAsync(1);
+  expect(completed).toBe(true);
+  await sending;
+});
+
+it('includes compression in the remaining preparation budget and discards its late output', async () => {
+  const { ReadableStream, TransformStream } = require('node:stream/web');
+  const originalReadable = globalThis.ReadableStream;
+  const originalCompression = globalThis.CompressionStream;
+  const header = deferred<string>();
+  const compression = deferred<void>();
+  const compress = jest.fn(
+    () =>
+      new TransformStream({
+        transform: async (chunk: Uint8Array, controller: TransformStreamDefaultController<Uint8Array>) => {
+          await compression.promise;
+          controller.enqueue(chunk);
+        },
+      })
+  );
+  Object.assign(globalThis, { ReadableStream, CompressionStream: compress });
+  try {
+    const transport = createTransport({
+      bufferSize: 1,
+      requestCompression: true,
+      requestOptions: { headers: { Authorization: () => header.promise } },
+    });
+    let completed = false;
+    const sending = transport.send([item]).then(() => {
+      completed = true;
+    });
+    await jest.advanceTimersByTimeAsync(8);
+    header.resolve('ready');
+    await jest.advanceTimersByTimeAsync(0);
+    expect(compress).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(2);
+    expect(completed).toBe(true);
+    await sending;
+    await expect(transport.promiseBuffer.add(async () => {})).resolves.toBeUndefined();
+    compression.resolve(undefined);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  } finally {
+    globalThis.ReadableStream = originalReadable;
+    globalThis.CompressionStream = originalCompression;
+  }
+});
+
+it.each(['header', 'fetch'])('cancels %s work from the caller even with the SDK deadline disabled', async (stage) => {
+  const controller = new AbortController();
+  const header = deferred<string>();
+  const response = deferred<ReturnType<typeof accepted>>();
+  if (stage === 'fetch') {
+    fetchMock.mockImplementationOnce(() => response.promise);
+  }
+  const laterHeader = jest.fn(() => 'later');
+  const transport = createTransport({
+    requestTimeoutMs: 0,
+    requestOptions: {
+      signal: controller.signal,
+      headers: { First: () => (stage === 'header' ? header.promise : 'ready'), Later: laterHeader },
+    },
+  });
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(0);
+  controller.abort(new Error('caller cancelled'));
+  await jest.advanceTimersByTimeAsync(0);
+  expect(completed).toBe(true);
+  await sending;
+  header.resolve('late');
+  response.resolve(accepted());
+  await jest.advanceTimersByTimeAsync(0);
+  expect(laterHeader).toHaveBeenCalledTimes(stage === 'header' ? 0 : 1);
+  expect(fetchMock).toHaveBeenCalledTimes(stage === 'header' ? 0 : 1);
+});
+
+it.each(['deadline', 'caller'])(
+  'cancels backoff at the %s boundary and prevents a later unload flush',
+  async (boundary) => {
+    const controller = new AbortController();
+    fetchMock.mockResolvedValue({ ...accepted(), status: 503 });
+    const transport = createTransport({
+      requestTimeoutMs: boundary === 'deadline' ? 10 : 0,
+      requestOptions: { signal: controller.signal, keepalive: false },
+      retry: { initialBackoffMs: 20 },
+      getRandom: () => 0,
+    });
+    let completed = false;
+    const sending = transport.send([item]).then(() => {
+      completed = true;
+    });
+    await jest.advanceTimersByTimeAsync(10);
+    if (boundary === 'caller') {
+      controller.abort();
+      await jest.advanceTimersByTimeAsync(0);
+    }
+    expect(completed).toBe(true);
+    await sending;
+    window.dispatchEvent(new Event('pagehide'));
+    await jest.advanceTimersByTimeAsync(50);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }
+);
+
+it('gives keepalive fallback only the remaining send budget', async () => {
+  const first = deferred<ReturnType<typeof accepted>>();
+  fetchMock.mockImplementationOnce(() => first.promise).mockImplementationOnce(() => new Promise(() => {}));
+  const transport = createTransport();
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(8);
+  first.reject(new TypeError('keepalive failed'));
+  await jest.advanceTimersByTimeAsync(0);
+  expect(fetchMock.mock.calls.map(([, init]) => init.keepalive)).toEqual([true, false]);
+  await jest.advanceTimersByTimeAsync(2);
+  expect(completed).toBe(true);
+  await sending;
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('rechecks the budget after synchronous application work before running another stage', async () => {
+  const pending = deferred<string>();
+  const later = jest.fn(() => 'later');
+  const transport = createTransport({
+    requestOptions: {
+      headers: {
+        First: () => {
+          jest.setSystemTime(Date.now() + 10);
+          return pending.promise;
+        },
+        Later: later,
+      },
+    },
+  });
+  await transport.send([item]);
+  expect(later).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
+  pending.reject(new Error('abandoned header failed later'));
+  await jest.advanceTimersByTimeAsync(0);
+});
+
+it('enforces the SDK deadline even when AbortController is unavailable', async () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'AbortController')!;
+  Object.defineProperty(globalThis, 'AbortController', { configurable: true, value: undefined });
+  try {
+    fetchMock.mockImplementationOnce(() => new Promise(() => {}));
+    const transport = createTransport({ bufferSize: 1, concurrency: 1 });
+    let completed = false;
+    const sending = transport.send([item]).then(() => {
+      completed = true;
+    });
+    await jest.advanceTimersByTimeAsync(10);
+    expect(completed).toBe(true);
+    await sending;
+    await transport.send([item]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  } finally {
+    Object.defineProperty(globalThis, 'AbortController', descriptor);
+  }
+});
+
+it.each([0, -1])('disables only the SDK timer when requestTimeoutMs is %s', async (requestTimeoutMs) => {
+  const response = deferred<ReturnType<typeof accepted>>();
+  fetchMock.mockImplementationOnce(() => response.promise);
+  const transport = createTransport({ requestTimeoutMs });
+  let completed = false;
+  const sending = transport.send([item]).then(() => {
+    completed = true;
+  });
+  await jest.advanceTimersByTimeAsync(20_000);
+  expect(completed).toBe(false);
+  response.resolve(accepted());
+  await sending;
+  expect(completed).toBe(true);
+});
+
+it('keeps reserved identity headers authoritative regardless of custom header casing', async () => {
+  const override = jest.fn(() => 'wrong');
+  const transport = createTransport({
+    requestOptions: {
+      headers: {
+        'X-FARO-SESSION-ID': override,
+        'idempotency-key': override,
+        'IDEMPOTENCY-KEY': 'also-wrong',
+        'x-faro-session-id': 'another-session',
+        Custom: 'kept',
+      },
+    },
+  });
+  await transport.send([item]);
+  const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>;
+  expect(Object.keys(headers).filter((name) => name.toLowerCase() === 'x-faro-session-id')).toEqual([
+    'x-faro-session-id',
+  ]);
+  expect(Object.keys(headers).filter((name) => name.toLowerCase() === 'idempotency-key')).toEqual(['Idempotency-Key']);
+  expect(headers['x-faro-session-id']).toBe('A');
+  expect(headers['Idempotency-Key']).not.toBe('wrong');
+  expect(headers['Custom']).toBe('kept');
+  expect(override).not.toHaveBeenCalled();
+});

--- a/packages/web-sdk/src/transports/fetch/deliveryQueue.test.ts
+++ b/packages/web-sdk/src/transports/fetch/deliveryQueue.test.ts
@@ -1,0 +1,112 @@
+import { type AttemptOutcome, ReliableDeliveryQueue } from './deliveryQueue';
+
+const success: AttemptOutcome = { kind: 'success', attemptsMade: 1 };
+const queue = () =>
+  new ReliableDeliveryQueue({
+    bufferSize: 2,
+    concurrency: 1,
+    retry: { maxAttempts: 3, initialBackoffMs: 10, maxBackoffMs: 100, backoffMultiplier: 2 },
+    getNow: Date.now,
+    getRandom: () => 0,
+  });
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+it('refuses delivery after the reservation has been released', async () => {
+  const reservation = queue().reserve()!;
+  reservation.release();
+  const attempt = jest.fn(async () => success);
+  await expect(reservation.deliver(attempt)).rejects.toThrow('released');
+  expect(attempt).not.toHaveBeenCalled();
+});
+
+it('cancels a queued attempt without waiting for another worker', async () => {
+  const delivery = queue();
+  const first = delivery.reserve()!;
+  const second = delivery.reserve()!;
+  let finish!: (value: AttemptOutcome) => void;
+  const running = first.deliver(
+    () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      })
+  );
+  const attempt = jest.fn(async () => success);
+  let cancelled = false;
+  const waiting = second.deliver(attempt).catch(() => {
+    cancelled = true;
+  });
+  second.release();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(cancelled).toBe(true);
+  finish(success);
+  await Promise.all([running, waiting]);
+  first.release();
+  expect(attempt).not.toHaveBeenCalled();
+});
+
+it('frees an abandoned worker once and ignores its late completion', async () => {
+  const delivery = queue();
+  const first = delivery.reserve()!;
+  const second = delivery.reserve()!;
+  let finishFirst!: (value: AttemptOutcome) => void;
+  let finishSecond!: (value: AttemptOutcome) => void;
+  const abandoned = first
+    .deliver(
+      () =>
+        new Promise((resolve) => {
+          finishFirst = resolve;
+        })
+    )
+    .catch(() => {});
+  const nextAttempt = jest.fn(
+    () =>
+      new Promise<AttemptOutcome>((resolve) => {
+        finishSecond = resolve;
+      })
+  );
+  const next = second.deliver(nextAttempt);
+  first.release();
+  first.release();
+  await Promise.resolve();
+  expect(nextAttempt).toHaveBeenCalledTimes(1);
+
+  const third = delivery.reserve()!;
+  const thirdAttempt = jest.fn(async () => success);
+  const waiting = third.deliver(thirdAttempt);
+  finishFirst(success);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(thirdAttempt).not.toHaveBeenCalled();
+  finishSecond(success);
+  await Promise.all([abandoned, next, waiting]);
+  second.release();
+  third.release();
+  expect(thirdAttempt).toHaveBeenCalledTimes(1);
+});
+
+it('cancels backoff and cannot be flushed into another attempt after release', async () => {
+  jest.useFakeTimers();
+  const delivery = queue();
+  const reservation = delivery.reserve()!;
+  const attempt = jest.fn<Promise<AttemptOutcome>, []>().mockResolvedValue({
+    kind: 'retry',
+    attemptsMade: 1,
+    failure: { status: 503 },
+  });
+  let cancelled = false;
+  const pending = reservation.deliver(attempt).catch(() => {
+    cancelled = true;
+  });
+  await jest.advanceTimersByTimeAsync(0);
+  reservation.release();
+  await jest.advanceTimersByTimeAsync(0);
+  expect(cancelled).toBe(true);
+  delivery.flush();
+  await jest.advanceTimersByTimeAsync(100);
+  await pending;
+  expect(attempt).toHaveBeenCalledTimes(1);
+});

--- a/packages/web-sdk/src/transports/fetch/deliveryQueue.ts
+++ b/packages/web-sdk/src/transports/fetch/deliveryQueue.ts
@@ -18,7 +18,6 @@ export type AttemptOutcome =
 export interface DeliveryOutcome {
   kind: 'success' | 'terminal';
   attempts: number;
-  elapsedTimeMs: number;
   failure?: DeliveryFailure;
   reason?: 'retries-exhausted' | 'retry-after-too-long';
 }
@@ -45,6 +44,11 @@ interface QueuedAttempt {
   isRedelivery: boolean;
 }
 
+interface DeliveryLifetime {
+  phase: 'reserved' | 'delivering' | 'released';
+  cancel?: () => void;
+}
+
 export interface DeliveryReservation {
   deliver: (performAttempt: PerformAttempt) => Promise<DeliveryOutcome>;
   release: () => void;
@@ -59,7 +63,8 @@ export interface DeliveryReservation {
  * accepted. The concurrency limit separately controls how many attempts can execute at one time.
  *
  * The caller owns the reservation and must release it in a `finally` block after preparation and
- * delivery finish. Release is idempotent so cleanup remains safe on every exit path. This module
+ * delivery finish. Release cancels queued, waiting, or active work and ignores its late result.
+ * It is idempotent so cleanup remains safe on every exit path. This module
  * deliberately has no dependency on Fetch so another transport can supply its own single-attempt
  * callback.
  */
@@ -83,36 +88,44 @@ export class ReliableDeliveryQueue {
 
     this.admitted++;
     const sequence = this.sequence++;
-    let released = false;
+    const lifetime: DeliveryLifetime = { phase: 'reserved' };
 
     const release = () => {
-      if (released) {
+      if (lifetime.phase === 'released') {
         return;
       }
-      released = true;
+      lifetime.phase = 'released';
       this.admitted--;
+      lifetime.cancel?.();
     };
 
     return {
       deliver: async (performAttempt) => {
-        const startedAt = this.options.getNow();
+        if (lifetime.phase !== 'reserved') {
+          throw new Error('Delivery reservation already used or released');
+        }
+        lifetime.phase = 'delivering';
         let attempts = 0;
         let failure: DeliveryFailure | undefined;
 
         for (;;) {
           const attemptsRemaining = this.options.retry.maxAttempts - attempts;
-          const outcome = await this.runAttempt(() => performAttempt(attemptsRemaining, this.unloading), attempts > 0);
+          const outcome = await this.runAttempt(
+            () => performAttempt(attemptsRemaining, this.unloading),
+            lifetime,
+            attempts > 0
+          );
+          this.assertActive(lifetime);
           attempts += outcome.attemptsMade;
 
           if (outcome.kind === 'success') {
-            return { kind: 'success', attempts, elapsedTimeMs: this.options.getNow() - startedAt };
+            return { kind: 'success', attempts };
           }
           failure = outcome.failure;
           if (outcome.kind === 'terminal' || this.unloading) {
             return {
               kind: 'terminal',
               attempts,
-              elapsedTimeMs: this.options.getNow() - startedAt,
               failure,
             };
           }
@@ -120,7 +133,6 @@ export class ReliableDeliveryQueue {
             return {
               kind: 'terminal',
               attempts,
-              elapsedTimeMs: this.options.getNow() - startedAt,
               failure,
               reason: 'retries-exhausted',
             };
@@ -129,7 +141,6 @@ export class ReliableDeliveryQueue {
             return {
               kind: 'terminal',
               attempts,
-              elapsedTimeMs: this.options.getNow() - startedAt,
               failure,
               reason: 'retry-after-too-long',
             };
@@ -141,15 +152,17 @@ export class ReliableDeliveryQueue {
             this.options.retry.maxBackoffMs
           );
           this.options.onRetry?.(backoff, attempts + 1);
-          const unloading = await this.waitForTurn(sequence, backoff);
+          this.assertActive(lifetime);
+          const unloading = await this.waitForTurn(sequence, backoff, lifetime);
+          this.assertActive(lifetime);
           if (unloading) {
             const attemptsRemaining = this.options.retry.maxAttempts - attempts;
-            const flushOutcome = await this.runAttempt(() => performAttempt(attemptsRemaining, true));
+            const flushOutcome = await this.runAttempt(() => performAttempt(attemptsRemaining, true), lifetime);
+            this.assertActive(lifetime);
             attempts += flushOutcome.attemptsMade;
             return {
               kind: flushOutcome.kind === 'success' ? 'success' : 'terminal',
               attempts,
-              elapsedTimeMs: this.options.getNow() - startedAt,
               failure: flushOutcome.kind === 'success' ? undefined : flushOutcome.failure,
             };
           }
@@ -181,26 +194,58 @@ export class ReliableDeliveryQueue {
     this.unloading = false;
   }
 
-  private runAttempt<T>(perform: () => Promise<T>, isRedelivery = false): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      const run = () => {
-        this.inProgress++;
-        const onSettled = () => {
+  private assertActive(lifetime: DeliveryLifetime): void {
+    if (lifetime.phase === 'released') {
+      throw new Error('Delivery reservation released');
+    }
+  }
+
+  private runAttempt(
+    perform: () => Promise<AttemptOutcome>,
+    lifetime: DeliveryLifetime,
+    isRedelivery = false
+  ): Promise<AttemptOutcome> {
+    this.assertActive(lifetime);
+    return new Promise<AttemptOutcome>((resolve, reject) => {
+      let started = false;
+      let settled = false;
+      const finish = (complete: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (lifetime.cancel === cancel) {
+          lifetime.cancel = undefined;
+        }
+        const index = this.attemptQueue.indexOf(attempt);
+        if (index !== -1) {
+          this.attemptQueue.splice(index, 1);
+        }
+        if (started) {
           this.inProgress--;
-          this.runNextAttempt();
-        };
-        perform().then(
-          (value) => {
-            onSettled();
-            resolve(value);
-          },
-          (error) => {
-            onSettled();
-            reject(error);
-          }
-        );
+        }
+        complete();
+        this.runNextAttempt();
       };
-      this.attemptQueue.push({ run, isRedelivery });
+      const cancel = () => finish(() => reject(new Error('Delivery reservation released')));
+      const run = () => {
+        if (settled) {
+          return;
+        }
+        started = true;
+        this.inProgress++;
+        try {
+          perform().then(
+            (value) => finish(() => resolve(value)),
+            (error) => finish(() => reject(error))
+          );
+        } catch (error) {
+          finish(() => reject(error));
+        }
+      };
+      const attempt = { run, isRedelivery };
+      lifetime.cancel = cancel;
+      this.attemptQueue.push(attempt);
       this.runNextAttempt();
     });
   }
@@ -235,10 +280,34 @@ export class ReliableDeliveryQueue {
     }
   }
 
-  private waitForTurn(sequence: number, delayMs: number): Promise<boolean> {
+  private waitForTurn(sequence: number, delayMs: number, lifetime: DeliveryLifetime): Promise<boolean> {
     const jitteredDelay = Math.min(delayMs * (1 + this.options.getRandom() * 0.2), this.options.retry.maxBackoffMs);
-    return new Promise<boolean>((resolve) => {
-      this.waiting.push({ sequence, readyAt: this.options.getNow() + jitteredDelay, resolve });
+    const readyAt = this.options.getNow() + jitteredDelay;
+    this.assertActive(lifetime);
+    return new Promise<boolean>((resolve, reject) => {
+      const cancel = () => {
+        const index = this.waiting.indexOf(delivery);
+        if (index !== -1) {
+          this.waiting.splice(index, 1);
+        }
+        lifetime.cancel = undefined;
+        clearTimeout(this.waitingTimer);
+        this.waitingTimer = undefined;
+        this.scheduleNext();
+        reject(new Error('Delivery reservation released'));
+      };
+      const delivery: WaitingDelivery = {
+        sequence,
+        readyAt,
+        resolve: (unloading) => {
+          if (lifetime.cancel === cancel) {
+            lifetime.cancel = undefined;
+          }
+          resolve(unloading);
+        },
+      };
+      lifetime.cancel = cancel;
+      this.waiting.push(delivery);
       this.waiting.sort((left, right) =>
         left.readyAt === right.readyAt ? left.sequence - right.sequence : left.readyAt - right.readyAt
       );

--- a/packages/web-sdk/src/transports/fetch/lifecycle.test.ts
+++ b/packages/web-sdk/src/transports/fetch/lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { type Faro, initializeFaro, type TransportItem, TransportItemType } from '@grafana/faro-core';
+import { mockConfig } from '@grafana/faro-core/src/testUtils';
+
+import { FetchTransport } from './transport';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = jest.fn();
+const response = (status: number) => ({ status, headers: { get: () => null }, text: async () => '' });
+const item: TransportItem = {
+  type: TransportItemType.EVENT,
+  meta: { session: { id: 'A' } },
+  payload: { name: 'lifecycle', timestamp: new Date(0).toISOString() },
+};
+let sdk: Faro;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  fetchMock.mockReset().mockResolvedValue(response(202));
+  globalThis.fetch = fetchMock;
+  sdk = initializeFaro(mockConfig());
+});
+
+afterEach(() => {
+  sdk.transports.remove(...sdk.transports.transports);
+  jest.restoreAllMocks();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  globalThis.fetch = originalFetch;
+});
+
+it('removes named lifecycle listeners and ignores an old callback already selected for delivery', async () => {
+  const add = jest.spyOn(window, 'addEventListener');
+  const remove = jest.spyOn(window, 'removeEventListener');
+  const transport = new FetchTransport({
+    url: '/collect',
+    requestTimeoutMs: 0,
+    retry: { initialBackoffMs: 20 },
+    getRandom: () => 0,
+  });
+  sdk.transports.add(transport);
+  const listeners = add.mock.calls.filter(([name]) => name === 'pagehide' || name === 'pageshow');
+  expect(listeners).toHaveLength(2);
+  const oldHide = listeners.find(([name]) => name === 'pagehide')![1] as EventListener;
+  fetchMock.mockResolvedValueOnce(response(503));
+  const sending = transport.send([item]);
+  await jest.advanceTimersByTimeAsync(0);
+  sdk.transports.remove(transport);
+  for (const [name, listener] of listeners) {
+    expect(remove).toHaveBeenCalledWith(name, listener);
+  }
+  oldHide(new Event('pagehide'));
+  window.dispatchEvent(new Event('pagehide'));
+  await jest.advanceTimersByTimeAsync(0);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  await jest.advanceTimersByTimeAsync(20);
+  await sending;
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+
+  sdk.transports.add(transport);
+  expect(add.mock.calls.filter(([name]) => name === 'pagehide' || name === 'pageshow')).toHaveLength(4);
+  fetchMock.mockResolvedValueOnce(response(503));
+  const resumed = transport.send([item]);
+  await jest.advanceTimersByTimeAsync(0);
+  window.dispatchEvent(new Event('pagehide'));
+  await jest.advanceTimersByTimeAsync(0);
+  await resumed;
+  expect(fetchMock).toHaveBeenCalledTimes(4);
+});
+
+it('unwinds partially installed native listeners when construction fails', () => {
+  const addListener = window.addEventListener;
+  const remove = jest.spyOn(window, 'removeEventListener');
+  jest.spyOn(window, 'addEventListener').mockImplementation((name, listener, options) => {
+    if (name === 'pageshow') {
+      throw new Error('registration failed');
+    }
+    addListener.call(window, name, listener, options);
+  });
+  expect(() => new FetchTransport({ url: '/collect' })).toThrow('registration failed');
+  expect(remove).toHaveBeenCalledWith('pagehide', expect.any(Function));
+});
+
+it('resumes normal delivery when re-added after restoration happened while removed', async () => {
+  const transport = new FetchTransport({
+    url: '/collect',
+    requestTimeoutMs: 0,
+    retry: { initialBackoffMs: 20 },
+    getRandom: () => 0,
+  });
+  sdk.transports.add(transport);
+  window.dispatchEvent(new Event('pagehide'));
+  sdk.transports.remove(transport);
+  window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+  sdk.transports.add(transport);
+  fetchMock.mockResolvedValueOnce(response(503));
+  const sending = transport.send([item]);
+  await jest.advanceTimersByTimeAsync(20);
+  await sending;
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('calls a subclass initialization hook after construction and SDK configuration', () => {
+  const initialized = jest.fn();
+  class CustomFetch extends FetchTransport {
+    private ready = true;
+    override initialize(): void {
+      expect(this.ready).toBe(true);
+      expect(this.config).toBe(sdk.config);
+      initialized();
+      super.initialize();
+    }
+  }
+  const transport = new CustomFetch({ url: '/collect' });
+  expect(initialized).not.toHaveBeenCalled();
+  sdk.transports.add(transport);
+  expect(initialized).toHaveBeenCalledTimes(1);
+});

--- a/packages/web-sdk/src/transports/fetch/sendDeadline.ts
+++ b/packages/web-sdk/src/transports/fetch/sendDeadline.ts
@@ -1,0 +1,80 @@
+import { noop } from '@grafana/faro-core';
+
+class SendTimeoutError extends Error {}
+
+/** One lifetime for scheduling, preparation, delivery, and retry waits. */
+export class SendDeadline {
+  readonly signal: AbortSignal | undefined;
+  private readonly expiresAt: number | undefined;
+  private readonly controller = typeof AbortController === 'undefined' ? undefined : new AbortController();
+  private readonly cancelled: Promise<never>;
+  private rejectCancellation!: (reason: unknown) => void;
+  private ended?: { reason: unknown };
+  private timeout?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    readonly startedAt: number,
+    timeoutMs: number,
+    private readonly getNow: () => number,
+    private readonly callerSignal: AbortSignal | undefined
+  ) {
+    this.expiresAt = timeoutMs > 0 ? this.startedAt + timeoutMs : undefined;
+    this.signal = this.controller?.signal ?? callerSignal;
+    this.cancelled = new Promise<never>((_resolve, reject) => {
+      this.rejectCancellation = reject;
+    });
+    void this.cancelled.catch(noop);
+    callerSignal?.addEventListener('abort', this.abortFromCaller, { once: true });
+    if (callerSignal?.aborted) {
+      this.abortFromCaller();
+    } else if (this.expiresAt != null) {
+      this.timeout = setTimeout(
+        () => this.cancel(new SendTimeoutError('Send deadline exceeded')),
+        Math.max(0, this.expiresAt - getNow())
+      );
+    }
+  }
+
+  assertActive(): void {
+    if (!this.ended && this.callerSignal?.aborted) {
+      this.abortFromCaller();
+    }
+    if (!this.ended && this.expiresAt != null && this.getNow() >= this.expiresAt) {
+      this.cancel(new SendTimeoutError('Send deadline exceeded'));
+    }
+    if (this.ended) {
+      throw this.ended.reason;
+    }
+  }
+
+  async run<T>(operation: () => T | PromiseLike<T>): Promise<T> {
+    this.assertActive();
+    const pending = Promise.resolve(operation());
+    // A synchronous callback may cancel before the race is installed. Its
+    // eventual rejection must still be observed when we abandon its result.
+    void pending.catch(noop);
+    this.assertActive();
+    const value = await Promise.race([pending, this.cancelled]);
+    this.assertActive();
+    return value;
+  }
+
+  dispose(): void {
+    this.cancel(new Error('Send completed'));
+  }
+
+  private readonly abortFromCaller = () => {
+    this.cancel(this.callerSignal?.reason ?? new Error('Send cancelled'));
+  };
+
+  private cancel(reason: unknown): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = { reason };
+    clearTimeout(this.timeout);
+    this.callerSignal?.removeEventListener('abort', this.abortFromCaller);
+    this.rejectCancellation(reason);
+    this.controller?.abort(reason);
+  }
+}

--- a/packages/web-sdk/src/transports/fetch/session.integration.test.ts
+++ b/packages/web-sdk/src/transports/fetch/session.integration.test.ts
@@ -44,6 +44,8 @@ describe('default Fetch transport session ownership', () => {
 
   afterEach(() => {
     faro?.pause();
+    faro?.instrumentations.remove(...faro.instrumentations.instrumentations);
+    faro?.transports.remove(...faro.transports.transports);
     jest.restoreAllMocks();
     jest.clearAllTimers();
     jest.useRealTimers();
@@ -243,4 +245,175 @@ describe('default Fetch transport session ownership', () => {
     await jest.advanceTimersByTimeAsync(250);
     expect(events().some((event) => event.name === 'paused-during-capture')).toBe(false);
   });
+
+  it('does not retry an accepted batch when onSessionChange throws a TypeError', async () => {
+    await start(false);
+    const previous = faro.api.getSession()?.id;
+    faro.config.sessionTracking!.onSessionChange = jest.fn(() => {
+      throw new TypeError('application callback failed');
+    });
+    invalidateNext = true;
+    faro.api.pushEvent('accepted-before-callback-error');
+    await jest.advanceTimersByTimeAsync(4_000);
+    expect(faro.api.getSession()?.id).not.toBe(previous);
+    expect(events().filter((event) => event.name === 'accepted-before-callback-error')).toHaveLength(1);
+    expect(faro.config.sessionTracking!.onSessionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([true, false])(
+    'does not overwrite a session that replaces the guarded storage read, persistent=%s',
+    async (persistent) => {
+      await start(persistent);
+      const session = faro.api.getSession()!;
+      const manager = persistent ? PersistentSessionsManager : VolatileSessionsManager;
+      const fetchSession = manager.fetchUserSession;
+      const replacement = {
+        ...fetchSession()!,
+        sessionId: 'another-tab',
+        sessionMeta: { ...session, id: 'another-tab' },
+      };
+      let reads = 0;
+      jest.spyOn(manager, 'fetchUserSession').mockImplementation(() => {
+        if (++reads === 2) {
+          storage(persistent).setItem(STORAGE_KEY, JSON.stringify(replacement));
+        }
+        return fetchSession();
+      });
+      const changed = jest.fn();
+      faro.config.sessionTracking!.onSessionChange = changed;
+      invalidateNext = true;
+      await faro.transports.transports[0]!.send([
+        {
+          type: TransportItemType.EVENT,
+          meta: { session },
+          payload: { name: 'invalidates-old-owner', timestamp: new Date().toISOString() },
+        },
+      ]);
+      expect(JSON.parse(storage(persistent).getItem(STORAGE_KEY)!).sessionId).toBe('another-tab');
+      expect(changed).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([true, false])(
+    'preserves an application session replacement made during renewal, persistent=%s',
+    async (persistent) => {
+      await start(persistent);
+      const session = faro.api.getSession()!;
+      faro.config.sessionTracking!.generateSessionId = () => {
+        faro.api.setSession({ id: 'application-replacement' });
+        return 'obsolete-renewal';
+      };
+      invalidateNext = true;
+      await faro.transports.transports[0]!.send([
+        {
+          type: TransportItemType.EVENT,
+          meta: { session },
+          payload: { name: 'reentrant-renewal', timestamp: new Date().toISOString() },
+        },
+      ]);
+      expect(faro.api.getSession()?.id).toBe('application-replacement');
+      expect(JSON.parse(storage(persistent).getItem(STORAGE_KEY)!).sessionId).toBe('application-replacement');
+    }
+  );
+
+  it.each([true, false])(
+    'stops response-side renewal when a generator exhausts the deadline, persistent=%s',
+    async (persistent) => {
+      await start(persistent);
+      const session = faro.api.getSession()!;
+      faro.config.sessionTracking!.generateSessionId = () => {
+        jest.setSystemTime(Date.now() + 10_001);
+        return 'too-late';
+      };
+      invalidateNext = true;
+      await faro.transports.transports[0]!.send([
+        {
+          type: TransportItemType.EVENT,
+          meta: { session },
+          payload: { name: 'slow-renewal', timestamp: new Date().toISOString() },
+        },
+      ]);
+      expect(faro.api.getSession()?.id).toBe(session.id);
+      expect(JSON.parse(storage(persistent).getItem(STORAGE_KEY)!).sessionId).toBe(session.id);
+      faro.api.pushEvent('after-deadline');
+      await jest.advanceTimersByTimeAsync(250);
+      expect(events().some((event) => event.name === 'after-deadline')).toBe(true);
+    }
+  );
+
+  it('stops response-side renewal when its caller cancels inside the generator', async () => {
+    await start(false);
+    const controller = new AbortController();
+    const transport = new FetchTransport({
+      url: 'https://collector.test/collect',
+      requestOptions: { signal: controller.signal },
+    });
+    faro.transports.add(transport);
+    const session = faro.api.getSession()!;
+    faro.config.sessionTracking!.generateSessionId = () => {
+      controller.abort();
+      return 'cancelled-renewal';
+    };
+    invalidateNext = true;
+    await transport.send([
+      {
+        type: TransportItemType.EVENT,
+        meta: { session },
+        payload: { name: 'cancelled-renewal', timestamp: new Date().toISOString() },
+      },
+    ]);
+    expect(faro.api.getSession()?.id).toBe(session.id);
+    expect(JSON.parse(storage(false).getItem(STORAGE_KEY)!).sessionId).toBe(session.id);
+  });
+
+  it.each([
+    [true, 'replace'],
+    [false, 'replace'],
+    [true, 'cancel'],
+    [false, 'deadline'],
+  ] as const)(
+    'checks ownership after serializing session overrides, persistent=%s action=%s',
+    async (persistent, action) => {
+      await start(persistent);
+      const controller = new AbortController();
+      const transport = new FetchTransport({
+        url: 'https://collector.test/collect',
+        requestTimeoutMs: 10,
+        requestOptions: { signal: controller.signal },
+      });
+      faro.transports.add(transport);
+      const session = faro.api.getSession()!;
+      faro.config.sessionTracking!.generateSessionId = () => 'obsolete-renewal';
+      let acted = false;
+      session.overrides = {};
+      Object.defineProperty(session.overrides, 'serviceName', {
+        enumerable: true,
+        get: () => {
+          if (!acted) {
+            acted = true;
+            if (action === 'replace') {
+              faro.api.setSession({ id: 'application-replacement' });
+            } else if (action === 'cancel') {
+              controller.abort();
+            } else {
+              jest.setSystemTime(Date.now() + 11);
+            }
+          }
+          return 'application-service';
+        },
+      });
+      invalidateNext = true;
+      await transport.send([
+        {
+          type: TransportItemType.EVENT,
+          meta: { session: { id: session.id } },
+          payload: { name: 'serialization-renewal', timestamp: new Date().toISOString() },
+        },
+      ]);
+      expect(acted).toBe(true);
+      const expected = action === 'replace' ? 'application-replacement' : session.id;
+      expect(faro.api.getSession()?.id).toBe(expected);
+      expect(JSON.parse(storage(persistent).getItem(STORAGE_KEY)!).sessionId).toBe(expected);
+    }
+  );
 });

--- a/packages/web-sdk/src/transports/fetch/transport.test.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.test.ts
@@ -19,6 +19,7 @@ interface TestResponse {
 }
 
 const fetchMock = jest.fn<Promise<TestResponse>, [string, RequestInit]>();
+const transports: FetchTransport[] = [];
 const runtimeGlobal = globalThis as typeof globalThis & { fetch: typeof fetch };
 runtimeGlobal.fetch = fetchMock as unknown as typeof fetch;
 
@@ -64,6 +65,7 @@ const createTransport = (options: Omit<FetchTransportOptions, 'url'> = {}) => {
     getRandom: () => 0.5,
     ...options,
   });
+  transports.push(transport);
   transport.metas.value = {};
   const internalLogger = logger();
   transport.internalLogger = internalLogger;
@@ -78,6 +80,9 @@ describe('reliable FetchTransport', () => {
   });
 
   afterEach(() => {
+    for (const transport of transports.splice(0)) {
+      transport.destroy();
+    }
     jest.useRealTimers();
     jest.restoreAllMocks();
   });
@@ -295,6 +300,7 @@ describe('reliable FetchTransport', () => {
       concurrency: 2,
       getRandom: () => 0,
       retry: { maxBackoffMs: 60000 },
+      requestTimeoutMs: 0,
     });
 
     const first = transport.send([item]);
@@ -516,7 +522,7 @@ describe('reliable FetchTransport', () => {
     );
   });
 
-  it('times out a hung attempt and retries it', async () => {
+  it('ends a hung send at its deadline without retrying after expiry', async () => {
     fetchMock
       .mockImplementationOnce(
         (_url, init) =>
@@ -530,7 +536,8 @@ describe('reliable FetchTransport', () => {
     const sending = transport.send([item]);
     await jest.advanceTimersByTimeAsync(15);
     await sending;
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![1].signal?.aborted).toBe(true);
   });
 
   it('sends the expected serialized request', async () => {

--- a/packages/web-sdk/src/transports/fetch/transport.ts
+++ b/packages/web-sdk/src/transports/fetch/transport.ts
@@ -1,13 +1,5 @@
-import {
-  BaseExtension,
-  BaseTransport,
-  createPromiseBuffer,
-  genShortID,
-  getTransportBody,
-  noop,
-  VERSION,
-} from '@grafana/faro-core';
-import type { Config, Patterns, PromiseBuffer, PromiseProducer, TransportItem } from '@grafana/faro-core';
+import { BaseTransport, createPromiseBuffer, genShortID, getTransportBody, noop, VERSION } from '@grafana/faro-core';
+import type { Patterns, PromiseBuffer, PromiseProducer, TransportItem } from '@grafana/faro-core';
 
 import { getSessionManagerByConfig } from '../../instrumentations/session/sessionManager';
 import { getUserSessionUpdater } from '../../instrumentations/session/sessionManager/sessionManagerUtils';
@@ -15,6 +7,7 @@ import { parseHttpDate } from '../../utils/httpDate';
 
 import { ReliableDeliveryQueue } from './deliveryQueue';
 import type { AttemptOutcome, DeliveryFailure, DeliveryReservation } from './deliveryQueue';
+import { SendDeadline } from './sendDeadline';
 import type { FetchTransportOptions } from './types';
 
 const DEFAULT_BUFFER_SIZE = 30;
@@ -37,7 +30,13 @@ interface KeepaliveReservation {
   keepalive: boolean;
   release: () => void;
 }
-class RequestTimeoutError extends Error {}
+
+interface PreparedRequest {
+  requestInit: RequestInit;
+  bodySize: number;
+  sessionId: string | undefined;
+  keepalive: boolean | undefined;
+}
 
 function getBodyByteSize(body: string): number {
   return typeof TextEncoder === 'undefined' ? body.length : new TextEncoder().encode(body).byteLength;
@@ -58,6 +57,7 @@ export class FetchTransport extends BaseTransport {
   private readonly requestTimeoutMs: number;
   private readonly compressionEnabled: boolean;
   private readonly deliveryQueue: ReliableDeliveryQueue;
+  private removeLifecycleListeners?: () => void;
 
   constructor(private readonly options: FetchTransportOptions) {
     super();
@@ -70,9 +70,6 @@ export class FetchTransport extends BaseTransport {
       this.logWarn(
         'requestCompression is enabled but CompressionStream is not available. Falling back to uncompressed.'
       );
-    }
-    if (this.requestTimeoutMs > 0 && typeof AbortController === 'undefined') {
-      this.logWarn('AbortController is unavailable. Requests will be sent without the configured timeout.');
     }
 
     this.deliveryQueue = new ReliableDeliveryQueue({
@@ -106,7 +103,7 @@ export class FetchTransport extends BaseTransport {
           this.promiseBuffer.add !== this.defaultBufferAdd ||
           this.pendingCustomSends > 0
         ) {
-          return this.customPromiseBuffer.add(producer);
+          return this.customPromiseBuffer.add(async () => producer());
         }
         const reservation = this.deliveryQueue.reserve();
         if (!reservation) {
@@ -118,30 +115,108 @@ export class FetchTransport extends BaseTransport {
     this.defaultBufferAdd = this.defaultPromiseBuffer.add;
     this.promiseBuffer = this.defaultPromiseBuffer;
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('pagehide', () => this.deliveryQueue.flush());
-      window.addEventListener('pageshow', (event) => {
-        if (event.persisted) {
-          this.deliveryQueue.resume();
-        }
-      });
+    // Derived initialization hooks run after their constructor and SDK wiring.
+    FetchTransport.prototype.initialize.call(this);
+  }
+
+  initialize(): void {
+    if (this.removeLifecycleListeners || typeof window === 'undefined') {
+      return;
+    }
+    let active = true;
+    const onPageHide = () => {
+      if (active) {
+        this.deliveryQueue.flush();
+      }
+    };
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (active && event.persisted) {
+        this.deliveryQueue.resume();
+      }
+    };
+    const dispose = () => {
+      active = false;
+      window.removeEventListener('pagehide', onPageHide);
+      window.removeEventListener('pageshow', onPageShow);
+    };
+    this.removeLifecycleListeners = dispose;
+    try {
+      window.addEventListener('pagehide', onPageHide);
+      window.addEventListener('pageshow', onPageShow);
+      if (this.removeLifecycleListeners !== dispose) {
+        dispose();
+        return;
+      }
+      this.deliveryQueue.resume();
+    } catch (error) {
+      if (this.removeLifecycleListeners === dispose) {
+        this.removeLifecycleListeners = undefined;
+      }
+      dispose();
+      throw error;
     }
   }
 
+  destroy(): void {
+    const dispose = this.removeLifecycleListeners;
+    this.removeLifecycleListeners = undefined;
+    dispose?.();
+  }
+
   async send(items: TransportItem[]): Promise<void> {
-    const buffer = this.promiseBuffer;
-    if (buffer === this.defaultPromiseBuffer && buffer.add === this.defaultBufferAdd) {
-      await this.deliver(items);
+    const startedAt = this.getNow();
+    const reservation = this.deliveryQueue.reserve();
+    if (!reservation) {
+      this.logError('Permanent delivery failure', {
+        error: 'Reliable delivery queue is full',
+        attempts: 0,
+        elapsedTimeMs: 0,
+      });
       return;
     }
 
-    this.pendingCustomSends++;
+    let deadline: SendDeadline | undefined;
+    let custom = false;
+    let attempts = 0;
     try {
-      await buffer.add(() => this.deliver(items));
+      const task = new SendDeadline(
+        startedAt,
+        this.requestTimeoutMs,
+        this.getNow,
+        this.options.requestOptions?.signal ?? undefined
+      );
+      deadline = task;
+      const buffer = this.promiseBuffer;
+      custom = buffer !== this.defaultPromiseBuffer || buffer.add !== this.defaultBufferAdd;
+      let work: Promise<void> | undefined;
+      const produce = () => {
+        if (!work) {
+          work = Promise.resolve().then(() =>
+            this.deliver(items, reservation, task, () => {
+              attempts++;
+            })
+          );
+          void work.catch(noop);
+        }
+        return work;
+      };
+      if (custom) {
+        this.pendingCustomSends++;
+        await task.run(() => buffer.add(produce));
+      } else {
+        await task.run(produce);
+      }
     } catch (error) {
-      this.logError('Permanent delivery failure', { error, attempts: 0, elapsedTimeMs: 0 });
+      this.logError('Permanent delivery failure', { error, attempts, elapsedTimeMs: this.getNow() - startedAt });
     } finally {
-      this.pendingCustomSends--;
+      try {
+        deadline?.dispose();
+      } finally {
+        reservation.release();
+        if (custom) {
+          this.pendingCustomSends--;
+        }
+      }
     }
   }
 
@@ -161,37 +236,28 @@ export class FetchTransport extends BaseTransport {
     }
   }
 
-  private async deliver(items: TransportItem[]): Promise<void> {
-    const reservation = this.deliveryQueue.reserve();
-    if (!reservation) {
-      this.logError('Permanent delivery failure', {
-        error: 'Reliable delivery queue is full',
-        attempts: 0,
-        elapsedTimeMs: 0,
-      });
-      return;
-    }
-
-    try {
-      const prepared = await this.prepareRequest(items);
-      const outcome = await reservation.deliver((attemptsRemaining, unloading) =>
-        this.performAttempt(prepared, attemptsRemaining, unloading)
+  private async deliver(
+    items: TransportItem[],
+    reservation: DeliveryReservation,
+    deadline: SendDeadline,
+    onFetch: () => void
+  ): Promise<void> {
+    const prepared = await deadline.run(() => this.prepareRequest(items, deadline));
+    const outcome = await deadline.run(() =>
+      reservation.deliver((attemptsRemaining, unloading) =>
+        this.performAttempt(prepared, deadline, attemptsRemaining, unloading, onFetch)
+      )
+    );
+    if (outcome.kind === 'terminal') {
+      this.logError(
+        outcome.reason === 'retries-exhausted' ? 'Delivery retries exhausted' : 'Permanent delivery failure',
+        {
+          ...outcome.failure,
+          reason: outcome.reason,
+          attempts: outcome.attempts,
+          elapsedTimeMs: this.getNow() - deadline.startedAt,
+        }
       );
-      if (outcome.kind === 'terminal') {
-        this.logError(
-          outcome.reason === 'retries-exhausted' ? 'Delivery retries exhausted' : 'Permanent delivery failure',
-          {
-            ...outcome.failure,
-            reason: outcome.reason,
-            attempts: outcome.attempts,
-            elapsedTimeMs: outcome.elapsedTimeMs,
-          }
-        );
-      }
-    } catch (error) {
-      this.logError('Permanent delivery failure', { error, attempts: 0, elapsedTimeMs: 0 });
-    } finally {
-      reservation.release();
     }
   }
 
@@ -203,28 +269,33 @@ export class FetchTransport extends BaseTransport {
     return true;
   }
 
-  private async prepareRequest(
-    items: TransportItem[]
-  ): Promise<{ requestInit: RequestInit; bodySize: number; sessionId: string | undefined }> {
+  private async prepareRequest(items: TransportItem[], deadline: SendDeadline): Promise<PreparedRequest> {
     // Async headers and compression can outlive a session. Bind both the header
     // and its response handling to the payload, not the current session.
     const transportBody = getTransportBody(items);
     const sessionId = transportBody.meta.session?.id;
     const jsonBody = JSON.stringify(transportBody);
+    deadline.assertActive();
 
     const { headers = {}, ...requestOptions } = this.options.requestOptions ?? {};
-    const { keepalive: _keepalive, signal: _signal, ...requestOptionsWithoutManagedFields } = requestOptions;
+    const { keepalive, signal: _signal, ...requestOptionsWithoutManagedFields } = requestOptions;
     const resolvedHeaders: Record<string, string> = {};
 
-    for (const [key, value] of Object.entries(headers)) {
-      resolvedHeaders[key] = typeof value === 'function' ? await value() : value;
+    for (const key of Object.keys(headers)) {
+      deadline.assertActive();
+      if (key.toLowerCase() === 'idempotency-key' || key.toLowerCase() === 'x-faro-session-id') {
+        continue;
+      }
+      const value = headers[key]!;
+      resolvedHeaders[key] = typeof value === 'function' ? await deadline.run(value) : value;
     }
 
+    deadline.assertActive();
     let body: string | Blob = jsonBody;
     let bodySize = getBodyByteSize(jsonBody);
     const compressionHeaders: Record<string, string> = {};
     if (this.compressionEnabled) {
-      body = await this.compress(jsonBody);
+      body = await deadline.run(() => this.compress(jsonBody, deadline));
       bodySize = body.size;
       compressionHeaders['Content-Encoding'] = 'gzip';
     }
@@ -232,6 +303,7 @@ export class FetchTransport extends BaseTransport {
     return {
       bodySize,
       sessionId,
+      keepalive,
       requestInit: {
         method: 'POST',
         headers: {
@@ -250,48 +322,58 @@ export class FetchTransport extends BaseTransport {
   }
 
   private async performAttempt(
-    prepared: { requestInit: RequestInit; bodySize: number; sessionId: string | undefined },
+    prepared: PreparedRequest,
+    deadline: SendDeadline,
     attemptsRemaining: number,
-    unloading: boolean
+    unloading: boolean,
+    onFetch: () => void
   ): Promise<AttemptOutcome> {
-    const callerSignal = this.options.requestOptions?.signal;
-    if (callerSignal?.aborted) {
-      return { kind: 'terminal', failure: { error: callerSignal.reason }, attemptsMade: 0 };
-    }
-
+    deadline.assertActive();
     let attemptsMade = 0;
+    let response: Response;
     try {
-      const response = await this.fetchWithKeepaliveFallback(
+      response = await this.fetchWithKeepaliveFallback(
         prepared.requestInit,
         prepared.bodySize,
-        unloading ? true : this.options.requestOptions?.keepalive,
+        unloading ? true : prepared.keepalive,
         attemptsRemaining,
-        () => attemptsMade++
+        deadline,
+        () => {
+          attemptsMade++;
+          onFetch();
+        }
       );
-      this.handleResponse(response, prepared.sessionId);
-
-      if (response.status >= 200 && response.status < 300) {
-        return { kind: 'success', attemptsMade };
-      }
-
-      const failure = { status: response.status };
-      if (!RETRYABLE_STATUS_CODES.has(response.status) || unloading) {
-        return { kind: 'terminal', failure, attemptsMade };
-      }
-
-      return {
-        kind: 'retry',
-        failure,
-        attemptsMade,
-        retryAfterMs: WAIT_INTERVAL_STATUS_CODES.has(response.status) ? this.getRetryAfterDelayMs(response) : undefined,
-      };
     } catch (error) {
+      deadline.assertActive();
       const failure: DeliveryFailure = { error };
-      if (callerSignal?.aborted || !this.isFetchNetworkError(error) || unloading) {
+      if (!this.isFetchNetworkError(error) || unloading) {
         return { kind: 'terminal', failure, attemptsMade };
       }
       return { kind: 'retry', failure, attemptsMade };
     }
+
+    deadline.assertActive();
+    try {
+      this.handleResponse(response, prepared.sessionId, deadline);
+    } catch (error) {
+      deadline.assertActive();
+      this.logError('Failed to process collector response', error);
+    }
+    deadline.assertActive();
+    if (response.status >= 200 && response.status < 300) {
+      return { kind: 'success', attemptsMade };
+    }
+
+    const failure = { status: response.status };
+    if (!RETRYABLE_STATUS_CODES.has(response.status) || unloading) {
+      return { kind: 'terminal', failure, attemptsMade };
+    }
+    return {
+      kind: 'retry',
+      failure,
+      attemptsMade,
+      retryAfterMs: WAIT_INTERVAL_STATUS_CODES.has(response.status) ? this.getRetryAfterDelayMs(response) : undefined,
+    };
   }
 
   private async fetchWithKeepaliveFallback(
@@ -299,64 +381,27 @@ export class FetchTransport extends BaseTransport {
     bodySize: number,
     configuredKeepalive: boolean | undefined,
     attemptsRemaining: number,
+    deadline: SendDeadline,
     onFetch: () => void
   ): Promise<Response> {
-    const startedAt = this.getNow();
     const reservation = this.reserveKeepalive(bodySize, configuredKeepalive);
     try {
-      return await this.fetchWithTimeout(
-        { ...requestInit, keepalive: reservation.keepalive },
-        this.requestTimeoutMs,
-        onFetch
-      );
+      return await deadline.run(() => {
+        onFetch();
+        return fetch(this.options.url, { ...requestInit, keepalive: reservation.keepalive, signal: deadline.signal });
+      });
     } catch (error) {
-      if (
-        reservation.keepalive &&
-        attemptsRemaining > 1 &&
-        this.isFetchNetworkError(error) &&
-        !(error instanceof RequestTimeoutError) &&
-        !this.options.requestOptions?.signal?.aborted
-      ) {
+      deadline.assertActive();
+      if (reservation.keepalive && attemptsRemaining > 1 && this.isFetchNetworkError(error)) {
         this.logDebug('Retrying failed keepalive request with keepalive disabled.');
-        const remainingTimeoutMs = this.requestTimeoutMs - (this.getNow() - startedAt);
-        return this.fetchWithTimeout({ ...requestInit, keepalive: false }, remainingTimeoutMs, onFetch);
+        return deadline.run(() => {
+          onFetch();
+          return fetch(this.options.url, { ...requestInit, keepalive: false, signal: deadline.signal });
+        });
       }
       throw error;
     } finally {
       reservation.release();
-    }
-  }
-
-  private async fetchWithTimeout(requestInit: RequestInit, timeoutMs: number, onFetch: () => void): Promise<Response> {
-    const callerSignal = this.options.requestOptions?.signal;
-    if (this.requestTimeoutMs <= 0 || typeof AbortController === 'undefined') {
-      onFetch();
-      return fetch(this.options.url, { ...requestInit, signal: callerSignal });
-    }
-    if (timeoutMs <= 0) {
-      throw new RequestTimeoutError('Request timed out');
-    }
-
-    const controller = new AbortController();
-    const abortFromCaller = () => controller.abort(callerSignal?.reason);
-    callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
-    let timedOut = false;
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-    }, timeoutMs);
-
-    try {
-      onFetch();
-      return await fetch(this.options.url, { ...requestInit, signal: controller.signal });
-    } catch (error) {
-      if (timedOut && !callerSignal?.aborted) {
-        throw new RequestTimeoutError('Request timed out');
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeout);
-      callerSignal?.removeEventListener('abort', abortFromCaller);
     }
   }
 
@@ -399,22 +444,23 @@ export class FetchTransport extends BaseTransport {
     };
   }
 
-  private handleResponse(response: Response, requestSessionId: string | undefined): void {
-    if (response.status === ACCEPTED && response.headers.get('X-Faro-Session-Status') === 'invalid') {
-      this.extendFaroSession(this.config, this.logDebug.bind(this), requestSessionId);
+  private handleResponse(response: Response, requestSessionId: string | undefined, deadline: SendDeadline): void {
+    try {
+      const invalid = response.status === ACCEPTED && response.headers.get('X-Faro-Session-Status') === 'invalid';
+      deadline.assertActive();
+      if (invalid) {
+        this.extendFaroSession(requestSessionId, deadline);
+      }
+    } finally {
+      response.text().catch(noop);
     }
-    response.text().catch(noop);
   }
 
   private isFetchNetworkError(error: unknown): boolean {
-    return (
-      error instanceof TypeError ||
-      error instanceof RequestTimeoutError ||
-      (error instanceof DOMException && error.name === 'AbortError')
-    );
+    return error instanceof TypeError || (error instanceof DOMException && error.name === 'AbortError');
   }
 
-  private async compress(body: string): Promise<Blob> {
+  private async compress(body: string, deadline: SendDeadline): Promise<Blob> {
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(new TextEncoder().encode(body));
@@ -423,23 +469,24 @@ export class FetchTransport extends BaseTransport {
     }).pipeThrough(new CompressionStream('gzip'));
     const chunks: BlobPart[] = [];
     const reader = stream.getReader();
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) {
-        return new Blob(chunks);
+    try {
+      for (;;) {
+        const { done, value } = await deadline.run(() => reader.read());
+        if (done) {
+          return new Blob(chunks);
+        }
+        chunks.push(value);
       }
-      chunks.push(value);
+    } finally {
+      void reader.cancel().catch(noop);
+      reader.releaseLock();
     }
   }
 
-  private extendFaroSession(
-    config: Config,
-    logDebug: BaseExtension['logDebug'],
-    requestSessionId: string | undefined
-  ): void {
-    const sessionTrackingConfig = config.sessionTracking;
+  private extendFaroSession(requestSessionId: string | undefined, deadline: SendDeadline): void {
+    const sessionTrackingConfig = this.config.sessionTracking;
     if (!sessionTrackingConfig?.enabled) {
-      logDebug('Session expired.');
+      this.logDebug('Session expired.');
       return;
     }
 
@@ -448,13 +495,19 @@ export class FetchTransport extends BaseTransport {
     // A delayed response must not rotate a newer session, including one another
     // tab has already established in shared storage.
     const currentSessionId = this.metas.value.session?.id;
-    const storedSessionId = fetchUserSession()?.sessionId;
-    if (!requestSessionId || requestSessionId !== currentSessionId || requestSessionId !== storedSessionId) {
-      logDebug('Ignoring stale or cross-tab session-invalid response; request session no longer current.');
+    if (!requestSessionId || requestSessionId !== currentSessionId) {
+      this.logDebug('Ignoring stale session-invalid response; request session no longer current.');
       return;
     }
 
-    getUserSessionUpdater({ fetchUserSession, storeUserSession })({ forceSessionExtend: true });
-    logDebug('Session expired; created new session.');
+    getUserSessionUpdater({
+      fetchUserSession,
+      storeUserSession,
+      isActive: () => {
+        deadline.assertActive();
+        return true;
+      },
+    })({ forceSessionExtend: true, expectedSessionId: requestSessionId });
+    this.logDebug('Session invalidation processed.');
   }
 }

--- a/packages/web-sdk/src/transports/fetch/types.ts
+++ b/packages/web-sdk/src/transports/fetch/types.ts
@@ -22,7 +22,7 @@ export interface FetchTransportOptions {
   /** @deprecated Use retry.initialBackoffMs. This sets retry backoff, not a transport-wide cooldown. */
   defaultRateLimitBackoffMs?: number;
   retry?: RetryOptions;
-  /** Maximum duration of one logical request attempt. Default: 10000 ms. */
+  /** Total send deadline, including scheduling, preparation, and retries. Default: 10000 ms; <= 0 disables it. */
   requestTimeoutMs?: number;
   getNow?: ClockFn;
   getRandom?: RandomFn;


### PR DESCRIPTION
## Why

Per-attempt timeouts allow scheduling, preparation, and retries to outlive a batch's intended timeout. An accepted response can also be retried when session callbacks throw. Give each accepted send one cancellable lifetime through every stage and keep response handling outside network retry classification.

## What

- Start the existing timeout budget at send admission and apply it to custom scheduling, queue waits, headers, compression, fetch, keepalive fallback, retries, and backoff. Caller cancellation remains active when the SDK timeout is disabled.
- Release each reservation once, refuse abandoned producers, cancel readers/backoff, and ignore late responses. Prepare the body, captured session, and idempotency key once.
- Ignore reserved headers case-insensitively before invoking header callbacks. Recheck expected session identity after application callbacks and serialization before response-triggered renewal.
- Add optional transport lifecycle hooks so Fetch removes its native listeners and can be re-added safely. Remove the superseded per-attempt timeout and unused elapsed-time bookkeeping.

Validation: deadline/cancellation, custom scheduler, late-response, accepted-202 callback, session serialization reentrancy, and transport removal/re-addition regressions pass. The complete stack passes 970 unit tests (one existing skip), all 30 smoke tests, builds/typechecks, lint, and circular-dependency checks. Standards and specification review findings are addressed.

The timeout now bounds the entire accepted send (default 10 seconds; values at or below zero disable the SDK timeout). Delivery can still end in a terminal drop, and an idempotency header alone does not provide receiver deduplication. Collector/proxy CORS must allow the header.

## Links

Follow-up to #2259 and #2264.

Draft stack: #2272 (session capture) → #2273 (span ownership) → #2274 (recording leases) → #2275 (send deadline). Review and merge from the bottom.

## Checklist

- [x] Tests added
- [x] Conventional commit included for the release-please changelog
- [x] Documentation updated
